### PR TITLE
Allow fake configuration before faked type's constructor is called.

### DIFF
--- a/Source/FakeItEasy.Specs/ConstructorWithVirtualCallsSpecs.cs
+++ b/Source/FakeItEasy.Specs/ConstructorWithVirtualCallsSpecs.cs
@@ -146,6 +146,21 @@
         };
     }
 
+    public class when_faking_a_class_which_calls_virtual_member_in_constructor_with_Wrapping_fake_option
+    {
+        static SimpleVirtualCallInConstructor fake;
+
+        Because of = () =>
+            fake = A.Fake<SimpleVirtualCallInConstructor>(
+                    o => o.Wrapping(new SimpleVirtualCallInConstructor()));
+
+        It should_delegate_to_the_wrapped_instance_inside_and_outside_of_the_constructor_call = () =>
+        {
+            fake.VirtualMethodValueDuringConstructorCall.Should().Be("implementation value");
+            fake.VirtualMethod(null).Should().Be("implementation value");
+        };
+    }
+
     public class when_faking_a_class_which_calls_virtual_property_members_in_constructor
     {
         static FakedClass fake;

--- a/Source/FakeItEasy.Tests/Core/FakeManagerProviderTests.cs
+++ b/Source/FakeItEasy.Tests/Core/FakeManagerProviderTests.cs
@@ -1,6 +1,8 @@
 namespace FakeItEasy.Tests.Core
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
     using FakeItEasy.Core;
     using FakeItEasy.Tests.TestHelpers;
@@ -22,6 +24,9 @@ namespace FakeItEasy.Tests.Core
         [Fake]
         private Type typeOfFake = null;
 
+        [Fake]
+        private IEnumerable<Action<object>> onFakeConfigurationActions = null;
+
         [UnderTest]
         private FakeManagerProvider fakeManagerProvider = null;
 
@@ -42,6 +47,11 @@ namespace FakeItEasy.Tests.Core
         public void Fetch_should_create_a_fake_manager_and_tag_and_configure_the_fake()
         {
             // Arrange
+            var onFakeConfigurationAction1 = A.Fake<Action<object>>();
+            var onFakeConfigurationAction2 = A.Fake<Action<object>>();
+
+            A.CallTo(() => this.onFakeConfigurationActions.GetEnumerator())
+                    .Returns(new[] { onFakeConfigurationAction1, onFakeConfigurationAction2 }.AsEnumerable().GetEnumerator());
 
             // Act
             var fakeCallProcessor = this.fakeManagerProvider.Fetch(this.proxy);
@@ -54,6 +64,9 @@ namespace FakeItEasy.Tests.Core
             A.CallTo(() => this.fakeManagerAccessor.TagProxy(this.proxy, this.fakeManager)).MustHaveHappened();
 
             A.CallTo(() => this.configurer.ConfigureFake(this.typeOfFake, this.proxy)).MustHaveHappened();
+
+            A.CallTo(() => onFakeConfigurationAction1(this.proxy)).MustHaveHappened();
+            A.CallTo(() => onFakeConfigurationAction2(this.proxy)).MustHaveHappened();
         }
 
         [Test]

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeAndDummyManagerTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeAndDummyManagerTests.cs
@@ -1,7 +1,6 @@
 namespace FakeItEasy.Tests.Creation
 {
     using System;
-    using FakeItEasy.Core;
     using FakeItEasy.Creation;
     using NUnit.Framework;
 
@@ -14,9 +13,6 @@ namespace FakeItEasy.Tests.Creation
 
         [Fake]
         private FakeObjectCreator fakeCreator;
-
-        [Fake]
-        private IFakeWrapperConfigurer wrapperConfigurer;
 #pragma warning restore 649
 
         private DefaultFakeAndDummyManager manager;
@@ -26,10 +22,7 @@ namespace FakeItEasy.Tests.Creation
         {
             Fake.InitializeFixture(this);
 
-            this.manager = new DefaultFakeAndDummyManager(
-                this.dummySession,
-                this.fakeCreator,
-                this.wrapperConfigurer);
+            this.manager = new DefaultFakeAndDummyManager(this.dummySession, this.fakeCreator);
         }
 
         [Test]

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
@@ -62,17 +62,20 @@ namespace FakeItEasy.Tests.Creation
         public void Should_use_new_fake_call_processor_for_the_proxy_generator()
         {
             // Arrange
-            var options = new FakeOptions();
+            var options = new FakeOptions
+            {
+                OnFakeConfigurationActions = new Action<object>[] { },
+            };
 
             var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
 
-            A.CallTo(() => this.fakeCallProcessorProviderFactory(A<Type>._)).Returns(fakeCallProcessorProvider);
+            A.CallTo(() => this.fakeCallProcessorProviderFactory(A<Type>._, A<IEnumerable<Action<object>>>._)).Returns(fakeCallProcessorProvider);
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(IFoo), options, A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
 
             // Assert
-            A.CallTo(() => this.fakeCallProcessorProviderFactory(typeof(IFoo))).MustHaveHappened();
+            A.CallTo(() => this.fakeCallProcessorProviderFactory(typeof(IFoo), options.OnFakeConfigurationActions)).MustHaveHappened();
 
             A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>._, A<IEnumerable<CustomAttributeBuilder>>._, fakeCallProcessorProvider))
                 .MustHaveHappened();
@@ -88,13 +91,16 @@ namespace FakeItEasy.Tests.Creation
 
             this.StubProxyGeneratorToFail();
 
-            var options = new FakeOptions();
+            var options = new FakeOptions
+            {
+                OnFakeConfigurationActions = new Action<object>[] { },
+            };
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), options, session, throwOnFailure: false);
 
             // Assert
