### PR TITLE
moving wrapper from FakeOptions to FakeOptionsBuilder

### DIFF
--- a/Source/FakeItEasy.Tests/Core/FakeWrapperConfiguratorTests.cs
+++ b/Source/FakeItEasy.Tests/Core/FakeWrapperConfiguratorTests.cs
@@ -2,6 +2,7 @@
 {
     using System.Linq;
     using FakeItEasy.Core;
+    using FakeItEasy.Creation;
     using FakeItEasy.SelfInitializedFakes;
     using FluentAssertions;
     using NUnit.Framework;
@@ -10,7 +11,7 @@
     public class FakeWrapperConfiguratorTests
     {
         private IFoo faked;
-        private FakeWrapperConfigurator wrapperConfigurator;
+        private FakeWrapperConfigurator<IFoo> wrapperConfigurator;
 
         [SetUp]
         public void Setup()
@@ -18,7 +19,7 @@
             this.faked = A.Fake<IFoo>();
 
             IFoo wrapped = A.Fake<IFoo>();
-            this.wrapperConfigurator = new FakeWrapperConfigurator(wrapped);
+            this.wrapperConfigurator = new FakeWrapperConfigurator<IFoo>(A.Fake<IFakeOptionsBuilder<IFoo>>(), wrapped);
         }
 
         [Test]

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
@@ -16,7 +16,7 @@ namespace FakeItEasy.Tests.Creation
 
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Used reflectively.")]
         private object[] optionBuilderCalls = TestCases.Create<Func<IFakeOptionsBuilder<Foo>, IFakeOptionsBuilder<Foo>>>(
-                x => x.Wrapping(A.Fake<Foo>()),
+                x => x.Wrapping(A.Fake<Foo>()).Implements(typeof(Foo)),
                 x => x.Implements(typeof(Foo)),
                 x => x.WithArgumentsForConstructor(() => new Foo()),
                 x => x.WithArgumentsForConstructor(new object[] { A.Fake<IServiceProvider>() }),
@@ -71,33 +71,6 @@ namespace FakeItEasy.Tests.Creation
             // Act, Assert
             Assert.Throws<ArgumentException>(() =>
                 this.creator.CreateFake<Foo>(x => x.WithArgumentsForConstructor(() => CreateFoo())));
-        }
-
-        [Test]
-        public void CreateFake_should_pass_wrapped_instance_to_manager()
-        {
-            // Arrange
-            var wrapped = A.Fake<IFoo>();
-
-            // Act
-            this.creator.CreateFake<IFoo>(x => x.Wrapping(wrapped));
-
-            // Assert
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<FakeOptions>.That.Wraps(wrapped))).MustHaveHappened();
-        }
-
-        [Test]
-        public void CreateFake_should_pass_recorder_to_manager()
-        {
-            // Arrange
-            var wrapped = A.Fake<IFoo>();
-            var recorder = A.Fake<ISelfInitializingFakeRecorder>();
-
-            // Act
-            this.creator.CreateFake<IFoo>(x => x.Wrapping(wrapped).RecordedBy(recorder));
-
-            // Assert
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<FakeOptions>.That.HasRecorder(recorder))).MustHaveHappened();
         }
 
         [Test]

--- a/Source/FakeItEasy.Tests/Creation/FakeOptionsConstraints.cs
+++ b/Source/FakeItEasy.Tests/Creation/FakeOptionsConstraints.cs
@@ -3,23 +3,12 @@ namespace FakeItEasy.Tests.Creation
     using System.Collections.Generic;
     using System.Linq;
     using FakeItEasy.Creation;
