### PR TITLE
refactor: build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 [Oo]bj
 [Bb]in
-Build*/*
+artifacts
 
 *.csproj.user
 *.vbproj.user


### PR DESCRIPTION
- reduce MSBuild console verbosity
- pipe detailed MSBuild log to file
- switch to cleaner 'artifacts' folder
- reduced MSpec console verbosity
- pipe detailed MSpec log to file
- suppress printing of release creation variables
- suppress NUnit logo
