### PR TITLE
fixing aberrant test class namespaces

### DIFF
--- a/Source/FakeItEasy-SL.Tests/FakeItEasy-SL.Tests.csproj
+++ b/Source/FakeItEasy-SL.Tests/FakeItEasy-SL.Tests.csproj
@@ -9,7 +9,7 @@
     <ProjectTypeGuids>{A1591282-1198-4647-A2B1-27E5FF5F6F3B};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>FakeItEasy.Tests</RootNamespace>
+    <RootNamespace>FakeItEasy_SL.Tests</RootNamespace>
     <AssemblyName>FakeItEasy-SL.Tests</AssemblyName>
     <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>

--- a/Source/FakeItEasy.Net35.Tests/ConditionalWeakTableTests.cs
+++ b/Source/FakeItEasy.Net35.Tests/ConditionalWeakTableTests.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy
+﻿namespace FakeItEasy.Net35.Tests
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/Source/FakeItEasy.Net35.Tests/FakeItEasy.Net35.Tests.csproj
+++ b/Source/FakeItEasy.Net35.Tests/FakeItEasy.Net35.Tests.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{E029C5AB-EC90-45B0-BBD9-29A60864B137}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>FakeItEasy</RootNamespace>
+    <RootNamespace>FakeItEasy.Net35.Tests</RootNamespace>
     <AssemblyName>FakeItEasy.Net35.Tests</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/Source/FakeItEasy.Net35.Tests/ZipTests.cs
+++ b/Source/FakeItEasy.Net35.Tests/ZipTests.cs
@@ -1,6 +1,5 @@
-﻿namespace FakeItEasy
+﻿namespace FakeItEasy.Net35.Tests
 {
-    using System;
     using System.Linq;
     using NUnit.Framework;
 

--- a/Source/FakeItEasy.Tests/Core/DynamicContainerTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DynamicContainerTests.cs
@@ -1,8 +1,9 @@
-﻿namespace FakeItEasy.Core.Tests
+﻿namespace FakeItEasy.Tests.Core
 {
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using FakeItEasy.Core;
     using NUnit.Framework;
 
     [TestFixture]

--- a/Source/FakeItEasy.Tests/Expressions/ArgumentConstraints/EqualityArgumentConstraintTests.cs
+++ b/Source/FakeItEasy.Tests/Expressions/ArgumentConstraints/EqualityArgumentConstraintTests.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Tests.ExpressionsConstraints
+﻿namespace FakeItEasy.Tests.Expressions.ArgumentConstraints
 {
     using System;
     using System.Collections.Generic;

--- a/Source/FakeItEasy.Tests/SyntaxTests.cs
+++ b/Source/FakeItEasy.Tests/SyntaxTests.cs
@@ -1,9 +1,8 @@
-﻿namespace FakeItEasy
+﻿namespace FakeItEasy.Tests
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using FakeItEasy.Tests;
-    
+
     internal class SyntaxTests
     {
         [SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Justification = "Required for testing.")]

--- a/Source/FakeItEasy.Win8.Tests/FakeItEasy.Win8.Tests.csproj
+++ b/Source/FakeItEasy.Win8.Tests/FakeItEasy.Win8.Tests.csproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{19A3E9ED-D8A6-463A-83E6-D59ABA52F1BF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>FakeItEasy.Tests</RootNamespace>
+    <RootNamespace>FakeItEasy.Win8.Tests</RootNamespace>
     <AssemblyName>FakeItEasy.Win8.Tests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>

--- a/Source/FakeItEasy.Win8.Tests/Tests.cs
+++ b/Source/FakeItEasy.Win8.Tests/Tests.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Tests
+﻿namespace FakeItEasy.Win8.Tests
 {
     using FluentAssertions;
     using NUnit.Framework;

--- a/Source/FakeItEasy.Win81.Tests/FakeItEasy.Win81.Tests.csproj
+++ b/Source/FakeItEasy.Win81.Tests/FakeItEasy.Win81.Tests.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{A84169B8-3CAC-415B-A367-A167836B034C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>FakeItEasy.Tests</RootNamespace>
+    <RootNamespace>FakeItEasy.Win81.Tests</RootNamespace>
     <AssemblyName>FakeItEasy.Win81.Tests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>

--- a/Source/FakeItEasy.Win81.Tests/Tests.cs
+++ b/Source/FakeItEasy.Win81.Tests/Tests.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Tests
+﻿namespace FakeItEasy.Win81.Tests
 {
     using FluentAssertions;
     using NUnit.Framework;


### PR DESCRIPTION
While working on the "internalizing" issue, I broke the Win8/Win8.1 tests and couldn't tell which tests were failing at first, due to the less-than-ideal namespace. So I figured, "let's fix those up while we're deconfusing ourself".