### PR TITLE
fixing lazy code analysis warnings

### DIFF
--- a/Source/FakeItEasy.Specs/LazySpecs.cs
+++ b/Source/FakeItEasy.Specs/LazySpecs.cs
@@ -1,10 +1,12 @@
 ﻿namespace FakeItEasy.Specs
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
+
     using FluentAssertions;
     using Machine.Specifications;
 
-    public class when_calling_an_unconfigured_method_that_returns_a_lazy_of_ifoo
+    public class when_calling_a_method_that_returns_a_lazy
     {
         static ILazyFactory fake;
         static Lazy<IFoo> lazy;
@@ -21,24 +23,30 @@
 
         It should_return_a_lazy = () => lazy.Should().NotBeNull();
 
-        It should_return_a_lazy_whose_value_is_an_ifoo_dummy = () => lazy.Value.Should().Be(FooDefinition.Instance);
+        It should_return_a_lazy_whose_value_is_a_dummy = () => lazy.Value.Should().Be(FooDefinition.Instance);
         
         public interface ILazyFactory
         {
             Lazy<IFoo> Create();
         }
 
+        [SuppressMessage("Microsoft.Design", "CA1040:AvoidEmptyInterfaces", Justification = "Required for testing.")]
         public interface IFoo
         {
         }
 
         public class FooDefinition : DummyDefinition<IFoo>, IFoo
         {
-            public static readonly IFoo Instance = new FooDefinition();
+            private static IFoo instance = new FooDefinition();
+
+            public static IFoo Instance
+            {
+                get { return instance; }
+            }
 
             protected override IFoo CreateDummy()
             {
-                return Instance;
+                return instance;
             }
         }
     }


### PR DESCRIPTION
Introduced during #363. The naming ones were a result of bad suggestions from me.