-    using FakeItEasy.SelfInitializedFakes;
 
     public static class FakeOptionsConstraints
     {
-        internal static FakeOptions HasRecorder(this IArgumentConstraintManager<FakeOptions> scope, ISelfInitializingFakeRecorder recorder)
-        {
-            return scope.Matches(x => recorder.Equals(x.Wrapper.Recorder), "Specified recorder");
-        }
-
         internal static FakeOptions HasArgumentsForConstructor(this IArgumentConstraintManager<FakeOptions> scope, IEnumerable<object> argumentsForConstructor)
         {
             return scope.Matches(x => argumentsForConstructor.SequenceEqual(x.ArgumentsForConstructor), "Constructor arguments ({0})".FormatInvariant(string.Join(", ", argumentsForConstructor.Select(x => x.ToString()).ToArray())));
-        }
-
-        internal static FakeOptions Wraps(this IArgumentConstraintManager<FakeOptions> scope, object wrappedInstance)
-        {
-            return scope.Matches(x => object.ReferenceEquals(x.Wrapper.WrappedObject, wrappedInstance), "Wraps {0}".FormatInvariant(wrappedInstance));
         }
     }
 }

--- a/Source/FakeItEasy.Tests/CustomArgumentConstraints.cs
+++ b/Source/FakeItEasy.Tests/CustomArgumentConstraints.cs
@@ -43,7 +43,8 @@ namespace FakeItEasy.Tests
             return scope.NullCheckedMatches(
                 x => !x.AdditionalInterfacesToImplement.Any()
                      && x.ArgumentsForConstructor == null
-                     && x.Wrapper == null,
+                     && !x.FakeConfigurationActions.Any()
+                     && !x.AdditionalAttributes.Any(),
                 x => x.Write("empty fake options"));
         }
 

--- a/Source/FakeItEasy/Core/FakeWrapperConfigurator.cs
+++ b/Source/FakeItEasy/Core/FakeWrapperConfigurator.cs
@@ -1,20 +1,70 @@
 namespace FakeItEasy.Core
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+    using System.Reflection.Emit;
+    using Creation;
     using FakeItEasy.SelfInitializedFakes;
 
     /// <summary>
     /// Handles configuring of fake objects to delegate all their calls to a wrapped instance.
     /// </summary>
-    internal class FakeWrapperConfigurator
+    /// <typeparam name="T">The type of fake object generated.</typeparam>
+    internal class FakeWrapperConfigurator<T> : IFakeOptionsBuilderForWrappers<T>
     {
-        public FakeWrapperConfigurator(object wrappedObject)
+        private readonly IFakeOptionsBuilder<T> fakeOptionsBuilder;
+
+        public FakeWrapperConfigurator(IFakeOptionsBuilder<T> fakeOptionsBuilder, object wrappedObject)
         {
+            this.fakeOptionsBuilder = fakeOptionsBuilder;
             this.WrappedObject = wrappedObject;
         }
 
-        public object WrappedObject { get; private set; }
+        public ISelfInitializingFakeRecorder Recorder { private get; set; }
 
-        public ISelfInitializingFakeRecorder Recorder { get; set; }
+        private object WrappedObject { get; set; }
+
+        public IFakeOptionsBuilder<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
+        {
+            return this.fakeOptionsBuilder.WithArgumentsForConstructor(argumentsForConstructor);
+        }
+
+        public IFakeOptionsBuilder<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
+        {
+            return this.fakeOptionsBuilder.WithArgumentsForConstructor(constructorCall);
+        }
+
+        public IFakeOptionsBuilderForWrappers<T> Wrapping(T wrappedInstance)
+        {
+            return this.fakeOptionsBuilder.Wrapping(wrappedInstance);
+        }
+
+        public IFakeOptionsBuilder<T> WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders)
+        {
+            return this.fakeOptionsBuilder.WithAdditionalAttributes(customAttributeBuilders);
+        }
+
+        public IFakeOptionsBuilder<T> Implements(Type interfaceType)
+        {
+            return this.fakeOptionsBuilder.Implements(interfaceType);
+        }
+
+        public IFakeOptionsBuilder<T> Implements<TInterface>()
+        {
+            return this.fakeOptionsBuilder.Implements<TInterface>();
+        }
+
+        public IFakeOptionsBuilder<T> ConfigureFake(Action<T> action)
+        {
+            return this.fakeOptionsBuilder.ConfigureFake(action);
+        }
+
+        public IFakeOptionsBuilder<T> RecordedBy(ISelfInitializingFakeRecorder recorder)
+        {
+            this.Recorder = recorder;
+            return this.fakeOptionsBuilder;
+        }
 
         /// <summary>
         /// Configures the specified faked object to wrap the specified instance.