-            A.CallTo(() => this.fakeCallProcessorProviderFactory(typeof(TypeWithMultipleConstructors)))
+            A.CallTo(() => this.fakeCallProcessorProviderFactory(typeof(TypeWithMultipleConstructors), options.OnFakeConfigurationActions))
                 .MustHaveHappened(Repeated.Exactly.Times(3));
         }
 

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
@@ -69,13 +69,13 @@ namespace FakeItEasy.Tests.Creation
 
             var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
 
-            A.CallTo(() => this.fakeCallProcessorProviderFactory(A<Type>._, A<IEnumerable<Action<object>>>._)).Returns(fakeCallProcessorProvider);
+            A.CallTo(() => this.fakeCallProcessorProviderFactory(A<Type>._, A<FakeOptions>._)).Returns(fakeCallProcessorProvider);
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(IFoo), options, A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
 
             // Assert
-            A.CallTo(() => this.fakeCallProcessorProviderFactory(typeof(IFoo), options.OnFakeConfigurationActions)).MustHaveHappened();
+            A.CallTo(() => this.fakeCallProcessorProviderFactory(typeof(IFoo), options)).MustHaveHappened();
 
             A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>._, A<IEnumerable<CustomAttributeBuilder>>._, fakeCallProcessorProvider))
                 .MustHaveHappened();
@@ -100,7 +100,7 @@ namespace FakeItEasy.Tests.Creation
             this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), options, session, throwOnFailure: false);
 
             // Assert
-            A.CallTo(() => this.fakeCallProcessorProviderFactory(typeof(TypeWithMultipleConstructors), options.OnFakeConfigurationActions))
+            A.CallTo(() => this.fakeCallProcessorProviderFactory(typeof(TypeWithMultipleConstructors), options))
                 .MustHaveHappened(Repeated.Exactly.Times(3));
         }
 

