### PR TITLE
removing FakeOptions's parameterless constructor

### DIFF
--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
@@ -120,7 +120,7 @@ namespace FakeItEasy.Tests.Creation
             this.StubProxyGeneratorToFail();
 
             // Act
-            var createdFake = this.fakeObjectCreator.CreateFake(typeof(IFoo), FakeOptions.Empty, A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
+            var createdFake = this.fakeObjectCreator.CreateFake(typeof(IFoo), new FakeOptions(), A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
 
             // Assert
             createdFake.Should().BeNull();
@@ -133,7 +133,7 @@ namespace FakeItEasy.Tests.Creation
             this.StubProxyGeneratorToFail();
 
             // Act
-            this.fakeObjectCreator.CreateFake(typeof(IFoo), FakeOptions.Empty, A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
+            this.fakeObjectCreator.CreateFake(typeof(IFoo), new FakeOptions(), A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
 
             // Assert
             A.CallTo(this.thrower).MustNotHaveHappened();
@@ -224,7 +224,7 @@ namespace FakeItEasy.Tests.Creation
             StubSessionToFailForType<string>(session);
 
             // Act
-            this.fakeObjectCreator.CreateFake(typeof(TypeWithConstructorThatTakesDifferentTypes), FakeOptions.Empty, session, throwOnFailure: false);
+            this.fakeObjectCreator.CreateFake(typeof(TypeWithConstructorThatTakesDifferentTypes), new FakeOptions(), session, throwOnFailure: false);
 
             // Assert
             A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>.That.Not.IsNull(), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
@@ -239,7 +239,7 @@ namespace FakeItEasy.Tests.Creation
             StubSessionWithDummyValue(session, 1);
             this.StubProxyGeneratorToFail();
 
-            var options = FakeOptions.Empty;
+            var options = new FakeOptions();
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(TypeWithProtectedConstructor), options, session, throwOnFailure: false);
@@ -260,7 +260,7 @@ namespace FakeItEasy.Tests.Creation
             this.StubProxyGeneratorToFail("failed");
 
             // Act
-            this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), FakeOptions.Empty, session, throwOnFailure: true);
+            this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), new FakeOptions(), session, throwOnFailure: true);
 
             // Assert
             var expectedConstructors = new[] 

--- a/Source/FakeItEasy/Core/DefaultFixtureInitializer.cs
+++ b/Source/FakeItEasy/Core/DefaultFixtureInitializer.cs
@@ -91,7 +91,7 @@
 
                 if (!fakesUsedToCreateSut.TryGetValue(setter.MemberType, out fake))
                 {
-                    fake = this.fakeAndDummyManager.CreateFake(setter.MemberType, FakeOptions.Empty);
+                    fake = this.fakeAndDummyManager.CreateFake(setter.MemberType, new FakeOptions());
                 }
 
                 setter.Setter(fake);

--- a/Source/FakeItEasy/Core/DefaultSutInitializer.cs
+++ b/Source/FakeItEasy/Core/DefaultSutInitializer.cs
@@ -42,7 +42,7 @@
 
         private object CreateFake(Type typeOfFake, Action<Type, object> onFakeCreated)
         {
-            var result = this.fakeManager.CreateFake(typeOfFake, FakeOptions.Empty);
+            var result = this.fakeManager.CreateFake(typeOfFake, new FakeOptions());
             onFakeCreated.Invoke(typeOfFake, result);
             return result;
         }

--- a/Source/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
+++ b/Source/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
@@ -56,7 +56,7 @@
 
             private static bool TryCreateFake(Type type, out object fake)
             {
-                return FakeAndDummyManager.TryCreateFake(type, FakeOptions.Empty, out fake);
+                return FakeAndDummyManager.TryCreateFake(type, new FakeOptions(), out fake);
             }
 
             private static object DefaultReturnValue(IInterceptedFakeObjectCall fakeObjectCall)

--- a/Source/FakeItEasy/Creation/FakeOptions.cs
+++ b/Source/FakeItEasy/Creation/FakeOptions.cs
@@ -7,22 +7,10 @@ namespace FakeItEasy.Creation
 
     internal class FakeOptions
     {
-        private readonly List<Type> additionalInterfacesToImplement;
-        private readonly List<Action<object>> fakeConfigurationActions;
-        private readonly List<CustomAttributeBuilder> additionalAttributes;
+        private readonly List<Type> additionalInterfacesToImplement = new List<Type>();
+        private readonly List<Action<object>> fakeConfigurationActions = new List<Action<object>>();
+        private readonly List<CustomAttributeBuilder> additionalAttributes = new List<CustomAttributeBuilder>();
         private FakeWrapperConfigurator wrapper;
-
-        public FakeOptions()
-        {
-            this.additionalInterfacesToImplement = new List<Type>();
-            this.fakeConfigurationActions = new List<Action<object>>();
-            this.additionalAttributes = new List<CustomAttributeBuilder>();
-        }
-
-        public static FakeOptions Empty
-        {
-            get { return new FakeOptions(); }
-        }
 
         public FakeWrapperConfigurator Wrapper
         {

--- a/Source/FakeItEasy/RootModule.cs
+++ b/Source/FakeItEasy/RootModule.cs
@@ -175,7 +175,7 @@
 
             public bool TryCreateFakeObject(Type typeOfFake, DummyValueCreationSession session, out object result)
             {
-                result = this.Creator.CreateFake(typeOfFake, FakeOptions.Empty, session, false);
+                result = this.Creator.CreateFake(typeOfFake, new FakeOptions(), session, false);
                 return result != null;
             }
         }


### PR DESCRIPTION
Per @adamralph's [comment in #487](https://github.com/FakeItEasy/FakeItEasy/pull/487/files#r33120984):

> Minor point, but this constructor can be removed and replaced with field initializers.


