### PR TITLE
#359 - no longer requiring Now when raising events

### DIFF
--- a/Source/FakeItEasy-SL/FakeItEasy-SL.csproj
+++ b/Source/FakeItEasy-SL/FakeItEasy-SL.csproj
@@ -120,6 +120,9 @@
     <Compile Include="..\FakeItEasy\Core\AssemblyExtensions.cs">
       <Link>Core\AssemblyExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\FakeItEasy\Core\EventHandlerArgumentProviderMap.cs">
+      <Link>Core\EventHandlerArgumentProviderMap.cs</Link>
+    </Compile>
     <Compile Include="..\FakeItEasy\EnumerableExtensions.cs">
       <Link>EnumerableExtensions.cs</Link>
     </Compile>
@@ -721,7 +724,7 @@
       <FlavorProperties GUID="{A1591282-1198-4647-A2B1-27E5FF5F6F3B}">
         <SilverlightProjectProperties />
       </FlavorProperties>
-      <UserProperties ProjectLinkReference="80721425-68e5-48dc-87ea-41d63d0b45fa" ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" />
+      <UserProperties ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" ProjectLinkReference="80721425-68e5-48dc-87ea-41d63d0b45fa" />
     </VisualStudio>
   </ProjectExtensions>
   <Target Name="AfterBuild">

--- a/Source/FakeItEasy.Examples.VB/RaisingEvents.vb
+++ b/Source/FakeItEasy.Examples.VB/RaisingEvents.vb
@@ -10,5 +10,11 @@ Public Class RaisingEvents
 
         ' Raise with the C# syntax
         AddHandler widget.WidgetBroke, AddressOf Raise.With(New WidgetEventArgs("foo")).Now
+
+        ' Raise with the shorter syntax and omitting Go, works only for EventHandler(Of T).
+        AddHandler widget.WidgetBroke, Raise.With(New WidgetEventArgs("foo"))
+
+        ' Raise with the C# syntax and omitting Now
+        AddHandler widget.WidgetBroke, AddressOf Raise.With(New WidgetEventArgs("foo")).ToString
     End Sub
 End Class

--- a/Source/FakeItEasy.Examples/RaisingEvents.cs
+++ b/Source/FakeItEasy.Examples/RaisingEvents.cs
@@ -7,7 +7,7 @@ namespace FakeItEasy.Examples
         public void Raising_event_specifying_both_sender_and_event_arguments()
         {
             var widget = A.Fake<IWidget>();
-            widget.WidgetBroke += Raise.With(widget, new WidgetEventArgs("widget name")).Now;
+            widget.WidgetBroke += Raise.With(widget, new WidgetEventArgs("widget name"));
         }
 
         public void Raising_event_specifying_event_arguments_only()
@@ -15,7 +15,7 @@ namespace FakeItEasy.Examples
             var widget = A.Fake<IWidget>();
 
             // When raising like this the fake object is set as sender.
-            widget.WidgetBroke += Raise.With(new WidgetEventArgs("widget name")).Now;
+            widget.WidgetBroke += Raise.With(new WidgetEventArgs("widget name"));
         }
     }
 }

--- a/Source/FakeItEasy.IntegrationTests.VB/FakeItEasy.IntegrationTests.VB.vbproj
+++ b/Source/FakeItEasy.IntegrationTests.VB/FakeItEasy.IntegrationTests.VB.vbproj
@@ -77,6 +77,7 @@
   <ItemGroup>
     <Compile Include="NextCallTests.vb" />
     <Compile Include="IndexedPropertyTests.vb" />
