### PR TITLE
#335 Add tests for Windows 8.1

### DIFF
--- a/Source/FakeItEasy.Win81.Tests/FakeItEasy.Win81.Tests.csproj
+++ b/Source/FakeItEasy.Win81.Tests/FakeItEasy.Win81.Tests.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A84169B8-3CAC-415B-A367-A167836B034C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FakeItEasy.Win81.Tests</RootNamespace>
+    <AssemblyName>FakeItEasy.Win81.Tests</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{BC8A1FFA-BEE3-4634-8014-F334798102B3};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+    <TargetPlatformVersion>8.1</TargetPlatformVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\FakeItEasy.Tests.ruleset</CodeAnalysisRuleSet>
+    <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\FakeItEasy.Tests.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Tests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="FakeItEasy">
+      <HintPath Condition=" '$(Configuration)' == 'Debug' ">..\FakeItEasy-SL\Bin\Debug\FakeItEasy.dll</HintPath>
+      <HintPath Condition=" '$(Configuration)' == 'Release' ">..\FakeItEasy-SL\Bin\Release\FakeItEasy.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\FluentAssertions.2.2.0.0\lib\winrt45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="..\packages\StyleCop.MSBuild.4.7.48.2\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.48.2\build\StyleCop.MSBuild.Targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\StyleCop.MSBuild.4.7.48.2\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.MSBuild.4.7.48.2\build\StyleCop.MSBuild.Targets'))" />
+  </Target>
+</Project>

--- a/Source/FakeItEasy.Win81.Tests/Tests.cs
+++ b/Source/FakeItEasy.Win81.Tests/Tests.cs
@@ -1,0 +1,16 @@
+﻿namespace FakeItEasy.Tests
+{
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public static class Tests
+    {
+        [Test]
+        public static void CanUseFakeItEasy()
+        {
+            var fake = A.Fake<IDummyDefinition>();
+            A.CallTo(() => fake.CreateDummy()).Returns(new object());
+            fake.CreateDummy().Should().NotBeNull();
+        }
+    }
+}

--- a/Source/FakeItEasy.Win81.Tests/packages.config
+++ b/Source/FakeItEasy.Win81.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentAssertions" version="2.2.0.0" targetFramework="win81" />
+  <package id="NUnit" version="2.6.3" targetFramework="win81" />
+  <package id="StyleCop.MSBuild" version="4.7.48.2" targetFramework="win81" developmentDependency="true" />
+</packages>

--- a/Source/FakeItEasy.sln
+++ b/Source/FakeItEasy.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A6A7B553-5359-4FB9-B19C-8A23004F49DB}"
 	ProjectSection(SolutionItems) = preProject
@@ -64,6 +64,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Specs", "Specs", "{575A3C3B-17BA-4A8A-9F53-05320913D0A6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FakeItEasy.Win81.Tests", "FakeItEasy.Win81.Tests\FakeItEasy.Win81.Tests.csproj", "{A84169B8-3CAC-415B-A367-A167836B034C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -121,6 +123,10 @@ Global
 		{19A3E9ED-D8A6-463A-83E6-D59ABA52F1BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19A3E9ED-D8A6-463A-83E6-D59ABA52F1BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19A3E9ED-D8A6-463A-83E6-D59ABA52F1BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A84169B8-3CAC-415B-A367-A167836B034C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A84169B8-3CAC-415B-A367-A167836B034C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A84169B8-3CAC-415B-A367-A167836B034C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A84169B8-3CAC-415B-A367-A167836B034C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -139,6 +145,7 @@ Global
 		{30396678-D653-4C67-A507-1749424A24CD} = {5D41D463-D53B-4ADC-90AD-44AA03D6340D}
 		{C291B61B-0729-4DC5-B8E4-147A8E3F801F} = {5D41D463-D53B-4ADC-90AD-44AA03D6340D}
 		{FA539A2D-98DC-4300-9A2C-EC6FE38A7392} = {575A3C3B-17BA-4A8A-9F53-05320913D0A6}
+		{A84169B8-3CAC-415B-A367-A167836B034C} = {DC5EAE30-96E3-4D38-B3C5-33E587C9FB76}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		version = 0.1

--- a/Source/packages/repositories.config
+++ b/Source/packages/repositories.config
@@ -10,6 +10,7 @@
   <repository path="..\FakeItEasy.Specs\packages.config" />
   <repository path="..\FakeItEasy.Tests\packages.config" />
   <repository path="..\FakeItEasy.Win8.Tests\packages.config" />
+  <repository path="..\FakeItEasy.Win81.Tests\packages.config" />
   <repository path="..\FakeItEasy\packages.config" />
   <repository path="..\FakeItEasy-SL.Tests\packages.config" />
   <repository path="..\FakeItEasy-SL\packages.config" />


### PR DESCRIPTION
As suggested in #335. This does seem to just work on the couple of machines that I have tested it on, which were running Windows 8.1 and Visual Studio 2013. The project builds and the test passes.

The [standard upgrade process](http://msdn.microsoft.com/en-GB/library/windows/apps/dn263114.aspx) also made changes to the minimum Visual Studio version (to require VS2013) but I don't think that this will be necessary, everything should also run in VS2012. However I do have those changes in a separate [commit](https://github.com/jamiehumphries/FakeItEasy/commit/637f2e5e94a937232923f96072680eff8704dfe5) that I could add to this PR if you are happy to require VS2013.
