### PR TITLE
#133 minor reformatting and refactoring of ApplicationDirectoryAssembliesTypeCatalogue

### DIFF
--- a/Source/FakeItEasy/Core/ApplicationDirectoryAssembliesTypeCatalogue.cs
+++ b/Source/FakeItEasy/Core/ApplicationDirectoryAssembliesTypeCatalogue.cs
@@ -10,20 +10,30 @@
     /// <summary>
     /// Access all types in all assemblies in the same directory as the FakeItEasy assembly.
     /// </summary>
-    public class ApplicationDirectoryAssembliesTypeCatalogue
-        : ITypeCatalogue
+    public class ApplicationDirectoryAssembliesTypeCatalogue : ITypeCatalogue
     {
         private static readonly Assembly FakeItEasyAssembly = Assembly.GetExecutingAssembly();
-        private readonly List<Type> availableTypes;
+        private readonly List<Type> availableTypes = new List<Type>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplicationDirectoryAssembliesTypeCatalogue"/> class.
         /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Defensive and performed on best effort basis.")]
         public ApplicationDirectoryAssembliesTypeCatalogue()
         {
-            this.availableTypes = new List<Type>();
-
-            this.InitializeAvailableTypes();
+            foreach (var assembly in GetAllAvailableAssemblies())
+            {
+                try
+                {
+                    foreach (var type in assembly.GetTypes())
+                    {
+                        this.availableTypes.Add(type);
+                    }
+                }
+                catch
+                {
+                }
+            }
         }
 
         /// <summary>
@@ -39,55 +49,51 @@
         private static IEnumerable<Assembly> GetAllAvailableAssemblies()
         {
             var appDomainAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var appDomainAssembliesReferencingFakeItEasy = appDomainAssemblies.Where(ReferencesFakeItEasy);
 
-            var assembliesInAppDomainWithFakeItEasyReferences = appDomainAssemblies.Where(ReferencesFakeItEasy);
-
-            // Find the paths of already loaded assemblies so we don't double scan them. Checking Assembly.IsDynamic would be preferable
-            // to the business with the Namespace, but the former isn't available in .NET 3.5. Exclude the ReflectionOnly assemblies because
-            // we want to be able to fully load them if we need to.
+            // Find the paths of already loaded assemblies so we don't double scan them.
+            // Checking Assembly.IsDynamic would be preferable to the business with the Namespace, but the former isn't available in .NET 3.5.
+            // Exclude the ReflectionOnly assemblies because we want to be able to fully load them if we need to.
             var loadedAssemblyPaths = new HashSet<string>(
                 appDomainAssemblies
                     .Where(a => !a.ReflectionOnly && a.ManifestModule.GetType().Namespace != "System.Reflection.Emit")
                     .Select(a => a.Location),
                 StringComparer.OrdinalIgnoreCase);
 
-            var assembliesFromDirectoryFilesWithFakeItEasyReferences = new List<Assembly>();
-            var applicationDirectory = Environment.CurrentDirectory;
+            var folderAssembliesReferencingFakeItEasy = new List<Assembly>();
 
-            foreach (var assemblyFile in Directory.GetFiles(applicationDirectory, "*.dll"))
+            // Skip assemblies already in the application domain.
+            // This is an optimization that can be fooled by test runners that make shadow copies of the assemblies, but it's a start.
+            foreach (var assemblyFile in Directory.GetFiles(Environment.CurrentDirectory, "*.dll").Except(loadedAssemblyPaths))
             {
-                // Skip assemblies already in the application domain. This is an optimization that can be fooled by test runners that
-                // make shadow copies of the assemblies, but it's a start.
-                if (loadedAssemblyPaths.Contains(assemblyFile))
-                {
-                    continue;
-                }
-
-                Assembly inspectedAssembly = null;
+                Assembly assembly = null;
                 try
                 {
-                    inspectedAssembly = Assembly.ReflectionOnlyLoadFrom(assemblyFile);
+                    assembly = Assembly.ReflectionOnlyLoadFrom(assemblyFile);
                 }
                 catch (BadImageFormatException)
                 {
                     // The assembly may not be managed, so move on.
+                    continue;
                 }
 
-                if (inspectedAssembly != null && ReferencesFakeItEasy(inspectedAssembly))
+                if (!ReferencesFakeItEasy(assembly))
                 {
-                    try
-                    {
-                        // A reflection-only loaded assembly can't be scanned for types, so fully load it before saving it.
-                        assembliesFromDirectoryFilesWithFakeItEasyReferences.Add(Assembly.Load(inspectedAssembly.GetName()));
-                    }
-                    catch
-                    {
-                    }
+                    continue;
+                }
+
+                try
+                {
+                    // A reflection-only loaded assembly can't be scanned for types, so fully load it before saving it.
+                    folderAssembliesReferencingFakeItEasy.Add(Assembly.Load(assembly.GetName()));
+                }
+                catch
+                {
                 }
             }
 
-            return assembliesFromDirectoryFilesWithFakeItEasyReferences
-                .Concat(assembliesInAppDomainWithFakeItEasyReferences)
+            return folderAssembliesReferencingFakeItEasy
+                .Concat(appDomainAssembliesReferencingFakeItEasy)
                 .Concat(new[] { FakeItEasyAssembly })
                 .Distinct();
         }
@@ -95,29 +101,6 @@
         private static bool ReferencesFakeItEasy(Assembly inspectedAssembly)
         {
             return inspectedAssembly.GetReferencedAssemblies().Any(r => r.FullName == FakeItEasyAssembly.FullName);
-        }
-
-        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Appropriate in try methods.")]
-        private void LoadAllTypesFromAssembly(Assembly assembly)
-        {
-            try
-            {
-                foreach (var type in assembly.GetTypes())
-                {
-                    this.availableTypes.Add(type);
-                }
-            }
-            catch
-            {
-            }
-        }
-
-        private void InitializeAvailableTypes()
-        {
-            foreach (var assembly in GetAllAvailableAssemblies())
-            {
-                this.LoadAllTypesFromAssembly(assembly);
-            }
         }
     }
 }


### PR DESCRIPTION
- moved field assignment from constructor to initializer
- inlined single use private methods
- inlined variables
- shortened variable names
- replaced foreach continuation with Linq method call
- reduced nesting
- formatted comments
- whitespace