+    <Compile Include="RaisingEventsTests.vb" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Source/FakeItEasy.IntegrationTests.VB/RaisingEventsTests.vb
+++ b/Source/FakeItEasy.IntegrationTests.VB/RaisingEventsTests.vb
@@ -1,0 +1,167 @@
+﻿Imports FluentAssertions
+Imports NUnit.Framework
+
+Public Interface IHaveEvents
+
+    Event NonGenericEventHander As EventHandler
+    Event GenericEventHander As EventHandler(Of MyEventArgs)
+    Event ObjectEvent(ByVal objectOfInterest As Object)
+
+End Interface
+
+Public Class MyEventArgs
+    Inherits EventArgs
+End Class
+
+<TestFixture()>
+Public Class RaisingEventsTests
+
+    Dim capturedSender As Object
+    Dim capturedEventArgs As EventArgs
+    Dim capturedObject As Object
+
+    Private Sub HandlesNonGenericEventHandler(sender As Object, eventArgs As EventArgs)
+        capturedSender = sender
+        capturedEventArgs = eventArgs
+    End Sub
+
+    Private Sub HandlesGenericEventHandler(sender As Object, eventArgs As MyEventArgs)
+        capturedSender = sender
+        capturedEventArgs = eventArgs
+    End Sub
+
+    Private Sub HandlesObjectEvent(objectOfInterset As Object)
+        capturedObject = objectOfInterset
+    End Sub
+
+    <SetUp()>
+    Public Sub SetUp()
+        capturedSender = Nothing
+        capturedEventArgs = Nothing
+    End Sub
+
+    <Test()>
+    Public Sub Raise_EventHandler_with_now_sends_good_sender()
+        'Arrange
+        Dim target = A.Fake(Of IHaveEvents)()
+        Dim aSender = New Object
+
+        AddHandler target.NonGenericEventHander, AddressOf HandlesNonGenericEventHandler
+
+        ' Act
+        AddHandler target.NonGenericEventHander, AddressOf Raise.With(aSender, New EventArgs()).Now
+
+        ' Assert
+        ReferenceEquals(capturedSender, aSender).Should().BeTrue()
+    End Sub
+
+    <Test()>
+    Public Sub Raise_EventHandler_with_now_sends_good_arguments()
+        'Arrange
+        Dim target = A.Fake(Of IHaveEvents)()
+        Dim eventArgs = New EventArgs()
+        Dim aSender = New Object
+
+        AddHandler target.NonGenericEventHander, AddressOf HandlesNonGenericEventHandler
+
+        ' Act
+        AddHandler target.NonGenericEventHander, AddressOf Raise.With(aSender, eventArgs).Now
+
+        ' Assert
+        ReferenceEquals(capturedEventArgs, eventArgs).Should().BeTrue()
+    End Sub
+
+    <Test()>
+    Public Sub Raise_EventHandler_without_now_sends_good_sender()
+        'Arrange
+        Dim target = A.Fake(Of IHaveEvents)()
+        Dim aSender = New Object
+
+        AddHandler target.NonGenericEventHander, AddressOf HandlesNonGenericEventHandler
+
+        ' Act
+        AddHandler target.NonGenericEventHander, Raise.With(aSender, New EventArgs())
+
+        ' Assert
+        ReferenceEquals(capturedSender, aSender).Should().BeTrue()
+    End Sub
+
+    <Test()>
+    Public Sub Raise_EventHandler_without_now_sends_good_arguments()
+        'Arrange
+        Dim target = A.Fake(Of IHaveEvents)()
+        Dim eventArgs = New EventArgs()
+        Dim aSender = New Object
+
+        AddHandler target.NonGenericEventHander, AddressOf HandlesNonGenericEventHandler
+
+        ' Act
+        AddHandler target.NonGenericEventHander, Raise.With(aSender, eventArgs)
+
+        ' Assert
+        ReferenceEquals(capturedEventArgs, eventArgs).Should().BeTrue()
+    End Sub
+
+    <Test()>
+    Public Sub Raise_EventHandlerOfT_with_now_sends_good_sender()
+        'Arrange
+        Dim target = A.Fake(Of IHaveEvents)()
+        Dim aSender = New Object
+
+        AddHandler target.GenericEventHander, AddressOf HandlesGenericEventHandler
+
+        ' Act
+        AddHandler target.GenericEventHander, AddressOf Raise.With(aSender, New MyEventArgs()).Now
+
+        ' Assert
+        ReferenceEquals(capturedSender, aSender).Should().BeTrue()
+    End Sub
+
+    <Test()>
+    Public Sub Raise_EventHandlerOfT_with_now_sends_good_arguments()
+        'Arrange
+        Dim target = A.Fake(Of IHaveEvents)()
+        Dim eventArgs As EventArgs = New MyEventArgs()
+        Dim aSender = New Object
+
+        AddHandler target.GenericEventHander, AddressOf HandlesGenericEventHandler
+
+        ' Act
+        AddHandler target.GenericEventHander, AddressOf Raise.With(aSender, eventArgs).Now
+
+        ' Assert
+        ReferenceEquals(capturedEventArgs, eventArgs).Should().BeTrue()
+    End Sub
+
+    <Test()>
+    Public Sub Raise_EventHandlerOfT_without_now_sends_good_sender()
+        'Arrange
+        Dim target = A.Fake(Of IHaveEvents)()
+        Dim aSender = New Object
+
+        AddHandler target.GenericEventHander, AddressOf HandlesGenericEventHandler
+
+        ' Act
+        AddHandler target.GenericEventHander, Raise.With(aSender, New MyEventArgs())
+
+        ' Assert
+        ReferenceEquals(capturedSender, aSender).Should().BeTrue()
+    End Sub
+
+    <Test()>
+    Public Sub Raise_EventHandlerOfT_without_now_sends_good_arguments()
+        'Arrange
+        Dim target = A.Fake(Of IHaveEvents)()
+        Dim eventArgs = New MyEventArgs()
+        Dim aSender = New Object
+
+        AddHandler target.GenericEventHander, AddressOf HandlesGenericEventHandler
+
+        ' Act
+        AddHandler target.GenericEventHander, Raise.With(aSender, eventArgs)
+
+        ' Assert
+        ReferenceEquals(capturedEventArgs, eventArgs).Should().BeTrue()
+    End Sub
+
+End Class

