### PR TITLE
avoiding attempts to create instances of abstract types

### DIFF
--- a/Source/FakeItEasy/Core/BootstrapperLocator.cs
+++ b/Source/FakeItEasy/Core/BootstrapperLocator.cs
@@ -29,7 +29,7 @@
 
             var candidateTypes = appDomainAssembliesReferencingFakeItEasy
                 .SelectMany(assembly => assembly.GetExportedTypes())
-                .Where(type => bootstrapperInterface.IsAssignableFrom(type));
+                .Where(type => type.CanBeInstantiatedAs(bootstrapperInterface));
 
             var bootstrapperType = candidateTypes.FirstOrDefault() ?? typeof(DefaultBootstrapper);
 

--- a/Source/FakeItEasy/Core/TypeCatalogueInstanceProvider.cs
+++ b/Source/FakeItEasy/Core/TypeCatalogueInstanceProvider.cs
@@ -28,7 +28,7 @@
         {
             var result = new List<T>();
 
-            foreach (var type in this.catalogue.GetAvailableTypes().Where(x => typeof(T).IsAssignableFrom(x)))
+            foreach (var type in this.catalogue.GetAvailableTypes().Where(x => x.CanBeInstantiatedAs(typeof(T))))
             {
                 try
                 {

--- a/Source/FakeItEasy/Creation/DummyValueCreationSession.cs
+++ b/Source/FakeItEasy/Creation/DummyValueCreationSession.cs
@@ -217,7 +217,7 @@
             public override bool TryCreateDummyValue(Type typeOfDummy, out object result)
             {
                 result = default(object);
-                if (typeof(Delegate).IsAssignableFrom(typeOfDummy))
+                if (typeof(Delegate).IsAssignableFrom(typeOfDummy) || typeOfDummy.IsAbstract)
                 {
                     return false;
                 }

--- a/Source/FakeItEasy/TypeExtensions.cs
+++ b/Source/FakeItEasy/TypeExtensions.cs
@@ -29,5 +29,11 @@
         {
             return type.IsValueType && !type.Equals(typeof(void)) ? Activator.CreateInstance(type) : null;
         }
+
+        [DebuggerStepThrough]
+        public static bool CanBeInstantiatedAs(this Type type, Type targetType)
+        {
+            return targetType.IsAssignableFrom(type) && !type.IsAbstract;
+        }
     }
 }


### PR DESCRIPTION
Fixes #494.

Not every CreateInstance got the treatment, and try as I might, I couldn't think of reasonable unit/integration/acceptance tests…