### PR TITLE
Make sure scope isn't null. Fixes code analysis warning from #331.

### DIFF
--- a/Source/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/DerivedTypeArgumentTests.cs
+++ b/Source/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/DerivedTypeArgumentTests.cs
@@ -24,6 +24,8 @@ namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
 
         protected override void CreateConstraint(IArgumentConstraintManager<string> scope)
         {
+            FakeItEasy.Guard.AgainstNull(scope, "scope");
+
             scope.Matches(x => x == null || x == "foo", x => x.Write("string that is \"foo\" or is empty"));
         }
     }


### PR DESCRIPTION
The new `DerivedTypeArgumentTests.CreateConstraint` from d5641eb55b223a8c62ab6a79c2c6d5b2651330df didn't make sure `scope` wasn't null.