--- a/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
+++ b/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
@@ -261,6 +261,9 @@
     <Compile Include="..\FakeItEasy\Core\DynamicContainer.cs">
       <Link>Core\DynamicContainer.cs</Link>
     </Compile>
+    <Compile Include="..\FakeItEasy\Core\EventHandlerArgumentProviderMap.cs">
+      <Link>Core\EventHandlerArgumentProviderMap.cs</Link>
+    </Compile>
     <Compile Include="..\FakeItEasy\Core\FakeAsserter.cs">
       <Link>Core\FakeAsserter.cs</Link>
     </Compile>

--- a/Source/FakeItEasy.Specs/EventRaisingSpecs.cs
+++ b/Source/FakeItEasy.Specs/EventRaisingSpecs.cs
@@ -10,15 +10,16 @@
 
         public interface ITypeWithEvent
         {
-            event EventHandler<SomethingHappenedEventArgs> SomethingHappened;
+            event EventHandler<SomethingHappenedEventArgs> GenericEventHandler;
+            
+            event EventHandler EventHandler;
         }
 
-        protected static ITypeWithEvent TypeWithEvent { get; set; }
+        protected static ITypeWithEvent TypeWithEvent { get; private set; }
 
         public class SomethingHappenedEventArgs
             : EventArgs
         {
-            public string Message { get; set; }
         }
     }
 
@@ -29,32 +30,109 @@
         static Exception exception;
 
         Because of = () =>
-            exception = Catch.Exception(() => TypeWithEvent.SomethingHappened += Raise.With(new SomethingHappenedEventArgs()).Now);
+            exception = Catch.Exception(() => TypeWithEvent.EventHandler += Raise.With(new SomethingHappenedEventArgs()));
 
         It should_not_throw = () => exception.Should().BeNull();
     }
 
     [Subject(typeof(Raise), "with subscribers")]
