### PR TITLE
#425 remove obsolete type members

### DIFF
--- a/Source/FakeItEasy.Tests/ATests.cs
+++ b/Source/FakeItEasy.Tests/ATests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using FakeItEasy.Creation;
+    using FluentAssertions;
     using NUnit.Framework;
 
     [TestFixture]
@@ -16,13 +17,13 @@
         {
             // Arrange
             var fake = A.Fake<IFoo>();
-            A.CallTo(() => this.fakeCreator.CreateFake<IFoo>(A<Action<IFakeOptionsBuilder<IFoo>>>._)).Returns(fake);
+            A.CallTo(() => this.fakeCreator.CreateFake(A<Action<IFakeOptionsBuilder<IFoo>>>._)).Returns(fake);
 
             // Act
             var result = A.Fake<IFoo>();
 
             // Assert
-            Assert.That(result, Is.SameAs(fake));
+            result.Should().BeSameAs(fake);
         }
 
         [Test]
@@ -32,13 +33,13 @@
             var fake = A.Fake<IFoo>();
 
             Action<IFakeOptionsBuilder<IFoo>> options = x => { };
-            A.CallTo(() => this.fakeCreator.CreateFake<IFoo>(options)).Returns(fake);
+            A.CallTo(() => this.fakeCreator.CreateFake(options)).Returns(fake);
 
             // Act
-            var result = A.Fake<IFoo>(options);
+            var result = A.Fake(options);
 
             // Assert
-            Assert.That(result, Is.SameAs(fake));
+            result.Should().BeSameAs(fake);
         }
 
         [Test]
@@ -52,7 +53,7 @@
             var result = A.Dummy<IFoo>();
 
             // Assert
-            Assert.That(result, Is.SameAs(dummy));
+            result.Should().BeSameAs(dummy);
         }
 
         [Test]
@@ -65,17 +66,17 @@
             A.CallTo(() => creator.CollectionOfFake<IFoo>(10)).Returns(returnedFromCreator);
 
             // Act
-            var result = A.CollectionOfFake<IFoo>(10);
+            object result = A.CollectionOfFake<IFoo>(10);
 
             // Assert
-            Assert.That(result, Is.SameAs(returnedFromCreator));
+            result.Should().BeSameAs(returnedFromCreator);
         }
 
         protected override void OnSetup()
         {
             base.OnSetup();
             this.fakeCreator = A.Fake<IFakeCreatorFacade>();
-            this.StubResolve<IFakeCreatorFacade>(this.fakeCreator);
+            this.StubResolve(this.fakeCreator);
             this.scope = Fake.CreateScope();
         }
 

--- a/Source/FakeItEasy.Tests/ATests.cs
+++ b/Source/FakeItEasy.Tests/ATests.cs
@@ -12,20 +12,6 @@
         private IDisposable scope;
 
         [Test]
-        public void Static_equals_delegates_to_static_method_on_object()
-        {
-            Assert.That(A.Equals("foo", "foo"), Is.True);
-        }
-
-        [Test]
-        public void Static_ReferenceEquals_delegates_to_static_method_on_object()
-        {
-            var s = string.Empty;
-
-            Assert.That(A.ReferenceEquals(s, s), Is.True);
-        }
-
-        [Test]
         public void Fake_without_arguments_should_call_fake_creator_with_empty_action()
         {
             // Arrange

--- a/Source/FakeItEasy/A.cs
+++ b/Source/FakeItEasy/A.cs
@@ -75,32 +75,6 @@ namespace FakeItEasy
         }
 
         /// <summary>
-        /// Gets a value indicating whether the two objects are equal.
-        /// </summary>
-        /// <param name="objA">The first object to compare.</param>
-        /// <param name="objB">The second object to compare.</param>
-        /// <returns>True if the two objects are equal.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Uses the same naming as the framework")]
-        public static new bool Equals(object objA, object objB)
-        {
-            return object.Equals(objA, objB);
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether the two objects are the same reference.
-        /// </summary>
-        /// <param name="objA">The object A.</param>
-        /// <param name="objB">The object B.</param>
-        /// <returns>True if the objects are the same reference.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Uses the same naming as the framework")]
-        public static new bool ReferenceEquals(object objA, object objB)
-        {
-            return object.ReferenceEquals(objA, objB);
-        }
-
-        /// <summary>
         /// Configures a call to a faked object.
         /// </summary>
         /// <param name="callSpecification">An expression where the configured member is called.</param>

--- a/Source/FakeItEasy/Fake.cs
+++ b/Source/FakeItEasy/Fake.cs
@@ -2,7 +2,6 @@ namespace FakeItEasy
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using FakeItEasy.Core;
@@ -50,32 +49,6 @@ namespace FakeItEasy
         public static IFakeScope CreateScope(IFakeObjectContainer container)
         {
             return Facade.CreateScope(container);
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether the two objects are equal.
-        /// </summary>
-        /// <param name="objA">The first object to compare.</param>
-        /// <param name="objB">The second object to compare.</param>
-        /// <returns>True if the two objects are equal.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Using the same names as the hidden method.")]
-        public static new bool Equals(object objA, object objB)
-        {
-            return object.Equals(objA, objB);
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether the two objects are the same reference.
-        /// </summary>
-        /// <param name="objA">The object A.</param>
-        /// <param name="objB">The object B.</param>
-        /// <returns>True if the objects are the same reference.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Using the same names as the hidden method.")]
-        public static new bool ReferenceEquals(object objA, object objB)
-        {
-            return object.ReferenceEquals(objA, objB);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #425.

These are all the _obsolete_ type members I could find. There are other types that could be made internal or moved to different namespaces, though. Unless there's an objection, I'll make another issue for those.