--- a/Source/FakeItEasy.Tests/FakeOptionsBuilderExtensionsTests.cs
+++ b/Source/FakeItEasy.Tests/FakeOptionsBuilderExtensionsTests.cs
@@ -29,7 +29,7 @@ namespace FakeItEasy.Tests
         {
             // Arrange
             var options = A.Fake<IFakeOptionsBuilder<IFoo>>();
-            A.CallTo(() => options.OnFakeCreated(A<Action<IFoo>>._)).Returns(options);
+            A.CallTo(() => options.OnFakeConfiguration(A<Action<IFoo>>._)).Returns(options);
 
             // Act
             var result = options.Strict();
@@ -81,7 +81,7 @@ namespace FakeItEasy.Tests
         {
             // Arrange
             var options = A.Fake<IFakeOptionsBuilder<IFoo>>();
-            A.CallTo(() => options.OnFakeCreated(A<Action<IFoo>>._)).Returns(options);
+            A.CallTo(() => options.OnFakeConfiguration(A<Action<IFoo>>._)).Returns(options);
 
             // Act
             var result = options.CallsBaseMethods();

--- a/Source/FakeItEasy/Core/FakeCallProcessorProvider.cs
+++ b/Source/FakeItEasy/Core/FakeCallProcessorProvider.cs
@@ -1,9 +1,10 @@
 namespace FakeItEasy.Core
 {
     using System;
+    using System.Collections.Generic;
 
     internal static class FakeCallProcessorProvider
     {
-        public delegate IFakeCallProcessorProvider Factory(Type typeOfFake);
+        public delegate IFakeCallProcessorProvider Factory(Type typeOfFake, IEnumerable<Action<object>> onFakeConfigurationActions);
     }
 }

--- a/Source/FakeItEasy/Core/FakeCallProcessorProvider.cs
+++ b/Source/FakeItEasy/Core/FakeCallProcessorProvider.cs
@@ -1,10 +1,10 @@
 namespace FakeItEasy.Core
 {
     using System;
-    using System.Collections.Generic;
+    using FakeItEasy.Creation;
 
     internal static class FakeCallProcessorProvider
     {
-        public delegate IFakeCallProcessorProvider Factory(Type typeOfFake, IEnumerable<Action<object>> onFakeConfigurationActions);
+        public delegate IFakeCallProcessorProvider Factory(Type typeOfFake, FakeOptions fakeOptions);
     }
 }

--- a/Source/FakeItEasy/Core/FakeManagerProvider.cs
+++ b/Source/FakeItEasy/Core/FakeManagerProvider.cs
@@ -1,7 +1,7 @@
 namespace FakeItEasy.Core
 {
     using System;
-    using System.Collections.Generic;
+    using FakeItEasy.Creation;
 
     /// <summary>
     /// Implementation of <see cref="IFakeCallProcessorProvider"/>, which returns a <see cref="FakeManager"/> as "call processor" lazily (on
@@ -22,13 +22,16 @@ namespace FakeItEasy.Core
         private readonly IFakeManagerAccessor fakeManagerAccessor;
 
         [NonSerialized]
-        private readonly IFakeObjectConfigurator configurer;
+        private readonly IFakeObjectConfigurator fakeObjectConfigurator;
+
+        [NonSerialized]
+        private readonly IFakeWrapperConfigurer wrapperConfigurer;
 
         [NonSerialized]
         private readonly Type typeOfFake;
 
         [NonSerialized]
-        private readonly IEnumerable<Action<object>> onFakeConfigurationActions;
+        private readonly FakeOptions fakeOptions;
 
         // We want to lock accesses to initializedFakeManager to guarantee thread-safety (see IFakeCallProcessorProvider documentation):
         private readonly object initializedFakeManagerLock = new object();
@@ -38,21 +41,24 @@ namespace FakeItEasy.Core
         public FakeManagerProvider(
                 FakeManager.Factory fakeManagerFactory,
                 IFakeManagerAccessor fakeManagerAccessor,
-                IFakeObjectConfigurator configurer,
+                IFakeObjectConfigurator fakeObjectConfigurator, 
+                IFakeWrapperConfigurer wrapperConfigurer,
                 Type typeOfFake,
-                IEnumerable<Action<object>> onFakeConfigurationActions)
+                FakeOptions fakeOptions)
         {
             Guard.AgainstNull(fakeManagerFactory, "fakeManagerFactory");
             Guard.AgainstNull(fakeManagerAccessor, "fakeManagerAccessor");
-            Guard.AgainstNull(configurer, "configurer");
+            Guard.AgainstNull(fakeObjectConfigurator, "fakeObjectConfigurator");
+            Guard.AgainstNull(wrapperConfigurer, "wrapperConfigurer");
             Guard.AgainstNull(typeOfFake, "typeOfFake");
-            Guard.AgainstNull(onFakeConfigurationActions, "onFakeConfigurationActions");
+            Guard.AgainstNull(fakeOptions, "fakeOptions");
 
             this.fakeManagerFactory = fakeManagerFactory;
             this.fakeManagerAccessor = fakeManagerAccessor;
-            this.configurer = configurer;
+            this.fakeObjectConfigurator = fakeObjectConfigurator;
+            this.wrapperConfigurer = wrapperConfigurer;
             this.typeOfFake = typeOfFake;
-            this.onFakeConfigurationActions = onFakeConfigurationActions;
+            this.fakeOptions = fakeOptions;
         }
 
         public IFakeCallProcessor Fetch(object proxy)
@@ -84,13 +90,23 @@ namespace FakeItEasy.Core
 
                     this.fakeManagerAccessor.TagProxy(proxy, this.initializedFakeManager);
 
-                    this.configurer.ConfigureFake(this.typeOfFake, proxy);
-
-                    foreach (var onFakeConfigurationAction in this.onFakeConfigurationActions)
-                    {
-                        onFakeConfigurationAction(proxy);
-                    }
+                    this.ApplyInitialConfiguration(proxy);
                 }
+            }
+        }
+
+        private void ApplyInitialConfiguration(object proxy)
+        {
+            this.fakeObjectConfigurator.ConfigureFake(this.typeOfFake, proxy);
+
+            if (this.fakeOptions.WrappedInstance != null)
+            {
+                this.wrapperConfigurer.ConfigureFakeToWrap(proxy, this.fakeOptions.WrappedInstance, this.fakeOptions.SelfInitializedFakeRecorder);
+            }
+
+            foreach (var onFakeConfigurationAction in this.fakeOptions.OnFakeConfigurationActions)
+            {
+                onFakeConfigurationAction(proxy);
             }
         }
     }