-    public class RaisingEventWithSubscriber
+    public class RaisingEventHandlerWithSubscriber
         : EventRaisingSpecs
     {
-        static SomethingHappenedEventArgs raisedWithArgs;
-        static object sender;
+        static EventArgs raisedWithArgs;
+        static EventArgs capturedArgs;
+        static object capturedSender;
 
-        private Establish context = () =>
+        Establish context = () =>
         {
-            TypeWithEvent.SomethingHappened += (sender, e) =>
+            raisedWithArgs = new EventArgs();
+            TypeWithEvent.EventHandler += (sender, e) =>
             {
-                RaisingEventWithSubscriber.sender = sender;
-                raisedWithArgs = e;
+                capturedSender = sender;
+                capturedArgs = e;
             };
         };
 
-        Because of = () => TypeWithEvent.SomethingHappened += Raise.With(new SomethingHappenedEventArgs() { Message = "message" }).Now;
+        Because of = () => TypeWithEvent.EventHandler += Raise.With(raisedWithArgs);
 
-        It should_pass_the_sender = () => sender.Should().BeSameAs(TypeWithEvent);
+        It should_pass_the_sender = () => capturedSender.Should().BeSameAs(TypeWithEvent);
 
-        It should_pass_the_event_arguments = () => raisedWithArgs.Message = "message";
+        It should_pass_the_event_arguments = () => capturedArgs.Should().BeSameAs(raisedWithArgs);
+    }
+
+    [Subject(typeof(Raise), "with subscribers and using Now")]
+    public class RaisingEventHandlerWithSubscriberUsingNow
+        : EventRaisingSpecs
+    {
+        static EventArgs raisedWithArgs;
+        static EventArgs capturedArgs;
+        static object capturedSender;
+
+        Establish context = () =>
+        {
+            raisedWithArgs = new EventArgs();
+            TypeWithEvent.EventHandler += (sender, e) =>
+            {
+                capturedSender = sender;
+                capturedArgs = e;
+            };
+        };
+
+        Because of = () => TypeWithEvent.EventHandler += Raise.With(raisedWithArgs).Now;
+
+        It should_pass_the_sender = () => capturedSender.Should().BeSameAs(TypeWithEvent);
+
+        It should_pass_the_event_arguments = () => capturedArgs.Should().BeSameAs(raisedWithArgs);
+    }
+
+    [Subject(typeof(Raise), "with subscribers")]
+    public class RaisingGenericEventHandlerWithSubscriber
+        : EventRaisingSpecs
+    {
+        static SomethingHappenedEventArgs raisedWithArgs;
+        static SomethingHappenedEventArgs capturedArgs;
+        static object capturedSender;
+
+        Establish context = () =>
+        {
+            raisedWithArgs = new SomethingHappenedEventArgs();
+            TypeWithEvent.GenericEventHandler += (sender, e) =>
+            {
+                capturedSender = sender;
+                capturedArgs = e;
+            };
+        };
+
+        Because of = () => TypeWithEvent.GenericEventHandler += Raise.With(raisedWithArgs);
+
+        It should_pass_the_sender = () => capturedSender.Should().BeSameAs(TypeWithEvent);
+
+        It should_pass_the_event_arguments = () => capturedArgs.Should().BeSameAs(raisedWithArgs);
+    }
+
+    [Subject(typeof(Raise), "with subscribers and using Now")]
+    public class RaisingGenericEventHandlerWithSubscriberUsingNow
+        : EventRaisingSpecs
+    {
+        static SomethingHappenedEventArgs raisedWithArgs;
+        static SomethingHappenedEventArgs capturedArgs;
+        static object capturedSender;
+
+        Establish context = () =>
+        {
+            raisedWithArgs = new SomethingHappenedEventArgs();
+            TypeWithEvent.GenericEventHandler += (sender, e) =>
+            {
+                capturedSender = sender;
+                capturedArgs = e;
+            };
+        };
+
+        Because of = () => TypeWithEvent.GenericEventHandler += Raise.With(raisedWithArgs).Now;
+
+        It should_pass_the_sender = () => capturedSender.Should().BeSameAs(TypeWithEvent);
+
+        It should_pass_the_event_arguments = () => capturedArgs.Should().BeSameAs(raisedWithArgs);
     }
 
     [Subject(typeof(Raise), "With multiple subscribers")]
@@ -66,11 +144,11 @@
 
         Establish context = () =>
         {
-            TypeWithEvent.SomethingHappened += (s, e) => firstWasRaisedNumberOfTimes++;
-            TypeWithEvent.SomethingHappened += (s, e) => secondWasRaisedNumberOfTimes++;
+            TypeWithEvent.EventHandler += (s, e) => firstWasRaisedNumberOfTimes++;
+            TypeWithEvent.EventHandler += (s, e) => secondWasRaisedNumberOfTimes++;
         };
 
