### PR TITLE
Added default support to DummyValueCreationSession for type Lazy<T>

### DIFF
--- a/Source/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/Source/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ConfigurationSpecs.cs" />
     <Compile Include="ConstructorWithVirtualCallsSpecs.cs" />
     <Compile Include="CreationSpecs.cs" />
+    <Compile Include="LazySpecs.cs" />
     <Compile Include="OrderedCallMatchingSpecs.cs" />
     <Compile Include="FakingInternalsSpecs.cs" />
     <Compile Include="EventRaisingSpecs.cs" />

--- a/Source/FakeItEasy.Specs/LazySpecs.cs
+++ b/Source/FakeItEasy.Specs/LazySpecs.cs
@@ -1,0 +1,45 @@
+﻿namespace FakeItEasy.Specs
+{
+    using System;
+    using FluentAssertions;
+    using Machine.Specifications;
+
+    public class when_calling_an_unconfigured_method_that_returns_a_lazy_of_ifoo
+    {
+        static ILazyFactory fake;
+        static Lazy<IFoo> lazy;
+        
+        Establish context = () =>
+        {
+            fake = A.Fake<ILazyFactory>();
+        };
+
+        Because of = () =>
+        {
+            lazy = fake.Create();
+        };
+
+        It should_return_a_lazy = () => lazy.Should().NotBeNull();
+
+        It should_return_a_lazy_whose_value_is_an_ifoo_dummy = () => lazy.Value.Should().Be(FooDefinition.Instance);
+        
+        public interface ILazyFactory
+        {
+            Lazy<IFoo> Create();
+        }
+
+        public interface IFoo
+        {
+        }
+
+        public class FooDefinition : DummyDefinition<IFoo>, IFoo
+        {
+            public static readonly IFoo Instance = new FooDefinition();
+
+            protected override IFoo CreateDummy()
+            {
+                return Instance;
+            }
+        }
+    }
+}

--- a/Source/FakeItEasy.Tests/Creation/DummyValueCreationSessionTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DummyValueCreationSessionTests.cs
@@ -198,6 +198,23 @@ namespace FakeItEasy.Tests.Creation
             Assert.That(result, Is.False);
         }
 
+        [Test]
+        public void Should_be_able_to_create_lazy_wrapper()
+        {
+            // Arrange
+            var fake = A.Fake<IFoo>();
+            this.StubFakeObjectCreatorWithValue<IFoo>(fake);
+
+            // Act
+            object dummy;
+            var result = this.session.TryResolveDummyValue(typeof(Lazy<IFoo>), out dummy);
+
+            // Assert
+            Assert.That(result, Is.True);
+            Assert.That(dummy, Is.InstanceOf<Lazy<IFoo>>());
+            Assert.That(((Lazy<IFoo>)dummy).Value, Is.SameAs(fake));
+        }
+
         private void StubFakeObjectCreatorWithValue<T>(T value)
         {
             object output;


### PR DESCRIPTION
Based off of the behavior that is defined for Task. Discussed in issue #358.
