### PR TITLE
Issue480

### DIFF
--- a/Source/FakeItEasy.IntegrationTests/GeneralTests.cs
+++ b/Source/FakeItEasy.IntegrationTests/GeneralTests.cs
@@ -161,6 +161,21 @@ namespace FakeItEasy.IntegrationTests
         }
 
         [Test]
+        public void ErrorMessage_when_configuring_generic_function_call_that_cannot_be_configured_should_be_correct()
+        {
+            // Arrange
+            var fake = A.Fake<TypeWithNonConfigurableMethod>();
+
+            // Act
+            var exception = Record.Exception(() =>
+                A.CallTo(() => fake.GenericNonVirtualFunction<int>(string.Empty, 1)).Returns(10));
+
+            // Asssert
+            exception.Should().BeAnExceptionOfType<FakeConfigurationException>().And
+                .Message.Should().Contain("Non virtual");
+        }
+
+        [Test]
         public void Should_be_able_to_generate_class_fake_that_implements_additional_interface()
         {
             // Arrange
@@ -292,6 +307,11 @@ namespace FakeItEasy.IntegrationTests
             public int NonVirtualFunction(string argument, int otherArgument)
             {
                 return 1;
+            }
+
+            public T GenericNonVirtualFunction<T>(string argument, int otherArgument)
+            {
+                return default(T);
             }
         }
     }

--- a/Source/FakeItEasy/Core/MethodInfoManager.cs
+++ b/Source/FakeItEasy/Core/MethodInfoManager.cs
@@ -53,10 +53,19 @@ namespace FakeItEasy.Core
 
         private static bool HasSameBaseMethod(MethodInfo first, MethodInfo second)
         {
-            var baseOfFirst = first.GetBaseDefinition();
-            var baseOfSecond = second.GetBaseDefinition();
+            var baseOfFirst = GetBaseDefinition(first);
+            var baseOfSecond = GetBaseDefinition(second);
 
             return IsSameMethod(baseOfFirst, baseOfSecond);
+        }
+
+        private static MethodInfo GetBaseDefinition(MethodInfo method)
+        {
+            if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
+            {
+                method = method.GetGenericMethodDefinition();
+            }
+            return method.GetBaseDefinition();
         }
 
         private static bool IsSameMethod(MethodInfo first, MethodInfo second)


### PR DESCRIPTION
Changed `HasSameBaseMethod` to ensure we're always working with the generic method definition

fixes #480