### PR TITLE
Assembly attribute fix for issue #130 - Added DisableFakeItEasyExtensionDirectoryScanAttribute

### DIFF
--- a/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
+++ b/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
@@ -660,6 +660,9 @@
     <Compile Include="..\FakeItEasy\WriteExtensions.cs">
       <Link>WriteExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\FakeItEasy\Core\DisableFakeItEasyExtensionDirectoryScanAttribute.cs">
+      <Link>Core\DisableFakeItEasyExtensionDirectoryScanAttribute.cs</Link>
+    </Compile>
     <Compile Include="Properties\CustomAssemblyInfo.cs" />
     <Compile Include="Compatibility.cs" />
   </ItemGroup>

--- a/Source/FakeItEasy/Core/DisableFakeItEasyExtensionDirectoryScanAttribute.cs
+++ b/Source/FakeItEasy/Core/DisableFakeItEasyExtensionDirectoryScanAttribute.cs
@@ -1,0 +1,14 @@
+﻿namespace FakeItEasy.Core
+{
+    using System;
+
+    /// <summary>
+    /// Add this attribute any assembly that references FakeItEasy to disable complete directory scan on startup.
+    /// This may prevent IArgumentValueFormatter, IDummyDefinition, IFakeConfigurator configurations from working.
+    /// If you don't know of these interfaces, it's probably fine to disable the directory scan without ill effects.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public class DisableFakeItEasyExtensionDirectoryScanAttribute : Attribute
+    {
+    }
+}

--- a/Source/FakeItEasy/FakeItEasy.csproj
+++ b/Source/FakeItEasy/FakeItEasy.csproj
@@ -86,6 +86,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="A.of.T.cs" />
+    <Compile Include="Core\DisableFakeItEasyExtensionDirectoryScanAttribute.cs" />
     <Compile Include="TwiceExtensions.cs" />
     <Compile Include="WriteExtensions.cs" />
     <Compile Include="MustNotHaveHappenedExtensions.cs" />


### PR DESCRIPTION
I've tried to enable the ability to disable the directory scanning extensibility logic without impacting current behaviour.  Please take a look and see what you think.  