--- a/Source/FakeItEasy/Core/FakeManagerProvider.cs
+++ b/Source/FakeItEasy/Core/FakeManagerProvider.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy.Core
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Implementation of <see cref="IFakeCallProcessorProvider"/>, which returns a <see cref="FakeManager"/> as "call processor" lazily (on
@@ -26,6 +27,9 @@ namespace FakeItEasy.Core
         [NonSerialized]
         private readonly Type typeOfFake;
 
+        [NonSerialized]
+        private readonly IEnumerable<Action<object>> onFakeConfigurationActions;
+
         // We want to lock accesses to initializedFakeManager to guarantee thread-safety (see IFakeCallProcessorProvider documentation):
         private readonly object initializedFakeManagerLock = new object();
 
@@ -35,17 +39,20 @@ namespace FakeItEasy.Core
                 FakeManager.Factory fakeManagerFactory,
                 IFakeManagerAccessor fakeManagerAccessor,
                 IFakeObjectConfigurator configurer,
-                Type typeOfFake)
+                Type typeOfFake,
+                IEnumerable<Action<object>> onFakeConfigurationActions)
         {
             Guard.AgainstNull(fakeManagerFactory, "fakeManagerFactory");
             Guard.AgainstNull(fakeManagerAccessor, "fakeManagerAccessor");
             Guard.AgainstNull(configurer, "configurer");
             Guard.AgainstNull(typeOfFake, "typeOfFake");
+            Guard.AgainstNull(onFakeConfigurationActions, "onFakeConfigurationActions");
 
             this.fakeManagerFactory = fakeManagerFactory;
             this.fakeManagerAccessor = fakeManagerAccessor;
             this.configurer = configurer;
             this.typeOfFake = typeOfFake;
+            this.onFakeConfigurationActions = onFakeConfigurationActions;
         }
 
         public IFakeCallProcessor Fetch(object proxy)
@@ -78,6 +85,11 @@ namespace FakeItEasy.Core
                     this.fakeManagerAccessor.TagProxy(proxy, this.initializedFakeManager);
 
                     this.configurer.ConfigureFake(this.typeOfFake, proxy);
+
+                    foreach (var onFakeConfigurationAction in this.onFakeConfigurationActions)
+                    {
+                        onFakeConfigurationAction(proxy);
+                    }
                 }
             }
         }

