### PR TITLE
Added 'AssignRefAndOutParametersLazily' method

### DIFF
--- a/Source/FakeItEasy.IntegrationTests/ConfigurationTests.cs
+++ b/Source/FakeItEasy.IntegrationTests/ConfigurationTests.cs
@@ -71,6 +71,30 @@
         }
 
         [Test]
+        public void Output_and_reference_parameters_can_be_configured_lazily()
+        {
+            var fake = A.Fake<IDictionary<string, string>>();
+            string bla = null;
+
+            string value = "bla";
+            Func<object> lazyGetter = () => value;
+
+            fake.Configure()
+                .CallsTo(x => x.TryGetValue("test", out bla))
+                .Returns(true)
+                .AssignsOutAndRefParametersLazily(lazyGetter);
+
+            fake.TryGetValue("test", out bla);
+
+            Assert.That(bla, Is.EqualTo(value));
+
+            bla = null;
+            value = "meh";
+            fake.TryGetValue("test", out bla);
+            Assert.That(bla, Is.EqualTo(value));
+        }
+
+        [Test]
         public void Void_methods_can_be_configured_by_the_all_in_one_syntax()
         {
             // Arrange

--- a/Source/FakeItEasy.Tests/Configuration/AnyCallConfigurationTests.cs
+++ b/Source/FakeItEasy.Tests/Configuration/AnyCallConfigurationTests.cs
@@ -197,6 +197,42 @@ namespace FakeItEasy.Tests.Configuration
         }
 
         [Test]
+        public void AssignsOutAndRefParametersLazily_delegates_to_configuration_produced_by_factory()
+        {
+            // Arrange
+            var parameters = new Func<object>[] { () => "a", () => "b" };
+
+            var factoryConfig = this.StubVoidConfig();
+            var nextConfig = A.Fake<IAfterCallSpecifiedConfiguration>();
+
+            A.CallTo(() => factoryConfig.AssignsOutAndRefParametersLazily(parameters)).Returns(nextConfig);
+
+            // Act
+            this.configuration.AssignsOutAndRefParametersLazily(parameters);
+
+            // Assert
+            A.CallTo(() => factoryConfig.AssignsOutAndRefParametersLazily(parameters)).MustHaveHappened();
+        }
+
+        [Test]
+        public void AssignsOutAndRefParametersLazily_returns_configuration_produced_by_factory()
+        {
+            // Arrange
+            var parameters = new Func<object>[] { () => "a", () => "b" };
+
+            var factoryConfig = this.StubVoidConfig();
+            var nextConfig = A.Fake<IAfterCallSpecifiedConfiguration>();
+
+            A.CallTo(() => factoryConfig.AssignsOutAndRefParametersLazily(parameters)).Returns(nextConfig);
+
+            // Act
+            var result = this.configuration.AssignsOutAndRefParametersLazily(parameters);
+
+            // Assert
+            Assert.That(result, Is.SameAs(nextConfig));
+        }
+
+        [Test]
         public void Assert_delegates_to_configuration_produced_by_factory()
         {
             // Arrange

--- a/Source/FakeItEasy.Tests/Configuration/RecordingRuleBuilderTests.cs
+++ b/Source/FakeItEasy.Tests/Configuration/RecordingRuleBuilderTests.cs
@@ -187,5 +187,21 @@ namespace FakeItEasy.Tests.Configuration
             // Assert
             Assert.That(returned, Is.SameAs(config));
         }
+
+        [Test]
+        public void AssignsOutAndRefParametersLazily_delegates_to_wrapped_builder()
+        {
+            // Arrange
+            var arguments = new Func<object>[] { () => "foo", () => "bar" };
+
+            var config = A.Fake<IAfterCallSpecifiedConfiguration>();
+            A.CallTo(() => this.wrappedBuilder.AssignsOutAndRefParametersLazily(arguments)).Returns(config);
+
+            // Act
+            var returned = this.builder.AssignsOutAndRefParametersLazily(arguments);
+
+            // Assert
+            Assert.That(returned, Is.SameAs(config));
+        }
     }
 }

--- a/Source/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
+++ b/Source/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
@@ -420,6 +420,21 @@
         }
 
         [Test]
+        public void AssignsOutAndRefParametersLazily_should_be_null_guarded()
+        {
+            NullGuardedConstraint.Assert(() =>
+                this.builder.AssignsOutAndRefParametersLazily());
+        }
+
+        [Test]
+        public void AssignsOutAndRefParametersLazily_returns_self()
+        {
+            var result = this.builder.AssignsOutAndRefParametersLazily(() => 1, () => "foo");
+
+            Assert.That(result, Is.SameAs(this.builder));
+        }
+
+        [Test]
         public void Assert_with_void_call_should_assert_on_assertions_produced_by_factory()
         {
             // Arrange

--- a/Source/FakeItEasy/Configuration/AnyCallConfiguration.cs
+++ b/Source/FakeItEasy/Configuration/AnyCallConfiguration.cs
@@ -53,6 +53,11 @@ namespace FakeItEasy.Configuration
             return this.VoidConfiguration.AssignsOutAndRefParameters(values);
         }
 
