### PR TITLE
Make IProxyGenerator (+ IFakeCallProcessorProvider and IFakeCallProcessor) internal

### DIFF
--- a/Source/CommonAssemblyInfo.cs
+++ b/Source/CommonAssemblyInfo.cs
@@ -25,6 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("FakeItEasy.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001002f50d82092713be482c885861c984334606da0f54c78738a3dd0862fb2dfc6080f0780132cc65d88f0f0c70af74e8a53430962395bfc1a36fab08b7a2549d387e805c13cc84acd884447ec8c4dcfb6216df720f0998380f9c906b5de8141798d64661f036d47274e6ecb76c9cde5f4cf2b521040601e44b3914fbeb9f39127f9")]
 
 // Module level suppress messages.
+[module: SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Justification = "Contains several internal types.", Scope = "namespace", Target = "FakeItEasy.Creation")]
 [module: SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Justification = "Contains several internal types.", Scope = "namespace", Target = "FakeItEasy.Expressions")]
 [module: SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Justification = "These types are only used by VB and should not confuse other developers.", Scope = "namespace", Target = "FakeItEasy.VisualBasic")]
 [module: SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Justification = "Is in a namespace of its own to allow for just using the extensions when they are explicitly requested.", Scope = "namespace", Target = "FakeItEasy.ExtensionSyntax")]

--- a/Source/FakeItEasy/Core/IFakeCallProcessor.cs
+++ b/Source/FakeItEasy/Core/IFakeCallProcessor.cs
@@ -4,7 +4,7 @@
     /// Represents the target of intercepted calls of a fake proxy. An implementation of this interface receives calls, gets its arguments
     /// and can provide return values.
     /// </summary>
-    public interface IFakeCallProcessor
+    internal interface IFakeCallProcessor
     {
         /// <summary>
         /// Processes an intercepted call of a fake proxy.

--- a/Source/FakeItEasy/Core/IFakeCallProcessorProvider.cs
+++ b/Source/FakeItEasy/Core/IFakeCallProcessorProvider.cs
@@ -16,7 +16,7 @@ namespace FakeItEasy.Core
     /// we don't need to serialize a fake before it has been initialized (returned to the user).
     /// </para>
     /// </remarks>
-    public interface IFakeCallProcessorProvider
+    internal interface IFakeCallProcessorProvider
     {
         /// <summary>
         /// Create and initialize a new <see cref="IFakeCallProcessor"/> for <paramref name="proxy"/>.

--- a/Source/FakeItEasy/Creation/IProxyGenerator.cs
+++ b/Source/FakeItEasy/Creation/IProxyGenerator.cs
@@ -10,7 +10,7 @@ namespace FakeItEasy.Creation
     /// <summary>
     /// An interface to be implemented by classes that can generate proxies for FakeItEasy.
     /// </summary>
-    public interface IProxyGenerator
+    internal interface IProxyGenerator
     {
         /// <summary>
         /// Generates a proxy of the specified type and returns a result object containing information


### PR DESCRIPTION
(@adamralph: follow up change for #368)

In #373 we introduced `IFakeCallProcessorProvider` and `IFakeCallProcessor`, which had to be public due to the usage in `IProxyGenerator`.

This PR proposes making `IProxyGenerator`, as a part of #374,  internal to allow making the introduced interfaces internal and hide `FakeManager.Process` (explicit implementation of `IFakeCallProcessor.Process`).

Note that `IProxyGenerator` is an infrastructure interface, which is just used in `FakeObjectCreator` and it was public since initial commit (without stating a reason).

Further note that we already introduced a breaking change in `IProxyGenerator` in #373 by adding the `fakeCallProcessorProvider` parameters, so we _could_ use this chance before releasing the next version to make this interface internal.

@ contributors: What do you think?