--- a/Source/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
@@ -11,13 +11,11 @@ namespace FakeItEasy.Creation
     {
         private readonly FakeObjectCreator fakeCreator;
         private readonly IDummyValueCreationSession session;
-        private readonly IFakeWrapperConfigurer wrapperConfigurer;
 
-        public DefaultFakeAndDummyManager(IDummyValueCreationSession session, FakeObjectCreator fakeCreator, IFakeWrapperConfigurer wrapperConfigurer)
+        public DefaultFakeAndDummyManager(IDummyValueCreationSession session, FakeObjectCreator fakeCreator)
         {
             this.session = session;
             this.fakeCreator = fakeCreator;
-            this.wrapperConfigurer = wrapperConfigurer;
         }
 
         public object CreateDummy(Type typeOfDummy)
@@ -35,7 +33,7 @@ namespace FakeItEasy.Creation
         {
             var result = this.fakeCreator.CreateFake(typeOfFake, options, this.session, throwOnFailure: true);
 
-            this.ApplyConfigurationFromOptions(result, options);
+            InvokeOnFakeCreatedActions(result, options);
 
             return result;
         }
@@ -54,17 +52,12 @@ namespace FakeItEasy.Creation
                 return false;
             }
 
-            this.ApplyConfigurationFromOptions(result, options);
+            InvokeOnFakeCreatedActions(result, options);
             return true;
         }
 
