### PR TITLE
#417 - managing beta label via VERSION_SUFFIX environment variable

### DIFF
--- a/Source/CommonAssemblyInfo.cs
+++ b/Source/CommonAssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("2.0.0")]
 [assembly: AssemblyFileVersion("2.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0-beta003")]
+[assembly: AssemblyInformationalVersion("2.0.0")]
 
 [assembly: AssemblyCompany("Patrik Hägne")]
 [assembly: AssemblyProduct("FakeItEasy")]


### PR DESCRIPTION
Fixes #417.

I also added a the VERSION_SUFFIX environment variable to the CI server:

![image](https://cloud.githubusercontent.com/assets/3275797/5387131/28006bee-80a3-11e4-9752-657574b3547a.png)

And, assuming the PR goes through, I'll update #336.