-        Because of = () => TypeWithEvent.SomethingHappened += Raise.With(new SomethingHappenedEventArgs()).Now;
+        Because of = () => TypeWithEvent.EventHandler += Raise.With(new SomethingHappenedEventArgs());
 
         It should_invoke_the_first_handler = () => firstWasRaisedNumberOfTimes.Should().Be(1);
 

--- a/Source/FakeItEasy.Tests/Core/FakeManagerTests.cs
+++ b/Source/FakeItEasy.Tests/Core/FakeManagerTests.cs
@@ -46,7 +46,7 @@
             foo.SomethingHappened += listener;
             foo.SomethingHappened -= listener;
 
-            foo.SomethingHappened += Raise.With(EventArgs.Empty).Now;
+            foo.SomethingHappened += Raise.With(EventArgs.Empty);
 
             Assert.That(called, Is.False);
         }
@@ -423,7 +423,7 @@
             interceptingProxy.FakeManager.AttachProxy(typeof(FakedProxyWithManagerSpecified), interceptingProxy, eventRaiser);
 
             // Act
-            eventRaiser.CallWasIntercepted += Raise.With(new CallInterceptedEventArgs(interceptedCall)).Now;
+            eventRaiser.CallWasIntercepted += Raise.With(new CallInterceptedEventArgs(interceptedCall));
 
             // Assert
             A.CallTo(() => interceptedCall.SetReturnValue(false)).MustHaveHappened();
@@ -447,7 +447,7 @@
             interceptingProxy.FakeManager.AttachProxy(typeof(FakedProxyWithManagerSpecified), interceptingProxy, eventRaiser);
 
             // Act
-            eventRaiser.CallWasIntercepted += Raise.With(new CallInterceptedEventArgs(interceptedCall)).Now;
+            eventRaiser.CallWasIntercepted += Raise.With(new CallInterceptedEventArgs(interceptedCall));
 
             // Assert
             A.CallTo(() => interceptedCall.SetReturnValue(true)).MustHaveHappened();
@@ -518,7 +518,7 @@
 
             fake.AddRuleFirst(rule);
 
-            eventRaiser.CallWasIntercepted += Raise.With(new CallInterceptedEventArgs(call)).Now;
+            eventRaiser.CallWasIntercepted += Raise.With(new CallInterceptedEventArgs(call));
 
             A.CallTo(() => rule.Apply(A<IInterceptedFakeObjectCall>._)).MustHaveHappened();
         }
@@ -654,7 +654,7 @@
             manager.AttachProxy(typeof(IFoo), A.Fake<IFoo>(), eventRaiser);
 
             // Act
-            eventRaiser.CallWasIntercepted += Raise.With(new CallInterceptedEventArgs(interceptedCall)).Now;
+            eventRaiser.CallWasIntercepted += Raise.With(new CallInterceptedEventArgs(interceptedCall));
 
             // Assert
             A.CallTo(() => interceptedCall.SetReturnValue(expectedValue.Invoke(manager))).MustHaveHappened();
@@ -697,7 +697,7 @@
         private sealed class RaisableFakeManager
             : FakeManager
         {
-            private ICallInterceptedEventRaiser raiser;
+            private readonly ICallInterceptedEventRaiser raiser;
 
             public RaisableFakeManager()
             {
@@ -707,7 +707,7 @@
 
             public void RaiseCallIntercepted(CallInterceptedEventArgs eventArgs)
             {
-                this.raiser.CallWasIntercepted += Raise.With(eventArgs).Now;
+                this.raiser.CallWasIntercepted += Raise.With(eventArgs);
             }
         }
     }