-        private void ApplyConfigurationFromOptions(object fake, FakeOptions options)
+        private static void InvokeOnFakeCreatedActions(object fake, FakeOptions options)
         {
-            if (options.WrappedInstance != null)
-            {
-                this.wrapperConfigurer.ConfigureFakeToWrap(fake, options.WrappedInstance, options.SelfInitializedFakeRecorder);
-            }
-
             foreach (var a in options.OnFakeCreatedActions)
             {
                 a.Invoke(fake);

--- a/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
@@ -126,6 +126,12 @@ namespace FakeItEasy.Creation
                 return this;
             }
 
+            public IFakeOptionsBuilder<T> OnFakeConfiguration(Action<T> action)
+            {
+                this.Options.OnFakeConfigurationActions.Add(x => action((T)x));
+                return this;
+            }
+
             public IFakeOptionsBuilder<T> RecordedBy(ISelfInitializingFakeRecorder recorder)
             {
                 this.Options.SelfInitializedFakeRecorder = recorder;

--- a/Source/FakeItEasy/Creation/FakeObjectCreator.cs
+++ b/Source/FakeItEasy/Creation/FakeObjectCreator.cs
@@ -110,7 +110,7 @@ namespace FakeItEasy.Creation
 
         private ProxyGeneratorResult GenerateProxy(Type typeOfFake, FakeOptions fakeOptions, IEnumerable<object> argumentsForConstructor)
         {
-            var fakeCallProcessorProvider = this.fakeCallProcessorProviderFactory(typeOfFake);
+            var fakeCallProcessorProvider = this.fakeCallProcessorProviderFactory(typeOfFake, fakeOptions.OnFakeConfigurationActions);
 
             return this.proxyGenerator.GenerateProxy(
                     typeOfFake,

--- a/Source/FakeItEasy/Creation/FakeObjectCreator.cs
+++ b/Source/FakeItEasy/Creation/FakeObjectCreator.cs
@@ -110,7 +110,7 @@ namespace FakeItEasy.Creation
 
         private ProxyGeneratorResult GenerateProxy(Type typeOfFake, FakeOptions fakeOptions, IEnumerable<object> argumentsForConstructor)
         {
-            var fakeCallProcessorProvider = this.fakeCallProcessorProviderFactory(typeOfFake, fakeOptions.OnFakeConfigurationActions);
+            var fakeCallProcessorProvider = this.fakeCallProcessorProviderFactory(typeOfFake, fakeOptions);
 
             return this.proxyGenerator.GenerateProxy(
                     typeOfFake,

--- a/Source/FakeItEasy/Creation/FakeOptions.cs
+++ b/Source/FakeItEasy/Creation/FakeOptions.cs
@@ -11,6 +11,7 @@ namespace FakeItEasy.Creation
         public FakeOptions()
         {
             this.AdditionalInterfacesToImplement = Enumerable.Empty<Type>();
+            this.OnFakeConfigurationActions = new List<Action<object>>();
             this.OnFakeCreatedActions = new List<Action<object>>();
             this.AdditionalAttributes = Enumerable.Empty<CustomAttributeBuilder>();
         }
@@ -27,6 +28,8 @@ namespace FakeItEasy.Creation
         public IEnumerable<object> ArgumentsForConstructor { get; set; }
 
         public IEnumerable<Type> AdditionalInterfacesToImplement { get; set; }
+
+        public ICollection<Action<object>> OnFakeConfigurationActions { get; set; }
 
         public ICollection<Action<object>> OnFakeCreatedActions { get; set; }
 

--- a/Source/FakeItEasy/Creation/IFakeOptionsBuilder.cs
+++ b/Source/FakeItEasy/Creation/IFakeOptionsBuilder.cs
@@ -56,8 +56,18 @@ namespace FakeItEasy.Creation
         IFakeOptionsBuilder<T> Implements(Type interfaceType);
 
         /// <summary>
-        /// Specifies an action that should be run over the fake object
-        /// once it's created.
+        /// Specifies an action that should be run over the fake object for the initial configuration (during the creation of the fake proxy).
+        /// </summary>
+        /// <param name="action">An action to perform.</param>
+        /// <returns>Options object.</returns>
+        /// <remarks>
+        /// Note that this method might be called when the fake is not be fully constructed yet. Use the fake instance to set up
+        /// behavior, but to not rely on its state.
+        /// </remarks>
+        IFakeOptionsBuilder<T> OnFakeConfiguration(Action<T> action);
+
+        /// <summary>
+        /// Specifies an action that should be run over the fake object after it has been successfully created.
         /// </summary>
         /// <param name="action">An action to perform.</param>
         /// <returns>Options object.</returns>

--- a/Source/FakeItEasy/FakeOptionsBuilderExtensions.cs
+++ b/Source/FakeItEasy/FakeOptionsBuilderExtensions.cs
@@ -26,8 +26,7 @@ namespace FakeItEasy
                     throw new ExpectationException("Call to non configured method \"{0}\" of strict fake.".FormatInvariant(call.Method.Name));
                 };
 
-            return options.OnFakeCreated(
-                fake => A.CallTo(fake).Invokes(thrower));
+            return options.OnFakeConfiguration(fake => A.CallTo(fake).Invokes(thrower));
         }
 
         /// <summary>
@@ -40,7 +39,7 @@ namespace FakeItEasy
         {
             Guard.AgainstNull(options, "options");
 
-            return options.OnFakeCreated(fake => A.CallTo(fake)
+            return options.OnFakeConfiguration(fake => A.CallTo(fake)
                                                   .Where(call => !call.Method.IsAbstract)
                                                   .CallsBaseMethod());
         }

--- a/Source/FakeItEasy/RootModule.cs
+++ b/Source/FakeItEasy/RootModule.cs
@@ -57,7 +57,8 @@
                 (Type fakeObjectType, object proxy) => new FakeManager(fakeObjectType, proxy));
 
             container.RegisterSingleton<FakeCallProcessorProvider.Factory>(c =>
-                (typeOfFake, onFakeConfigurationActions) => new FakeManagerProvider(c.Resolve<FakeManager.Factory>(), c.Resolve<IFakeManagerAccessor>(), c.Resolve<IFakeObjectContainer>(), typeOfFake, onFakeConfigurationActions));
+                (typeOfFake, fakeOptions) =>
+                    new FakeManagerProvider(c.Resolve<FakeManager.Factory>(), c.Resolve<IFakeManagerAccessor>(), c.Resolve<IFakeObjectContainer>(), c.Resolve<IFakeWrapperConfigurer>(), typeOfFake, fakeOptions));
 
             container.RegisterSingleton<IFakeObjectCallFormatter>(c =>
                 new DefaultFakeObjectCallFormatter(c.Resolve<ArgumentValueFormatter>(), c.Resolve<IFakeManagerAccessor>()));
@@ -96,7 +97,7 @@
                                                              var fakeCreator = new FakeObjectCreator(c.Resolve<IProxyGenerator>(), c.Resolve<IExceptionThrower>(), c.Resolve<FakeCallProcessorProvider.Factory>());
                                                              var session = new DummyValueCreationSession(c.Resolve<IFakeObjectContainer>(), new SessionFakeObjectCreator { Creator = fakeCreator });
 
-                                                             return new DefaultFakeAndDummyManager(session, fakeCreator, c.Resolve<IFakeWrapperConfigurer>());
+                                                             return new DefaultFakeAndDummyManager(session, fakeCreator);
                                                          });
 
             container.RegisterSingleton<CastleDynamicProxyGenerator>(c => new CastleDynamicProxyGenerator(c.Resolve<CastleDynamicProxyInterceptionValidator>()));

--- a/Source/FakeItEasy/RootModule.cs
+++ b/Source/FakeItEasy/RootModule.cs
@@ -57,7 +57,7 @@
                 (Type fakeObjectType, object proxy) => new FakeManager(fakeObjectType, proxy));
 
             container.RegisterSingleton<FakeCallProcessorProvider.Factory>(c =>
-                (typeOfFake) => new FakeManagerProvider(c.Resolve<FakeManager.Factory>(), c.Resolve<IFakeManagerAccessor>(), c.Resolve<IFakeObjectContainer>(), typeOfFake));
+                (typeOfFake, onFakeConfigurationActions) => new FakeManagerProvider(c.Resolve<FakeManager.Factory>(), c.Resolve<IFakeManagerAccessor>(), c.Resolve<IFakeObjectContainer>(), typeOfFake, onFakeConfigurationActions));
 
             container.RegisterSingleton<IFakeObjectCallFormatter>(c =>
                 new DefaultFakeObjectCallFormatter(c.Resolve<ArgumentValueFormatter>(), c.Resolve<IFakeManagerAccessor>()));