--- a/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
@@ -6,7 +6,6 @@ namespace FakeItEasy.Creation
     using System.Linq.Expressions;
     using System.Reflection.Emit;
     using FakeItEasy.Core;
-    using FakeItEasy.SelfInitializedFakes;
 
     /// <summary>
     /// Default implementation of the IFakeCreator-interface.
@@ -82,7 +81,7 @@ namespace FakeItEasy.Creation
         }
 
         private class FakeOptionsBuilder<T>
-            : IFakeOptionsBuilderForWrappers<T>
+            : IFakeOptionsBuilder<T>
         {
             public FakeOptionsBuilder()
             {
@@ -118,8 +117,9 @@ namespace FakeItEasy.Creation
 
             public IFakeOptionsBuilderForWrappers<T> Wrapping(T wrappedInstance)
             {
-                this.Options.Wrapper = new FakeWrapperConfigurator(wrappedInstance);
-                return this;
+                var wrapper = new FakeWrapperConfigurator<T>(this, wrappedInstance);
+                this.ConfigureFake(fake => wrapper.ConfigureFakeToWrap(fake));
+                return wrapper;
             }
 
             public IFakeOptionsBuilder<T> Implements(Type interfaceType)
@@ -131,12 +131,6 @@ namespace FakeItEasy.Creation
             public IFakeOptionsBuilder<T> Implements<TInterface>()
             {
                 return this.Implements(typeof(TInterface));
-            }
-
-            public IFakeOptionsBuilder<T> RecordedBy(ISelfInitializingFakeRecorder recorder)
-            {
-                this.Options.Wrapper.Recorder = recorder;
-                return this;
             }
 
             public IFakeOptionsBuilder<T> ConfigureFake(Action<T> action)

--- a/Source/FakeItEasy/Creation/FakeOptions.cs
+++ b/Source/FakeItEasy/Creation/FakeOptions.cs
@@ -3,28 +3,12 @@ namespace FakeItEasy.Creation
     using System;
     using System.Collections.Generic;
     using System.Reflection.Emit;
-    using FakeItEasy.Core;
 
     internal class FakeOptions
     {
         private readonly List<Type> additionalInterfacesToImplement = new List<Type>();
         private readonly List<Action<object>> fakeConfigurationActions = new List<Action<object>>();
         private readonly List<CustomAttributeBuilder> additionalAttributes = new List<CustomAttributeBuilder>();
-        private FakeWrapperConfigurator wrapper;
-
-        public FakeWrapperConfigurator Wrapper
-        {
-            get
-            {
-                return this.wrapper;
-            }
-
-            set
-            {
-                this.wrapper = value;
-                this.AddFakeConfigurationAction(fake => this.wrapper.ConfigureFakeToWrap(fake));
-            }
-        }
 
         public IEnumerable<object> ArgumentsForConstructor { get; set; }
 


### PR DESCRIPTION
I think an improvement over the arrangement introduced in #487.
@adamralph had [expressed doubts](https://github.com/FakeItEasy/FakeItEasy/pull/487#discussion_r32370948) about the mutable `FakeOptionsBuilder<T>.Recorder` field.
At the time, I couldn't think of a better alternative.
While preparing for #520, it seemed we'd be better off if `Wrapper` weren't on `FakeOptions`.
The change makes `FakeWrapperConfigurator` a stronger participant in the fluent fake configuration API.

I tried to preserve existing unit tests, but where it was super awkward, and where the conditions being tested were covered by all the new specs I'd added recently, I just dropped the tests.