--- a/Source/FakeItEasy/Core/EventHandlerArgumentProviderMap.cs
+++ b/Source/FakeItEasy/Core/EventHandlerArgumentProviderMap.cs
@@ -1,0 +1,37 @@
+﻿namespace FakeItEasy.Core
+{
+    using System;
+    using System.Collections.Generic;
+
+    internal class EventHandlerArgumentProviderMap
+    {
+        private readonly Dictionary<object, Func<object, object[]>> map = new Dictionary<object, Func<object, object[]>>();
+
+        public void AddArgumentProvider(object eventHandler, Func<object, object[]> provider)
+        {
+            lock (this.map)
+            {
+                this.map[eventHandler] = provider;
+            }
+        }
+
+        public bool TryGetArgumentProviderFor(object eventHandler, out Func<object, object[]> provider)
+        {
+            lock (this.map)
+            {
+                bool wasFound = this.map.TryGetValue(eventHandler, out provider);
+                if (wasFound)
+                {
+                    this.map.Remove(eventHandler);
+                }
+
+                return wasFound;
+            }
+        }
+
+        public bool Contains(object eventHandler)
+        {
+            return this.map.ContainsKey(eventHandler);
+        }
+    }
+}

--- a/Source/FakeItEasy/Core/FakeManager.EventRule.cs
+++ b/Source/FakeItEasy/Core/FakeManager.EventRule.cs
@@ -14,9 +14,14 @@ namespace FakeItEasy.Core
         private class EventRule
             : IFakeObjectCallRule
         {
-            [NonSerialized] private Dictionary<object, Delegate> registeredEventHandlersField;
+            [NonSerialized]
+            private readonly EventHandlerArgumentProviderMap eventHandlerArgumentProviderMap =
+                ServiceLocator.Current.Resolve<EventHandlerArgumentProviderMap>();
 
-            public FakeManager FakeManager { get; set; }
+            [NonSerialized]
+            private Dictionary<object, Delegate> registeredEventHandlersField;
+
+            public FakeManager FakeManager { private get; set; }
 
             public int? NumberOfTimesToCall
             {
@@ -45,7 +50,7 @@ namespace FakeItEasy.Core
 
             public void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
-                var eventCall = EventCall.GetEventCall(fakeObjectCall);
+                var eventCall = EventCall.GetEventCall(fakeObjectCall, this.eventHandlerArgumentProviderMap);
 
                 this.HandleEventCall(eventCall);
             }
@@ -106,7 +111,7 @@ namespace FakeItEasy.Core
 
             private void AddHandler(object key, Delegate handler)
             {
-                Delegate result = null;
+                Delegate result;
 
                 if (this.RegisteredEventHandlers.TryGetValue(key, out result))
                 {
@@ -122,7 +127,7 @@ namespace FakeItEasy.Core
 
             private void RemoveHandler(object key, Delegate handler)
             {
-                Delegate registration = null;
+                Delegate registration;
 
                 if (this.RegisteredEventHandlers.TryGetValue(key, out registration))
                 {
@@ -141,17 +146,20 @@ namespace FakeItEasy.Core
 
             private void RaiseEvent(EventCall call)
             {
-                Delegate raiseMethod = null;
+                Delegate raiseMethod;
 
                 if (this.RegisteredEventHandlers.TryGetValue(call.Event, out raiseMethod))
                 {
-                    var arguments = call.EventHandler.Target as IEventRaiserArguments;
+                    var arguments = new List<object>();
 
-                    var sender = arguments.Sender ?? this.FakeManager.Object;
+                    if (!this.CanFillArgumentsFromImplicitEventRaiser(call, arguments))
+                    {
+                        this.FillArgumentsFromExplicitEventRaiser(call, arguments);
+                    }
 
                     try
                     {
-                        raiseMethod.DynamicInvoke(sender, arguments.EventArguments);
+                        raiseMethod.DynamicInvoke(arguments.ToArray());
                     }
                     catch (TargetInvocationException ex)
                     {
@@ -168,19 +176,48 @@ namespace FakeItEasy.Core
                 }
             }
 
+            private bool CanFillArgumentsFromImplicitEventRaiser(EventCall call, List<object> arguments)
+            {
+                Func<object, object[]> argumentListBuilder;
+
+                if (this.eventHandlerArgumentProviderMap.TryGetArgumentProviderFor(call.EventHandler, out argumentListBuilder))
+                {
+                    arguments.AddRange(argumentListBuilder(this.FakeManager.Object));
+                    return true;
+                }
+
+                return false;
+            }
+
+            private void FillArgumentsFromExplicitEventRaiser(EventCall call, List<object> arguments)
+            {
+                var eventRaiserArguments = call.EventHandler.Target as IEventRaiserArguments;
+
+                if (eventRaiserArguments == null)
+                {
+                    return;
+                }
+
+                var sender = eventRaiserArguments.Sender ?? this.FakeManager.Object;
+                arguments.Add(sender);
+                arguments.Add(eventRaiserArguments.EventArguments);
+            }
+
             private class EventCall
             {
                 private EventCall()
                 {
                 }
 
-                public EventInfo Event { get; set; }
+                public EventInfo Event { get; private set; }
 
-                public MethodInfo CallingMethod { get; set; }
+                public Delegate EventHandler { get; private set; }
 
-                public Delegate EventHandler { get; set; }
+                private MethodInfo CallingMethod { get; set; }
 
-                public static EventCall GetEventCall(IFakeObjectCall fakeObjectCall)
+                private EventHandlerArgumentProviderMap EventHandlerArgumentProviderMap { get; set; }
+
+                public static EventCall GetEventCall(IFakeObjectCall fakeObjectCall, EventHandlerArgumentProviderMap eventHandlerArgumentProviderMap)
                 {
                     var eventInfo = GetEvent(fakeObjectCall.Method);
 
@@ -188,7 +225,8 @@ namespace FakeItEasy.Core
                                {
                                    Event = eventInfo, 
                                    CallingMethod = fakeObjectCall.Method, 
-                                   EventHandler = (Delegate)fakeObjectCall.Arguments[0]
+                                   EventHandler = (Delegate)fakeObjectCall.Arguments[0],
+                                   EventHandlerArgumentProviderMap = eventHandlerArgumentProviderMap
                                };
                 }
 
@@ -203,16 +241,27 @@ namespace FakeItEasy.Core
 
                 public bool IsEventRaiser()
                 {
-                    var declaringType = this.EventHandler.Method.DeclaringType;
-
-                    return declaringType.IsGenericType
-                        && declaringType.GetGenericTypeDefinition() == typeof(Raise<>)
-                            && this.EventHandler.Method.Name.Equals("Now");
+                    return this.IsImplicitEventRaiser() || this.IsExplicitEventRaiserUsingNow();
                 }
 
                 public bool IsEventRegistration()
                 {
                     return this.Event.GetAddMethod().Equals(this.CallingMethod);
+                }
+
+                private bool IsExplicitEventRaiserUsingNow()
+                {
+                    var declaringType = this.EventHandler.Method.DeclaringType;
+
+                    return declaringType != null
+                           && declaringType.IsGenericType
+                           && declaringType.GetGenericTypeDefinition() == typeof(Raise<>)
+                           && this.EventHandler.Method.Name.Equals("Now");
+                }
+
+                private bool IsImplicitEventRaiser()
+                {
+                    return this.EventHandlerArgumentProviderMap.Contains(this.EventHandler);
                 }
             }
         }

--- a/Source/FakeItEasy/FakeItEasy.csproj
+++ b/Source/FakeItEasy/FakeItEasy.csproj
@@ -88,6 +88,7 @@
     <Compile Include="A.of.T.cs" />
     <Compile Include="Core\AssemblyExtensions.cs" />
     <Compile Include="Core\BootstrapperLocator.cs" />
+    <Compile Include="Core\EventHandlerArgumentProviderMap.cs" />
     <Compile Include="DefaultBootstrapper.cs" />
     <Compile Include="Expressions\ArgumentConstraints\IArgumentValueProvider.cs" />
     <Compile Include="Expressions\ArgumentConstraints\OutArgumentConstraint.cs" />

--- a/Source/FakeItEasy/Raise.of.TEventArgs.cs
+++ b/Source/FakeItEasy/Raise.of.TEventArgs.cs
@@ -42,6 +42,32 @@
         }
 
         /// <summary>
+        /// Converts a raiser into an <see cref="EventHandler{TEventArgs}"/>
+        /// </summary>
+        /// <param name="raiser">The raiser to convert.</param>
+        /// <returns>The new event handler</returns>
+        public static implicit operator EventHandler<TEventArgs>(Raise<TEventArgs> raiser)
+        {
+            var eventHandler = new EventHandler<TEventArgs>(raiser.Now);
+            var providerMap = ServiceLocator.Current.Resolve<EventHandlerArgumentProviderMap>();
+            providerMap.AddArgumentProvider(eventHandler, fake => new[] { raiser.sender ?? fake, raiser.eventArguments });
+            return eventHandler;
+        }
+
+        /// <summary>
+        /// Converts a raiser into an <see cref="EventHandler"/>
+        /// </summary>
+        /// <param name="raiser">The raiser to convert.</param>
+        /// <returns>The new event handler</returns>
+        public static implicit operator EventHandler(Raise<TEventArgs> raiser)
+        {
+            var eventHandler = new EventHandler(raiser.Now);
+            var providerMap = ServiceLocator.Current.Resolve<EventHandlerArgumentProviderMap>();
+            providerMap.AddArgumentProvider(eventHandler, fake => new[] { raiser.sender ?? fake, raiser.eventArguments });
+            return eventHandler;
+        }
+
+        /// <summary>
         /// Register this event handler to an event on a faked object in order to raise that event.
         /// </summary>
         /// <param name="sender">The sender of the event.</param>
@@ -49,6 +75,16 @@
         [SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers", Justification = "Must be visible to provide the event raising syntax.")]
         [SuppressMessage("Microsoft.Maintainability", "CA1500:VariableNamesShouldNotMatchFieldNames", MessageId = "sender", Justification = "Unused parameter.")]
         public void Now(object sender, TEventArgs e)
+        {
+            throw new NotSupportedException(ExceptionMessages.NowCalledDirectly);
+        }
+
+        /// <summary>
+        /// Register this event handler to an event on a faked object in order to raise that event.
+        /// </summary>
+        /// <param name="sender">The sender of the event.</param>
+        /// <param name="e">Event args for the event.</param>
+        private void Now(object sender, EventArgs e)
         {
             throw new NotSupportedException(ExceptionMessages.NowCalledDirectly);
         }

--- a/Source/FakeItEasy/RootModule.cs
+++ b/Source/FakeItEasy/RootModule.cs
@@ -97,7 +97,7 @@
                                                              return new DefaultFakeAndDummyManager(session, fakeCreator, c.Resolve<IFakeWrapperConfigurer>());
                                                          });
 
-            container.RegisterSingleton<CastleDynamicProxyGenerator>(c => new CastleDynamicProxyGenerator(c.Resolve<CastleDynamicProxyInterceptionValidator>()));
+            container.RegisterSingleton(c => new CastleDynamicProxyGenerator(c.Resolve<CastleDynamicProxyInterceptionValidator>()));
 
             container.RegisterSingleton<IProxyGenerator>(c => new ProxyGeneratorSelector(new DelegateProxyGenerator(), c.Resolve<CastleDynamicProxyGenerator>()));
 
@@ -129,12 +129,14 @@
             container.RegisterSingleton<IOutputWriter>(c => new DefaultOutputWriter(Console.Write));
 
             container.Register<ISutInitializer>(c => new DefaultSutInitializer(c.Resolve<IFakeAndDummyManager>()));
+
+            container.RegisterSingleton(c => new EventHandlerArgumentProviderMap());
         }
 
         private class ExpressionCallMatcherFactory
             : IExpressionCallMatcherFactory
         {
-            public DictionaryContainer Container { get; set; }
+            public DictionaryContainer Container { private get; set; }
 
             public ICallMatcher CreateCallMathcer(LambdaExpression callSpecification)
             {
@@ -167,7 +169,7 @@
         private class SessionFakeObjectCreator
             : IFakeObjectCreator
         {
-            public FakeObjectCreator Creator { get; set; }
+            public FakeObjectCreator Creator { private get; set; }
 
             public bool TryCreateFakeObject(Type typeOfFake, DummyValueCreationSession session, out object result)
             {


### PR DESCRIPTION
Fixes #359.

Includes functionality that had been discussed as an add-on to #30 (and will enable changes for that issue).