### PR DESCRIPTION
Fixes #371.

Before this PR the `FakeManager` is created / attached and configured (`IFakeObjectConfigurator`) by the `FakeObjectCreator` *after* the proxy object was created and returned by `IProxyGenerator`. That's too late for the c'tor call. The `Strict()` and `CallsBaseMethods()` fake options were applied *even later* in the `DefaultFakeAndDummyManager` when evaluating the `OnFakeCreatedActions`. The `Wrapping()` fake option was also applied in the `DefaultFakeAndDummyManager`.

The idea of this pull request is to encapsulate the creation and initial configuration into the new `LazyFakeManagerProvider`. The first `LazyFakeManagerProvider.Fetch(): IInterceptionSink` call initializes the fake manager and returns an interface, which is used by the proxy interceptor to notify the `FakeManager` about an intercepted call. The `IInterceptionSink` interface replaces the old mechanism using the `CallWasIntercepted` event, which was exposed by the interceptor.

The advantage of this solution is that during the execution of an constructor, the very first call to a virtual member invokes `LazyFakeManagerProvider.Fetch()` and therefore configures the fake manager just in time. If there was no virtual call during the c'tor, then a call to `LazyFakeManagerProvider. EnsureInitialized()` initializes the fake manager *after the c'tor* as it happened before this PR.

For the application of the `Strict()` and `CallsBaseMethods()` options, there are now new `OnFakeConfiguration` callbacks, which are evaluated inside the `LazyFakeManagerProvider`. The existing `OnFakeCreated` callbacks stay in the `DefaultFakeAndDummyManager` to avoid breaking changes. The handling of `Wrapping()` is now also inside `LazyFakeManagerProvider`. So in the end `LazyFakeManagerProvider` is a cohesive service, which does all configuration steps before giving the fake instance to the user.

An interesting side effect of the new `OnFakeConfiguration` callbacks is that this also solves #365, because we can do something like this ...

```c#
A.Fake<ClassWithVirtualCallsInConstructor>(o => 
    o.OnFakeConfiguration(f => 
        A.CallTo(() => f.VirtualMethod(A<string>._)).Returns("configured value")));
```

... which also applies to calls within the constructor.


Note:
* There is a new `ConstructorWithVirtualCallsSpecs` with the formalized specifications of #371.
* Because there is a lot going on in this PR I tried to avoid any unnecessary changes. After this PR is accepted, I will propose a few small refactorings.


<!---
@huboard:{"order":0.03515625,"milestone_order":372}
-->
