### PR TITLE
added note about copying release notes forward when de-listing a version on NuGet

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -40,7 +40,7 @@ release_issue_body = <<-eos
     - [ ] publish the release
 - [ ] push NuGet package
 - [ ] copy release notes from GitHub to NuGet
-- [ ] de-list pre-release or superseded buggy NuGet packages if present
+- [ ] de-list pre-release or superseded buggy NuGet packages if present (copy any release notes forward to the new version)
 - [ ] update website with contributors list (if in place)
 - [ ] tweet, mentioning contributors and post link as comment here for easy retweeting ;-)
 - [ ] post tweet in JabbR ([fakeiteasy][1] and [general-chat][2]) and Gitter ([FakeItEasy/FakeItEasy][3])


### PR DESCRIPTION
I've already gone back and done this for the current de-listings.