+        public IAfterCallSpecifiedConfiguration AssignsOutAndRefParametersLazily(params Func<object>[] values)
+        {
+            return this.VoidConfiguration.AssignsOutAndRefParametersLazily(values);
+        }
+
         public void MustHaveHappened(Repeated repeatConstraint)
         {
             this.VoidConfiguration.MustHaveHappened(repeatConstraint);

--- a/Source/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/Source/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -34,6 +34,18 @@ namespace FakeItEasy.Configuration
         public virtual ICollection<Action<IFakeObjectCall>> Actions { get; private set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether [do evaluate ref and out funcs].
+        /// </summary>
+        /// <value>
+        /// 	<c>true</c> if [do evaluate ref and out funcs]; otherwise, <c>false</c>.
+        /// </value>
+        internal bool DoEvaluateOutAndRefFuncs
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Values to apply to output and reference variables.
         /// </summary>
         public virtual ICollection<object> OutAndRefParametersValues { get; set; }
@@ -149,7 +161,20 @@ namespace FakeItEasy.Configuration
 
             foreach (var argument in indexes.Zip(this.OutAndRefParametersValues))
             {
-                fakeObjectCall.SetArgumentValue(argument.Item1, argument.Item2);
+                if (this.DoEvaluateOutAndRefFuncs)
+                {
+                    Func<object> getter = argument.Item2 as Func<object>;
+
+                    if (getter != null)
+                    {
+                        object value = getter();
+                        fakeObjectCall.SetArgumentValue(argument.Item1, value);
+                    }
+                }
+                else
+                {
+                    fakeObjectCall.SetArgumentValue(argument.Item1, argument.Item2);
+                }
             }
         }
     }

--- a/Source/FakeItEasy/Configuration/IOutAndRefParametersConfiguration.cs
+++ b/Source/FakeItEasy/Configuration/IOutAndRefParametersConfiguration.cs
@@ -1,5 +1,7 @@
 namespace FakeItEasy.Configuration
 {
+    using System;
+
     /// <summary>
     /// Lets the developer configure output values of out and ref parameters.
     /// </summary>
@@ -12,5 +14,14 @@ namespace FakeItEasy.Configuration
         /// <param name="values">The values.</param>
         /// <returns>A configuration object.</returns>
         IAfterCallSpecifiedConfiguration AssignsOutAndRefParameters(params object[] values);
+
+        /// <summary>
+        /// Lazily specifies output values for out and ref parameters. Specify the values in the order
+        /// the ref and out parameters appear in the configured call. Parameters other than out and ref
+        /// parameters are ignored.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        /// <returns>A configuration object.</returns>
+        IAfterCallSpecifiedConfiguration AssignsOutAndRefParametersLazily(params Func<object>[] values);
     }
 }

--- a/Source/FakeItEasy/Configuration/RecordingRuleBuilder.cs
+++ b/Source/FakeItEasy/Configuration/RecordingRuleBuilder.cs
@@ -44,6 +44,11 @@ namespace FakeItEasy.Configuration
             return this.wrappedBuilder.AssignsOutAndRefParameters(values);
         }
 
+        public IAfterCallSpecifiedConfiguration AssignsOutAndRefParametersLazily(params Func<object>[] values)
+        {
+            return this.wrappedBuilder.AssignsOutAndRefParametersLazily(values);
+        }
+
         public void MustHaveHappened(Repeated repeatConstraint)
         {
             Guard.AgainstNull(repeatConstraint, "repeatConstraint");

--- a/Source/FakeItEasy/Configuration/RuleBuilder.cs
+++ b/Source/FakeItEasy/Configuration/RuleBuilder.cs
@@ -95,6 +95,16 @@ namespace FakeItEasy.Configuration
             return this;
         }
 
+        public virtual IAfterCallSpecifiedConfiguration AssignsOutAndRefParametersLazily(params Func<object>[] values)
+        {
+            Guard.AgainstNull(values, "values");
+
+            this.RuleBeingBuilt.DoEvaluateOutAndRefFuncs = true;
+            this.RuleBeingBuilt.OutAndRefParametersValues = values;
+
+            return this;
+        }
+
         public void MustHaveHappened(Repeated repeatConstraint)
         {
             this.manager.RemoveRule(this.RuleBeingBuilt);


### PR DESCRIPTION
Added 'AssignRefAndOutParametersLazily' method to
IOutAndRefParametersConfiguration to allow out and ref parameters to be
set lazily, similar to ReturnsLazily. Added corresponding tests.
