### PR TITLE
For discussion: Rename fake options builder

### DIFF
--- a/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
+++ b/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
@@ -438,11 +438,11 @@
     <Compile Include="..\FakeItEasy\Creation\IFakeObjectCreator.cs">
       <Link>Creation\IFakeObjectCreator.cs</Link>
     </Compile>
-    <Compile Include="..\FakeItEasy\Creation\IFakeOptionsBuilder.cs">
-      <Link>Creation\IFakeOptionsBuilder.cs</Link>
+    <Compile Include="..\FakeItEasy\Creation\IFakeOptions.cs">
+      <Link>Creation\IFakeOptions.cs</Link>
     </Compile>
-    <Compile Include="..\FakeItEasy\Creation\IFakeOptionsBuilderForWrappers.cs">
-      <Link>Creation\IFakeOptionsBuilderForWrappers.cs</Link>
+    <Compile Include="..\FakeItEasy\Creation\IFakeOptionsForWrappers.cs">
+      <Link>Creation\IFakeOptionsForWrappers.cs</Link>
     </Compile>
     <Compile Include="..\FakeItEasy\Creation\IProxyGenerator.cs">
       <Link>Creation\IProxyGenerator.cs</Link>

--- a/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
+++ b/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
@@ -423,8 +423,8 @@
     <Compile Include="..\FakeItEasy\Creation\FakeObjectCreator.cs">
       <Link>Creation\FakeObjectCreator.cs</Link>
     </Compile>
-    <Compile Include="..\FakeItEasy\Creation\FakeOptions.cs">
-      <Link>Creation\FakeOptions.cs</Link>
+    <Compile Include="..\FakeItEasy\Creation\ProxyOptions.cs">
+      <Link>Creation\ProxyOptions.cs</Link>
     </Compile>
     <Compile Include="..\FakeItEasy\Creation\IDummyValueCreationSession.cs">
       <Link>Creation\IDummyValueCreationSession.cs</Link>

--- a/Source/FakeItEasy.Tests/ATests.cs
+++ b/Source/FakeItEasy.Tests/ATests.cs
@@ -13,11 +13,11 @@
         private IDisposable scope;
 
         [Test]
-        public void Fake_without_arguments_should_call_fake_creator_with_empty_action()
+        public void Fake_without_arguments_should_call_fake_creator_with_empty_options_builder()
         {
             // Arrange
             var fake = A.Fake<IFoo>();
-            A.CallTo(() => this.fakeCreator.CreateFake(A<Action<IFakeOptionsBuilder<IFoo>>>._)).Returns(fake);
+            A.CallTo(() => this.fakeCreator.CreateFake(A<Action<IFakeOptions<IFoo>>>._)).Returns(fake);
 
             // Act
             var result = A.Fake<IFoo>();
@@ -32,11 +32,11 @@
             // Arrange
             var fake = A.Fake<IFoo>();
 
-            Action<IFakeOptionsBuilder<IFoo>> options = x => { };
-            A.CallTo(() => this.fakeCreator.CreateFake(options)).Returns(fake);
+            Action<IFakeOptions<IFoo>> optionsBuilder = x => { };
+            A.CallTo(() => this.fakeCreator.CreateFake(optionsBuilder)).Returns(fake);
 
             // Act
-            var result = A.Fake(options);
+            var result = A.Fake(optionsBuilder);
 
             // Assert
             result.Should().BeSameAs(fake);

--- a/Source/FakeItEasy.Tests/Core/DefaultFixtureInitializerTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DefaultFixtureInitializerTests.cs
@@ -156,7 +156,7 @@ namespace FakeItEasy.Tests.Core
         {
             Fake.InitializeFixture(this);
 
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<ProxyOptions>._)).Returns(this.fakeReturnedFromFakeAndDummyManager);
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<IProxyOptions>._)).Returns(this.fakeReturnedFromFakeAndDummyManager);
 
             this.fixture = new FixtureType();
         }

--- a/Source/FakeItEasy.Tests/Core/DefaultFixtureInitializerTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DefaultFixtureInitializerTests.cs
@@ -156,7 +156,7 @@ namespace FakeItEasy.Tests.Core
         {
             Fake.InitializeFixture(this);
 
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<FakeOptions>._)).Returns(this.fakeReturnedFromFakeAndDummyManager);
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<ProxyOptions>._)).Returns(this.fakeReturnedFromFakeAndDummyManager);
 
             this.fixture = new FixtureType();
         }

--- a/Source/FakeItEasy.Tests/Core/DefaultSutInitializerTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DefaultSutInitializerTests.cs
@@ -67,7 +67,7 @@
             this.sutInitializer.CreateSut(typeof(TypeWithFakeableDependencies), (x, y) => { });
 
             // Assert
-            A.CallTo(() => this.fakeManager.CreateFake(A<Type>._, A<ProxyOptions>.That.Not.IsEmpty())).MustNotHaveHappened();
+            A.CallTo(() => this.fakeManager.CreateFake(A<Type>._, A<IProxyOptions>.That.Not.IsEmpty())).MustNotHaveHappened();
         }
 
         [Test]
@@ -89,7 +89,7 @@
 
         private void StubFakeManagerWithFake<T>()
         {
-            A.CallTo(() => this.fakeManager.CreateFake(typeof(T), A<ProxyOptions>._)).ReturnsLazily(() => A.Fake<T>());
+            A.CallTo(() => this.fakeManager.CreateFake(typeof(T), A<IProxyOptions>._)).ReturnsLazily(() => A.Fake<T>());
         }
 
         public class TypeWithFakeableDependencies

--- a/Source/FakeItEasy.Tests/Core/DefaultSutInitializerTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DefaultSutInitializerTests.cs
@@ -67,7 +67,7 @@
             this.sutInitializer.CreateSut(typeof(TypeWithFakeableDependencies), (x, y) => { });
 
             // Assert
-            A.CallTo(() => this.fakeManager.CreateFake(A<Type>._, A<FakeOptions>.That.Not.IsEmpty())).MustNotHaveHappened();
+            A.CallTo(() => this.fakeManager.CreateFake(A<Type>._, A<ProxyOptions>.That.Not.IsEmpty())).MustNotHaveHappened();
         }
 
         [Test]
@@ -89,7 +89,7 @@
 
         private void StubFakeManagerWithFake<T>()
         {
-            A.CallTo(() => this.fakeManager.CreateFake(typeof(T), A<FakeOptions>._)).ReturnsLazily(() => A.Fake<T>());
+            A.CallTo(() => this.fakeManager.CreateFake(typeof(T), A<ProxyOptions>._)).ReturnsLazily(() => A.Fake<T>());
         }
 
         public class TypeWithFakeableDependencies

--- a/Source/FakeItEasy.Tests/Core/FakeManagerProviderTests.cs
+++ b/Source/FakeItEasy.Tests/Core/FakeManagerProviderTests.cs
@@ -24,7 +24,7 @@ namespace FakeItEasy.Tests.Core
         private Type typeOfFake = null;
 
         [Fake]
-        private FakeOptions fakeOptions = null;
+        private ProxyOptions proxyOptions = null;
 
         [UnderTest]
         private FakeManagerProvider fakeManagerProvider = null;
@@ -84,8 +84,8 @@ namespace FakeItEasy.Tests.Core
             // Arrange
             var fakeConfigurationAction1 = A.Fake<Action<object>>();
             var fakeConfigurationAction2 = A.Fake<Action<object>>();
-            this.fakeOptions.AddProxyConfigurationAction(fakeConfigurationAction1);
-            this.fakeOptions.AddProxyConfigurationAction(fakeConfigurationAction2);
+            this.proxyOptions.AddProxyConfigurationAction(fakeConfigurationAction1);
+            this.proxyOptions.AddProxyConfigurationAction(fakeConfigurationAction2);
 
             // Act
             this.fakeManagerProvider.Fetch(this.proxy);

--- a/Source/FakeItEasy.Tests/Core/FakeManagerProviderTests.cs
+++ b/Source/FakeItEasy.Tests/Core/FakeManagerProviderTests.cs
@@ -24,7 +24,7 @@ namespace FakeItEasy.Tests.Core
         private Type typeOfFake = null;
 
         [Fake]
-        private ProxyOptions proxyOptions = null;
+        private IProxyOptions proxyOptions = null;
 
         [UnderTest]
         private FakeManagerProvider fakeManagerProvider = null;
@@ -84,8 +84,9 @@ namespace FakeItEasy.Tests.Core
             // Arrange
             var fakeConfigurationAction1 = A.Fake<Action<object>>();
             var fakeConfigurationAction2 = A.Fake<Action<object>>();
-            this.proxyOptions.AddProxyConfigurationAction(fakeConfigurationAction1);
-            this.proxyOptions.AddProxyConfigurationAction(fakeConfigurationAction2);
+
+            A.CallTo(() => this.proxyOptions.ProxyConfigurationActions)
+                .Returns(new[] { fakeConfigurationAction1, fakeConfigurationAction2 });
 
             // Act
             this.fakeManagerProvider.Fetch(this.proxy);

--- a/Source/FakeItEasy.Tests/Core/FakeManagerProviderTests.cs
+++ b/Source/FakeItEasy.Tests/Core/FakeManagerProviderTests.cs
@@ -84,8 +84,8 @@ namespace FakeItEasy.Tests.Core
             // Arrange
             var fakeConfigurationAction1 = A.Fake<Action<object>>();
             var fakeConfigurationAction2 = A.Fake<Action<object>>();
-            this.fakeOptions.AddFakeConfigurationAction(fakeConfigurationAction1);
-            this.fakeOptions.AddFakeConfigurationAction(fakeConfigurationAction2);
+            this.fakeOptions.AddProxyConfigurationAction(fakeConfigurationAction1);
+            this.fakeOptions.AddProxyConfigurationAction(fakeConfigurationAction2);
 
             // Act
             this.fakeManagerProvider.Fetch(this.proxy);

--- a/Source/FakeItEasy.Tests/Core/FakeWrapperConfiguratorTests.cs
+++ b/Source/FakeItEasy.Tests/Core/FakeWrapperConfiguratorTests.cs
@@ -19,7 +19,7 @@
             this.faked = A.Fake<IFoo>();
 
             IFoo wrapped = A.Fake<IFoo>();
-            this.wrapperConfigurator = new FakeWrapperConfigurator<IFoo>(A.Fake<IFakeOptionsBuilder<IFoo>>(), wrapped);
+            this.wrapperConfigurator = new FakeWrapperConfigurator<IFoo>(A.Fake<IFakeOptions<IFoo>>(), wrapped);
         }
 
         [Test]

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
@@ -41,7 +41,7 @@ namespace FakeItEasy.Tests.Creation
             this.creator.CreateFake<Foo>(x => x.WithArgumentsForConstructor(() => new Foo(serviceProvider)));
 
             // Assert
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<ProxyOptions>.That.HasArgumentsForConstructor(new object[] { serviceProvider }))).MustHaveHappened();
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<IProxyOptions>.That.HasArgumentsForConstructor(new object[] { serviceProvider }))).MustHaveHappened();
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace FakeItEasy.Tests.Creation
             // Assert
             A.CallTo(() => this.fakeAndDummyManager.CreateFake(
                     A<Type>._,
-                    A<ProxyOptions>.That.Matches(
+                    A<IProxyOptions>.That.Matches(
                         x =>
                             x.AdditionalInterfacesToImplement.Contains(typeof(IFormatProvider)) &&
                             x.AdditionalInterfacesToImplement.Contains(typeof(IFormattable)),
@@ -78,7 +78,7 @@ namespace FakeItEasy.Tests.Creation
         {
             // Arrange
             var instanceFromManager = A.Fake<IFoo>();
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<ProxyOptions>._)).Returns(instanceFromManager);
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<IProxyOptions>._)).Returns(instanceFromManager);
 
             // Act
             var result = this.creator.CreateFake<IFoo>(x => { });
@@ -96,7 +96,7 @@ namespace FakeItEasy.Tests.Creation
             this.creator.CreateFake<IFoo>(x => { });
 
             // Assert
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<ProxyOptions>._)).MustHaveHappened();
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<IProxyOptions>._)).MustHaveHappened();
         }
 
         [TestCaseSource("optionsBuilderCalls")]
@@ -146,7 +146,7 @@ namespace FakeItEasy.Tests.Creation
             this.creator.CreateFake<Foo>(x => x.WithArgumentsForConstructor(constructorArguments));
 
             // Assert
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<ProxyOptions>.That.HasArgumentsForConstructor(constructorArguments))).MustHaveHappened();
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<IProxyOptions>.That.HasArgumentsForConstructor(constructorArguments))).MustHaveHappened();
         }
 
         [Test]
@@ -181,9 +181,9 @@ namespace FakeItEasy.Tests.Creation
 
         private void ConfigureDefaultValuesForFakeAndDummyManager()
         {
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<ProxyOptions>._))
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<IProxyOptions>._))
                 .Returns(A.Fake<IFoo>());
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(Foo), A<ProxyOptions>._))
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(Foo), A<IProxyOptions>._))
                 .Returns(A.Fake<Foo>());
         }
     }

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
@@ -41,7 +41,7 @@ namespace FakeItEasy.Tests.Creation
             this.creator.CreateFake<Foo>(x => x.WithArgumentsForConstructor(() => new Foo(serviceProvider)));
 
             // Assert
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<FakeOptions>.That.HasArgumentsForConstructor(new object[] { serviceProvider }))).MustHaveHappened();
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<ProxyOptions>.That.HasArgumentsForConstructor(new object[] { serviceProvider }))).MustHaveHappened();
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace FakeItEasy.Tests.Creation
             // Assert
             A.CallTo(() => this.fakeAndDummyManager.CreateFake(
                     A<Type>._,
-                    A<FakeOptions>.That.Matches(
+                    A<ProxyOptions>.That.Matches(
                         x =>
                             x.AdditionalInterfacesToImplement.Contains(typeof(IFormatProvider)) &&
                             x.AdditionalInterfacesToImplement.Contains(typeof(IFormattable)),
@@ -78,7 +78,7 @@ namespace FakeItEasy.Tests.Creation
         {
             // Arrange
             var instanceFromManager = A.Fake<IFoo>();
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<FakeOptions>._)).Returns(instanceFromManager);
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<ProxyOptions>._)).Returns(instanceFromManager);
 
             // Act
             var result = this.creator.CreateFake<IFoo>(x => { });
@@ -96,7 +96,7 @@ namespace FakeItEasy.Tests.Creation
             this.creator.CreateFake<IFoo>(x => { });
 
             // Assert
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<FakeOptions>._)).MustHaveHappened();
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<ProxyOptions>._)).MustHaveHappened();
         }
 
         [TestCaseSource("optionBuilderCalls")]
@@ -146,7 +146,7 @@ namespace FakeItEasy.Tests.Creation
             this.creator.CreateFake<Foo>(x => x.WithArgumentsForConstructor(constructorArguments));
 
             // Assert
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<FakeOptions>.That.HasArgumentsForConstructor(constructorArguments))).MustHaveHappened();
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(A<Type>._, A<ProxyOptions>.That.HasArgumentsForConstructor(constructorArguments))).MustHaveHappened();
         }
 
         [Test]
@@ -181,9 +181,9 @@ namespace FakeItEasy.Tests.Creation
 
         private void ConfigureDefaultValuesForFakeAndDummyManager()
         {
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<FakeOptions>._))
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<ProxyOptions>._))
                 .Returns(A.Fake<IFoo>());
-            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(Foo), A<FakeOptions>._))
+            A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(Foo), A<ProxyOptions>._))
                 .Returns(A.Fake<Foo>());
         }
     }

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
@@ -15,7 +15,7 @@ namespace FakeItEasy.Tests.Creation
         private DefaultFakeCreatorFacade creator;
 
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Used reflectively.")]
-        private object[] optionBuilderCalls = TestCases.Create<Func<IFakeOptionsBuilder<Foo>, IFakeOptionsBuilder<Foo>>>(
+        private object[] optionsBuilderCalls = TestCases.Create<Func<IFakeOptions<Foo>, IFakeOptions<Foo>>>(
                 x => x.Wrapping(A.Fake<Foo>()).Implements(typeof(Foo)),
                 x => x.Implements(typeof(Foo)),
                 x => x.WithArgumentsForConstructor(() => new Foo()),
@@ -99,19 +99,19 @@ namespace FakeItEasy.Tests.Creation
             A.CallTo(() => this.fakeAndDummyManager.CreateFake(typeof(IFoo), A<ProxyOptions>._)).MustHaveHappened();
         }
 
-        [TestCaseSource("optionBuilderCalls")]
-        public void CreateFake_should_pass_options_builder_that_returns_itself_for_any_call(Func<IFakeOptionsBuilder<Foo>, IFakeOptionsBuilder<Foo>> call)
+        [TestCaseSource("optionsBuilderCalls")]
+        public void CreateFake_should_pass_options_builder_that_returns_itself_for_any_call(Func<IFakeOptions<Foo>, IFakeOptions<Foo>> call)
         {
             Guard.AgainstNull(call, "call");
 
             // Arrange
-            IFakeOptionsBuilder<Foo> builderPassedToAction = null;
+            IFakeOptions<Foo> optionsPassedToAction = null;
 
             // Act
-            this.creator.CreateFake<Foo>(x => { builderPassedToAction = x; });
+            this.creator.CreateFake<Foo>(x => { optionsPassedToAction = x; });
 
             // Assert
-            Assert.That(call.Invoke(builderPassedToAction), Is.SameAs(builderPassedToAction));
+            Assert.That(call.Invoke(optionsPassedToAction), Is.SameAs(optionsPassedToAction));
         }
 
         [Test]

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
@@ -32,7 +32,7 @@ namespace FakeItEasy.Tests.Creation
         public void Should_pass_fake_options_to_the_proxy_generator_and_return_the_fake_when_successful()
         {
             // Arrange
-            var options = new FakeOptions();
+            var options = new ProxyOptions();
 
             var proxy = A.Fake<IFoo>();
 
@@ -58,11 +58,11 @@ namespace FakeItEasy.Tests.Creation
         public void Should_use_new_fake_call_processor_for_the_proxy_generator()
         {
             // Arrange
-            var options = new FakeOptions();
+            var options = new ProxyOptions();
 
             var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
 
-            A.CallTo(() => this.fakeCallProcessorProviderFactory(A<Type>._, A<FakeOptions>._)).Returns(fakeCallProcessorProvider);
+            A.CallTo(() => this.fakeCallProcessorProviderFactory(A<Type>._, A<ProxyOptions>._)).Returns(fakeCallProcessorProvider);
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(IFoo), options, A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
@@ -84,7 +84,7 @@ namespace FakeItEasy.Tests.Creation
 
             this.StubProxyGeneratorToFail();
 
-            var options = new FakeOptions();
+            var options = new ProxyOptions();
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), options, session, throwOnFailure: false);
@@ -100,7 +100,7 @@ namespace FakeItEasy.Tests.Creation
             // Arrange
             this.StubProxyGeneratorToFail("fail reason");
 
-            var options = new FakeOptions
+            var options = new ProxyOptions
             {
                 ArgumentsForConstructor = new object[] { "argument for constructor " }
             };
@@ -120,7 +120,7 @@ namespace FakeItEasy.Tests.Creation
             this.StubProxyGeneratorToFail();
 
             // Act
-            var createdFake = this.fakeObjectCreator.CreateFake(typeof(IFoo), new FakeOptions(), A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
+            var createdFake = this.fakeObjectCreator.CreateFake(typeof(IFoo), new ProxyOptions(), A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
 
             // Assert
             createdFake.Should().BeNull();
@@ -133,7 +133,7 @@ namespace FakeItEasy.Tests.Creation
             this.StubProxyGeneratorToFail();
 
             // Act
-            this.fakeObjectCreator.CreateFake(typeof(IFoo), new FakeOptions(), A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
+            this.fakeObjectCreator.CreateFake(typeof(IFoo), new ProxyOptions(), A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
 
             // Assert
             A.CallTo(this.thrower).MustNotHaveHappened();
@@ -151,7 +151,7 @@ namespace FakeItEasy.Tests.Creation
 
                 this.StubProxyGeneratorToFail();
 
-                var options = new FakeOptions();
+                var options = new ProxyOptions();
 
                 // Act
                 this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), options, session, throwOnFailure: false);
@@ -178,7 +178,7 @@ namespace FakeItEasy.Tests.Creation
 
             this.StubProxyGeneratorToFail();
 
-            var options = new FakeOptions
+            var options = new ProxyOptions
             {
                 ArgumentsForConstructor = new object[] { 2, 2 }
             };
@@ -198,7 +198,7 @@ namespace FakeItEasy.Tests.Creation
             var session = A.Fake<IDummyValueCreationSession>();
             StubSessionWithDummyValue(session, 1);
 
-            var options = new FakeOptions();
+            var options = new ProxyOptions();
 
             var proxy = A.Fake<IFoo>();
 
@@ -224,7 +224,7 @@ namespace FakeItEasy.Tests.Creation
             StubSessionToFailForType<string>(session);
 
             // Act
-            this.fakeObjectCreator.CreateFake(typeof(TypeWithConstructorThatTakesDifferentTypes), new FakeOptions(), session, throwOnFailure: false);
+            this.fakeObjectCreator.CreateFake(typeof(TypeWithConstructorThatTakesDifferentTypes), new ProxyOptions(), session, throwOnFailure: false);
 
             // Assert
             A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>.That.Not.IsNull(), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
@@ -239,7 +239,7 @@ namespace FakeItEasy.Tests.Creation
             StubSessionWithDummyValue(session, 1);
             this.StubProxyGeneratorToFail();
 
-            var options = new FakeOptions();
+            var options = new ProxyOptions();
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(TypeWithProtectedConstructor), options, session, throwOnFailure: false);
@@ -260,7 +260,7 @@ namespace FakeItEasy.Tests.Creation
             this.StubProxyGeneratorToFail("failed");
 
             // Act
-            this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), new FakeOptions(), session, throwOnFailure: true);
+            this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), new ProxyOptions(), session, throwOnFailure: true);
 
             // Assert
             var expectedConstructors = new[] 

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
@@ -32,7 +32,7 @@ namespace FakeItEasy.Tests.Creation
         public void Should_pass_fake_options_to_the_proxy_generator_and_return_the_fake_when_successful()
         {
             // Arrange
-            var options = new ProxyOptions();
+            var options = ProxyOptions.Empty;
 
             var proxy = A.Fake<IFoo>();
 
@@ -58,7 +58,7 @@ namespace FakeItEasy.Tests.Creation
         public void Should_use_new_fake_call_processor_for_the_proxy_generator()
         {
             // Arrange
-            var options = new ProxyOptions();
+            var options = ProxyOptions.Empty;
 
             var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
 
@@ -84,7 +84,7 @@ namespace FakeItEasy.Tests.Creation
 
             this.StubProxyGeneratorToFail();
 
-            var options = new ProxyOptions();
+            var options = ProxyOptions.Empty;
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), options, session, throwOnFailure: false);
@@ -100,10 +100,8 @@ namespace FakeItEasy.Tests.Creation
             // Arrange
             this.StubProxyGeneratorToFail("fail reason");
 
-            var options = new ProxyOptions
-            {
-                ArgumentsForConstructor = new object[] { "argument for constructor " }
-            };
+            var options = A.Fake<IProxyOptions>();
+            A.CallTo(() => options.ArgumentsForConstructor).Returns(new object[] { "argument for constructor " });
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(IFoo), options, A.Dummy<IDummyValueCreationSession>(), throwOnFailure: true);
@@ -120,7 +118,7 @@ namespace FakeItEasy.Tests.Creation
             this.StubProxyGeneratorToFail();
 
             // Act
-            var createdFake = this.fakeObjectCreator.CreateFake(typeof(IFoo), new ProxyOptions(), A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
+            var createdFake = this.fakeObjectCreator.CreateFake(typeof(IFoo), ProxyOptions.Empty, A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
 
             // Assert
             createdFake.Should().BeNull();
@@ -133,7 +131,7 @@ namespace FakeItEasy.Tests.Creation
             this.StubProxyGeneratorToFail();
 
             // Act
-            this.fakeObjectCreator.CreateFake(typeof(IFoo), new ProxyOptions(), A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
+            this.fakeObjectCreator.CreateFake(typeof(IFoo), ProxyOptions.Empty, A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);
 
             // Assert
             A.CallTo(this.thrower).MustNotHaveHappened();
@@ -151,7 +149,7 @@ namespace FakeItEasy.Tests.Creation
 
                 this.StubProxyGeneratorToFail();
 
-                var options = new ProxyOptions();
+                var options = ProxyOptions.Empty;
 
                 // Act
                 this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), options, session, throwOnFailure: false);
@@ -178,10 +176,8 @@ namespace FakeItEasy.Tests.Creation
 
             this.StubProxyGeneratorToFail();
 
-            var options = new ProxyOptions
-            {
-                ArgumentsForConstructor = new object[] { 2, 2 }
-            };
+            var options = A.Fake<IProxyOptions>();
+            A.CallTo(() => options.ArgumentsForConstructor).Returns(new object[] { 2, 2 });
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), options, session, throwOnFailure: false);
@@ -198,7 +194,7 @@ namespace FakeItEasy.Tests.Creation
             var session = A.Fake<IDummyValueCreationSession>();
             StubSessionWithDummyValue(session, 1);
 
-            var options = new ProxyOptions();
+            var options = ProxyOptions.Empty;
 
             var proxy = A.Fake<IFoo>();
 
@@ -224,7 +220,7 @@ namespace FakeItEasy.Tests.Creation
             StubSessionToFailForType<string>(session);
 
             // Act
-            this.fakeObjectCreator.CreateFake(typeof(TypeWithConstructorThatTakesDifferentTypes), new ProxyOptions(), session, throwOnFailure: false);
+            this.fakeObjectCreator.CreateFake(typeof(TypeWithConstructorThatTakesDifferentTypes), ProxyOptions.Empty, session, throwOnFailure: false);
 
             // Assert
             A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>.That.Not.IsNull(), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
@@ -239,7 +235,7 @@ namespace FakeItEasy.Tests.Creation
             StubSessionWithDummyValue(session, 1);
             this.StubProxyGeneratorToFail();
 
-            var options = new ProxyOptions();
+            var options = ProxyOptions.Empty;
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(TypeWithProtectedConstructor), options, session, throwOnFailure: false);
@@ -260,7 +256,7 @@ namespace FakeItEasy.Tests.Creation
             this.StubProxyGeneratorToFail("failed");
 
             // Act
-            this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), new ProxyOptions(), session, throwOnFailure: true);
+            this.fakeObjectCreator.CreateFake(typeof(TypeWithMultipleConstructors), ProxyOptions.Empty, session, throwOnFailure: true);
 
             // Assert
             var expectedConstructors = new[] 

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
@@ -62,7 +62,7 @@ namespace FakeItEasy.Tests.Creation
 
             var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
 
-            A.CallTo(() => this.fakeCallProcessorProviderFactory(A<Type>._, A<ProxyOptions>._)).Returns(fakeCallProcessorProvider);
+            A.CallTo(() => this.fakeCallProcessorProviderFactory(A<Type>._, A<IProxyOptions>._)).Returns(fakeCallProcessorProvider);
 
             // Act
             this.fakeObjectCreator.CreateFake(typeof(IFoo), options, A.Dummy<IDummyValueCreationSession>(), throwOnFailure: false);

--- a/Source/FakeItEasy.Tests/Creation/FakeOptionsConstraints.cs
+++ b/Source/FakeItEasy.Tests/Creation/FakeOptionsConstraints.cs
@@ -6,7 +6,7 @@ namespace FakeItEasy.Tests.Creation
 
     public static class FakeOptionsConstraints
     {
-        internal static FakeOptions HasArgumentsForConstructor(this IArgumentConstraintManager<FakeOptions> scope, IEnumerable<object> argumentsForConstructor)
+        internal static ProxyOptions HasArgumentsForConstructor(this IArgumentConstraintManager<ProxyOptions> scope, IEnumerable<object> argumentsForConstructor)
         {
             return scope.Matches(x => argumentsForConstructor.SequenceEqual(x.ArgumentsForConstructor), "Constructor arguments ({0})".FormatInvariant(string.Join(", ", argumentsForConstructor.Select(x => x.ToString()).ToArray())));
         }

--- a/Source/FakeItEasy.Tests/Creation/FakeOptionsConstraints.cs
+++ b/Source/FakeItEasy.Tests/Creation/FakeOptionsConstraints.cs
@@ -6,7 +6,7 @@ namespace FakeItEasy.Tests.Creation
 
     public static class FakeOptionsConstraints
     {
-        internal static ProxyOptions HasArgumentsForConstructor(this IArgumentConstraintManager<ProxyOptions> scope, IEnumerable<object> argumentsForConstructor)
+        internal static IProxyOptions HasArgumentsForConstructor(this IArgumentConstraintManager<IProxyOptions> scope, IEnumerable<object> argumentsForConstructor)
         {
             return scope.Matches(x => argumentsForConstructor.SequenceEqual(x.ArgumentsForConstructor), "Constructor arguments ({0})".FormatInvariant(string.Join(", ", argumentsForConstructor.Select(x => x.ToString()).ToArray())));
         }

--- a/Source/FakeItEasy.Tests/CustomArgumentConstraints.cs
+++ b/Source/FakeItEasy.Tests/CustomArgumentConstraints.cs
@@ -38,7 +38,7 @@ namespace FakeItEasy.Tests
                 string.Format(CultureInfo.InvariantCulture, "Expression that produces the value {0}", expectedValue));
         }
 
-        internal static FakeOptions IsEmpty(this IArgumentConstraintManager<FakeOptions> scope)
+        internal static ProxyOptions IsEmpty(this IArgumentConstraintManager<ProxyOptions> scope)
         {
             return scope.NullCheckedMatches(
                 x => !x.AdditionalInterfacesToImplement.Any()

--- a/Source/FakeItEasy.Tests/CustomArgumentConstraints.cs
+++ b/Source/FakeItEasy.Tests/CustomArgumentConstraints.cs
@@ -43,7 +43,7 @@ namespace FakeItEasy.Tests
             return scope.NullCheckedMatches(
                 x => !x.AdditionalInterfacesToImplement.Any()
                      && x.ArgumentsForConstructor == null
-                     && !x.FakeConfigurationActions.Any()
+                     && !x.ProxyConfigurationActions.Any()
                      && !x.AdditionalAttributes.Any(),
                 x => x.Write("empty fake options"));
         }

--- a/Source/FakeItEasy.Tests/CustomArgumentConstraints.cs
+++ b/Source/FakeItEasy.Tests/CustomArgumentConstraints.cs
@@ -38,7 +38,7 @@ namespace FakeItEasy.Tests
                 string.Format(CultureInfo.InvariantCulture, "Expression that produces the value {0}", expectedValue));
         }
 
-        internal static ProxyOptions IsEmpty(this IArgumentConstraintManager<ProxyOptions> scope)
+        internal static IProxyOptions IsEmpty(this IArgumentConstraintManager<IProxyOptions> scope)
         {
             return scope.NullCheckedMatches(
                 x => !x.AdditionalInterfacesToImplement.Any()

--- a/Source/FakeItEasy.Tests/Fake(T)Tests.cs
+++ b/Source/FakeItEasy.Tests/Fake(T)Tests.cs
@@ -22,7 +22,7 @@
 
             using (Fake.CreateScope())
             {
-                A.CallTo(() => this.fakeCreator.CreateFake<IFoo>(A<Action<IFakeOptionsBuilder<IFoo>>>._)).Returns(foo);
+                A.CallTo(() => this.fakeCreator.CreateFake<IFoo>(A<Action<IFakeOptions<IFoo>>>._)).Returns(foo);
 
                 var fake = new Fake<IFoo>();
 
@@ -31,28 +31,28 @@
         }
 
         [Test]
-        public void Constructor_that_takes_options_should_be_null_guarded()
+        public void Constructor_that_takes_options_builder_should_be_null_guarded()
         {
-            Action<IFakeOptionsBuilder<Foo>> options = x => { };
+            Action<IFakeOptions<Foo>> optionsBuilder = x => { };
 
             NullGuardedConstraint.Assert(() =>
-                new Fake<Foo>(options));
+                new Fake<Foo>(optionsBuilder));
         }
 
         [Test]
-        public void Constructor_that_takes_options_should_set_fake_returned_from_factory_to_FakedObject_property()
+        public void Constructor_that_takes_options_builder_should_set_fake_returned_from_factory_to_FakedObject_property()
         {
             var argumentsForConstructor = new object[] { A.Fake<IFoo>() };
             var fakeReturnedFromFactory = A.Fake<AbstractTypeWithNoDefaultConstructor>(x => x.WithArgumentsForConstructor(argumentsForConstructor));
 
-            Action<IFakeOptionsBuilder<AbstractTypeWithNoDefaultConstructor>> options = x => { };
+            Action<IFakeOptions<AbstractTypeWithNoDefaultConstructor>> optionsBuilder = x => { };
 
             using (Fake.CreateScope())
             {
-                A.CallTo(() => this.fakeCreator.CreateFake<AbstractTypeWithNoDefaultConstructor>(options))
+                A.CallTo(() => this.fakeCreator.CreateFake<AbstractTypeWithNoDefaultConstructor>(optionsBuilder))
                     .Returns(fakeReturnedFromFactory);
 
-                var fake = new Fake<AbstractTypeWithNoDefaultConstructor>(options);
+                var fake = new Fake<AbstractTypeWithNoDefaultConstructor>(optionsBuilder);
 
                 Assert.That(fake.FakedObject, Is.SameAs(fakeReturnedFromFactory));
             }

--- a/Source/FakeItEasy.Tests/FakeOptionsBuilderExtensionsTests.cs
+++ b/Source/FakeItEasy.Tests/FakeOptionsBuilderExtensionsTests.cs
@@ -28,14 +28,14 @@ namespace FakeItEasy.Tests
         public void Strict_should_return_configuration_object()
         {
             // Arrange
-            var options = A.Fake<IFakeOptionsBuilder<IFoo>>();
-            A.CallTo(() => options.ConfigureFake(A<Action<IFoo>>._)).Returns(options);
+            var optionsBuilder = A.Fake<IFakeOptions<IFoo>>();
+            A.CallTo(() => optionsBuilder.ConfigureFake(A<Action<IFoo>>._)).Returns(optionsBuilder);
 
             // Act
-            var result = options.Strict();
+            var result = optionsBuilder.Strict();
 
             // Assert
-            result.Should().BeSameAs(options);
+            result.Should().BeSameAs(optionsBuilder);
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace FakeItEasy.Tests
 
             // Assert
             NullGuardedConstraint.Assert(() =>
-                A.Dummy<IFakeOptionsBuilder<IFoo>>().Strict());
+                A.Dummy<IFakeOptions<IFoo>>().Strict());
         }
 
         [Test]
@@ -80,14 +80,14 @@ namespace FakeItEasy.Tests
         public void CallsBaseMethods_should_return_configuration_object()
         {
             // Arrange
-            var options = A.Fake<IFakeOptionsBuilder<IFoo>>();
-            A.CallTo(() => options.ConfigureFake(A<Action<IFoo>>._)).Returns(options);
+            var optionsBuilder = A.Fake<IFakeOptions<IFoo>>();
+            A.CallTo(() => optionsBuilder.ConfigureFake(A<Action<IFoo>>._)).Returns(optionsBuilder);
 
             // Act
-            var result = options.CallsBaseMethods();
+            var result = optionsBuilder.CallsBaseMethods();
 
             // Assert
-            result.Should().BeSameAs(options);
+            result.Should().BeSameAs(optionsBuilder);
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace FakeItEasy.Tests
 
             // Assert
             NullGuardedConstraint.Assert(() =>
-                A.Dummy<IFakeOptionsBuilder<IFoo>>().CallsBaseMethods());
+                A.Dummy<IFakeOptions<IFoo>>().CallsBaseMethods());
         }
 
         public class ConcreteClass

--- a/Source/FakeItEasy/A.cs
+++ b/Source/FakeItEasy/A.cs
@@ -39,13 +39,13 @@ namespace FakeItEasy
         /// Creates a fake object of the type T.
         /// </summary>
         /// <typeparam name="T">The type of fake object to create.</typeparam>
-        /// <param name="options">A lambda where options for the built fake object can be specified.</param>
+        /// <param name="optionsBuilder">A lambda where options for the built fake object can be specified.</param>
         /// <returns>A fake object.</returns>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design when using the Expression-, Action- and Func-types.")]
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Used to specifie the type of fake.")]
-        public static T Fake<T>(Action<IFakeOptionsBuilder<T>> options)
+        public static T Fake<T>(Action<IFakeOptions<T>> optionsBuilder)
         {
-            return FakeCreator.CreateFake(options);
+            return FakeCreator.CreateFake(optionsBuilder);
         }
 
         /// <summary>

--- a/Source/FakeItEasy/Core/DefaultFixtureInitializer.cs
+++ b/Source/FakeItEasy/Core/DefaultFixtureInitializer.cs
@@ -91,7 +91,7 @@
 
                 if (!fakesUsedToCreateSut.TryGetValue(setter.MemberType, out fake))
                 {
-                    fake = this.fakeAndDummyManager.CreateFake(setter.MemberType, new FakeOptions());
+                    fake = this.fakeAndDummyManager.CreateFake(setter.MemberType, new ProxyOptions());
                 }
 
                 setter.Setter(fake);

--- a/Source/FakeItEasy/Core/DefaultFixtureInitializer.cs
+++ b/Source/FakeItEasy/Core/DefaultFixtureInitializer.cs
@@ -91,7 +91,7 @@
 
                 if (!fakesUsedToCreateSut.TryGetValue(setter.MemberType, out fake))
                 {
-                    fake = this.fakeAndDummyManager.CreateFake(setter.MemberType, new ProxyOptions());
+                    fake = this.fakeAndDummyManager.CreateFake(setter.MemberType, ProxyOptions.Empty);
                 }
 
                 setter.Setter(fake);

--- a/Source/FakeItEasy/Core/DefaultSutInitializer.cs
+++ b/Source/FakeItEasy/Core/DefaultSutInitializer.cs
@@ -42,7 +42,7 @@
 
         private object CreateFake(Type typeOfFake, Action<Type, object> onFakeCreated)
         {
-            var result = this.fakeManager.CreateFake(typeOfFake, new ProxyOptions());
+            var result = this.fakeManager.CreateFake(typeOfFake, ProxyOptions.Empty);
             onFakeCreated.Invoke(typeOfFake, result);
             return result;
         }

--- a/Source/FakeItEasy/Core/DefaultSutInitializer.cs
+++ b/Source/FakeItEasy/Core/DefaultSutInitializer.cs
@@ -42,7 +42,7 @@
 
         private object CreateFake(Type typeOfFake, Action<Type, object> onFakeCreated)
         {
-            var result = this.fakeManager.CreateFake(typeOfFake, new FakeOptions());
+            var result = this.fakeManager.CreateFake(typeOfFake, new ProxyOptions());
             onFakeCreated.Invoke(typeOfFake, result);
             return result;
         }

--- a/Source/FakeItEasy/Core/FakeCallProcessorProvider.cs
+++ b/Source/FakeItEasy/Core/FakeCallProcessorProvider.cs
@@ -5,6 +5,6 @@ namespace FakeItEasy.Core
 
     internal static class FakeCallProcessorProvider
     {
-        public delegate IFakeCallProcessorProvider Factory(Type typeOfFake, ProxyOptions proxyOptions);
+        public delegate IFakeCallProcessorProvider Factory(Type typeOfFake, IProxyOptions proxyOptions);
     }
 }

--- a/Source/FakeItEasy/Core/FakeCallProcessorProvider.cs
+++ b/Source/FakeItEasy/Core/FakeCallProcessorProvider.cs
@@ -5,6 +5,6 @@ namespace FakeItEasy.Core
 
     internal static class FakeCallProcessorProvider
     {
-        public delegate IFakeCallProcessorProvider Factory(Type typeOfFake, FakeOptions fakeOptions);
+        public delegate IFakeCallProcessorProvider Factory(Type typeOfFake, ProxyOptions proxyOptions);
     }
 }

--- a/Source/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
+++ b/Source/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
@@ -56,7 +56,7 @@
 
             private static bool TryCreateFake(Type type, out object fake)
             {
-                return FakeAndDummyManager.TryCreateFake(type, new ProxyOptions(), out fake);
+                return FakeAndDummyManager.TryCreateFake(type, ProxyOptions.Empty, out fake);
             }
 
             private static object DefaultReturnValue(IInterceptedFakeObjectCall fakeObjectCall)

--- a/Source/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
+++ b/Source/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
@@ -56,7 +56,7 @@
 
             private static bool TryCreateFake(Type type, out object fake)
             {
-                return FakeAndDummyManager.TryCreateFake(type, new FakeOptions(), out fake);
+                return FakeAndDummyManager.TryCreateFake(type, new ProxyOptions(), out fake);
             }
 
             private static object DefaultReturnValue(IInterceptedFakeObjectCall fakeObjectCall)

--- a/Source/FakeItEasy/Core/FakeManagerProvider.cs
+++ b/Source/FakeItEasy/Core/FakeManagerProvider.cs
@@ -28,7 +28,7 @@ namespace FakeItEasy.Core
         private readonly Type typeOfFake;
 
         [NonSerialized]
-        private readonly FakeOptions fakeOptions;
+        private readonly ProxyOptions proxyOptions;
 
         // We want to lock accesses to initializedFakeManager to guarantee thread-safety (see IFakeCallProcessorProvider documentation):
         private readonly object initializedFakeManagerLock = new object();
@@ -40,19 +40,19 @@ namespace FakeItEasy.Core
                 IFakeManagerAccessor fakeManagerAccessor,
                 IFakeObjectConfigurator fakeObjectConfigurator, 
                 Type typeOfFake,
-                FakeOptions fakeOptions)
+                ProxyOptions proxyOptions)
         {
             Guard.AgainstNull(fakeManagerFactory, "fakeManagerFactory");
             Guard.AgainstNull(fakeManagerAccessor, "fakeManagerAccessor");
             Guard.AgainstNull(fakeObjectConfigurator, "fakeObjectConfigurator");
             Guard.AgainstNull(typeOfFake, "typeOfFake");
-            Guard.AgainstNull(fakeOptions, "fakeOptions");
+            Guard.AgainstNull(proxyOptions, "proxyOptions");
 
             this.fakeManagerFactory = fakeManagerFactory;
             this.fakeManagerAccessor = fakeManagerAccessor;
             this.fakeObjectConfigurator = fakeObjectConfigurator;
             this.typeOfFake = typeOfFake;
-            this.fakeOptions = fakeOptions;
+            this.proxyOptions = proxyOptions;
         }
 
         public IFakeCallProcessor Fetch(object proxy)
@@ -88,7 +88,7 @@ namespace FakeItEasy.Core
         {
             this.fakeObjectConfigurator.ConfigureFake(this.typeOfFake, proxy);
 
-            foreach (var proxyConfigurationAction in this.fakeOptions.ProxyConfigurationActions)
+            foreach (var proxyConfigurationAction in this.proxyOptions.ProxyConfigurationActions)
             {
                 proxyConfigurationAction(proxy);
             }

--- a/Source/FakeItEasy/Core/FakeManagerProvider.cs
+++ b/Source/FakeItEasy/Core/FakeManagerProvider.cs
@@ -28,7 +28,7 @@ namespace FakeItEasy.Core
         private readonly Type typeOfFake;
 
         [NonSerialized]
-        private readonly ProxyOptions proxyOptions;
+        private readonly IProxyOptions proxyOptions;
 
         // We want to lock accesses to initializedFakeManager to guarantee thread-safety (see IFakeCallProcessorProvider documentation):
         private readonly object initializedFakeManagerLock = new object();
@@ -40,7 +40,7 @@ namespace FakeItEasy.Core
                 IFakeManagerAccessor fakeManagerAccessor,
                 IFakeObjectConfigurator fakeObjectConfigurator, 
                 Type typeOfFake,
-                ProxyOptions proxyOptions)
+                IProxyOptions proxyOptions)
         {
             Guard.AgainstNull(fakeManagerFactory, "fakeManagerFactory");
             Guard.AgainstNull(fakeManagerAccessor, "fakeManagerAccessor");

--- a/Source/FakeItEasy/Core/FakeManagerProvider.cs
+++ b/Source/FakeItEasy/Core/FakeManagerProvider.cs
@@ -88,9 +88,9 @@ namespace FakeItEasy.Core
         {
             this.fakeObjectConfigurator.ConfigureFake(this.typeOfFake, proxy);
 
-            foreach (var fakeConfigurationAction in this.fakeOptions.FakeConfigurationActions)
+            foreach (var proxyConfigurationAction in this.fakeOptions.ProxyConfigurationActions)
             {
-                fakeConfigurationAction(proxy);
+                proxyConfigurationAction(proxy);
             }
         }
     }

--- a/Source/FakeItEasy/Core/FakeWrapperConfigurator.cs
+++ b/Source/FakeItEasy/Core/FakeWrapperConfigurator.cs
@@ -11,13 +11,13 @@ namespace FakeItEasy.Core
     /// Handles configuring of fake objects to delegate all their calls to a wrapped instance.
     /// </summary>
     /// <typeparam name="T">The type of fake object generated.</typeparam>
-    internal class FakeWrapperConfigurator<T> : IFakeOptionsBuilderForWrappers<T>
+    internal class FakeWrapperConfigurator<T> : IFakeOptionsForWrappers<T>
     {
-        private readonly IFakeOptionsBuilder<T> fakeOptionsBuilder;
+        private readonly IFakeOptions<T> fakeOptions;
 
-        public FakeWrapperConfigurator(IFakeOptionsBuilder<T> fakeOptionsBuilder, object wrappedObject)
+        public FakeWrapperConfigurator(IFakeOptions<T> fakeOptions, object wrappedObject)
         {
-            this.fakeOptionsBuilder = fakeOptionsBuilder;
+            this.fakeOptions = fakeOptions;
             this.WrappedObject = wrappedObject;
         }
 
@@ -25,45 +25,45 @@ namespace FakeItEasy.Core
 
         private object WrappedObject { get; set; }
 
-        public IFakeOptionsBuilder<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
+        public IFakeOptions<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
         {
-            return this.fakeOptionsBuilder.WithArgumentsForConstructor(argumentsForConstructor);
+            return this.fakeOptions.WithArgumentsForConstructor(argumentsForConstructor);
         }
 
-        public IFakeOptionsBuilder<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
+        public IFakeOptions<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
         {
-            return this.fakeOptionsBuilder.WithArgumentsForConstructor(constructorCall);
+            return this.fakeOptions.WithArgumentsForConstructor(constructorCall);
         }
 
-        public IFakeOptionsBuilderForWrappers<T> Wrapping(T wrappedInstance)
+        public IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance)
         {
-            return this.fakeOptionsBuilder.Wrapping(wrappedInstance);
+            return this.fakeOptions.Wrapping(wrappedInstance);
         }
 
-        public IFakeOptionsBuilder<T> WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders)
+        public IFakeOptions<T> WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders)
         {
-            return this.fakeOptionsBuilder.WithAdditionalAttributes(customAttributeBuilders);
+            return this.fakeOptions.WithAdditionalAttributes(customAttributeBuilders);
         }
 
-        public IFakeOptionsBuilder<T> Implements(Type interfaceType)
+        public IFakeOptions<T> Implements(Type interfaceType)
         {
-            return this.fakeOptionsBuilder.Implements(interfaceType);
+            return this.fakeOptions.Implements(interfaceType);
         }
 
-        public IFakeOptionsBuilder<T> Implements<TInterface>()
+        public IFakeOptions<T> Implements<TInterface>()
         {
-            return this.fakeOptionsBuilder.Implements<TInterface>();
+            return this.fakeOptions.Implements<TInterface>();
         }
 
-        public IFakeOptionsBuilder<T> ConfigureFake(Action<T> action)
+        public IFakeOptions<T> ConfigureFake(Action<T> action)
         {
-            return this.fakeOptionsBuilder.ConfigureFake(action);
+            return this.fakeOptions.ConfigureFake(action);
         }
 
-        public IFakeOptionsBuilder<T> RecordedBy(ISelfInitializingFakeRecorder recorder)
+        public IFakeOptions<T> RecordedBy(ISelfInitializingFakeRecorder recorder)
         {
             this.Recorder = recorder;
-            return this.fakeOptionsBuilder;
+            return this.fakeOptions;
         }
 
         /// <summary>

--- a/Source/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
@@ -29,7 +29,7 @@ namespace FakeItEasy.Creation
             return result;
         }
 
-        public object CreateFake(Type typeOfFake, ProxyOptions options)
+        public object CreateFake(Type typeOfFake, IProxyOptions options)
         {
             return this.fakeCreator.CreateFake(typeOfFake, options, this.session, throwOnFailure: true);
         }
@@ -39,7 +39,7 @@ namespace FakeItEasy.Creation
             return this.session.TryResolveDummyValue(typeOfDummy, out result);
         }
 
-        public bool TryCreateFake(Type typeOfFake, ProxyOptions options, out object result)
+        public bool TryCreateFake(Type typeOfFake, IProxyOptions options, out object result)
         {
             result = this.fakeCreator.CreateFake(typeOfFake, options, this.session, throwOnFailure: false);
             return result != null;

--- a/Source/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
@@ -29,7 +29,7 @@ namespace FakeItEasy.Creation
             return result;
         }
 
-        public object CreateFake(Type typeOfFake, FakeOptions options)
+        public object CreateFake(Type typeOfFake, ProxyOptions options)
         {
             return this.fakeCreator.CreateFake(typeOfFake, options, this.session, throwOnFailure: true);
         }
@@ -39,7 +39,7 @@ namespace FakeItEasy.Creation
             return this.session.TryResolveDummyValue(typeOfDummy, out result);
         }
 
-        public bool TryCreateFake(Type typeOfFake, FakeOptions options, out object result)
+        public bool TryCreateFake(Type typeOfFake, ProxyOptions options, out object result)
         {
             result = this.fakeCreator.CreateFake(typeOfFake, options, this.session, throwOnFailure: false);
             return result != null;

--- a/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
@@ -73,32 +73,37 @@ namespace FakeItEasy.Creation
             return (T)this.fakeAndDummyManager.CreateDummy(typeof(T));
         }
 
-        private static ProxyOptions BuildProxyOptions<T>(Action<IFakeOptions<T>> options)
+        private static IProxyOptions BuildProxyOptions<T>(Action<IFakeOptions<T>> options)
         {
             var builder = new FakeOptions<T>();
             options.Invoke(builder);
-            return builder.Options;
+            return builder.ProxyOptions;
         }
 
         private class FakeOptions<T>
             : IFakeOptions<T>
         {
+            private readonly ProxyOptions proxyOptions;
+
             public FakeOptions()
             {
-                this.Options = new ProxyOptions();
+                this.proxyOptions = new ProxyOptions();
             }
 
-            public ProxyOptions Options { get; private set; }
+            public IProxyOptions ProxyOptions
+            {
+                get { return this.proxyOptions; }
+            }
 
             public IFakeOptions<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
             {
-                this.Options.ArgumentsForConstructor = argumentsForConstructor;
+                this.proxyOptions.ArgumentsForConstructor = argumentsForConstructor;
                 return this;
             }
 
             public IFakeOptions<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
             {
-                this.Options.ArgumentsForConstructor = GetConstructorArgumentsFromExpression(constructorCall);
+                this.proxyOptions.ArgumentsForConstructor = GetConstructorArgumentsFromExpression(constructorCall);
                 return this;
             }
 
@@ -109,7 +114,7 @@ namespace FakeItEasy.Creation
 
                 foreach (var customAttributeBuilder in customAttributeBuilders)
                 {
-                    this.Options.AddAttribute(customAttributeBuilder);
+                    this.proxyOptions.AddAttribute(customAttributeBuilder);
                 }
 
                 return this;
@@ -124,7 +129,7 @@ namespace FakeItEasy.Creation
 
             public IFakeOptions<T> Implements(Type interfaceType)
             {
-                this.Options.AddInterfaceToImplement(interfaceType);
+                this.proxyOptions.AddInterfaceToImplement(interfaceType);
                 return this;
             }
 
@@ -135,7 +140,7 @@ namespace FakeItEasy.Creation
 
             public IFakeOptions<T> ConfigureFake(Action<T> action)
             {
-                this.Options.AddProxyConfigurationAction(x => action((T)x));
+                this.proxyOptions.AddProxyConfigurationAction(x => action((T)x));
                 return this;
             }
 

--- a/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
@@ -28,14 +28,14 @@ namespace FakeItEasy.Creation
         /// Creates a fake object of the specified type.
         /// </summary>
         /// <typeparam name="T">The type of fake to create.</typeparam>
-        /// <param name="options">Options for the created fake object.</param>
+        /// <param name="optionsBuilder">Options for the created fake object.</param>
         /// <returns>The created fake object.</returns>
         /// <exception cref="FakeCreationException">Was unable to generate the fake in the current configuration.</exception>
-        public T CreateFake<T>(Action<IFakeOptionsBuilder<T>> options)
+        public T CreateFake<T>(Action<IFakeOptions<T>> optionsBuilder)
         {
-            Guard.AgainstNull(options, "options");
+            Guard.AgainstNull(optionsBuilder, "optionsBuilder");
 
-            var proxyOptions = BuildProxyOptions(options);
+            var proxyOptions = BuildProxyOptions(optionsBuilder);
 
             return (T)this.fakeAndDummyManager.CreateFake(typeof(T), proxyOptions);
         }
@@ -73,36 +73,36 @@ namespace FakeItEasy.Creation
             return (T)this.fakeAndDummyManager.CreateDummy(typeof(T));
         }
 
-        private static ProxyOptions BuildProxyOptions<T>(Action<IFakeOptionsBuilder<T>> options)
+        private static ProxyOptions BuildProxyOptions<T>(Action<IFakeOptions<T>> options)
         {
-            var builder = new FakeOptionsBuilder<T>();
+            var builder = new FakeOptions<T>();
             options.Invoke(builder);
             return builder.Options;
         }
 
-        private class FakeOptionsBuilder<T>
-            : IFakeOptionsBuilder<T>
+        private class FakeOptions<T>
+            : IFakeOptions<T>
         {
-            public FakeOptionsBuilder()
+            public FakeOptions()
             {
                 this.Options = new ProxyOptions();
             }
 
             public ProxyOptions Options { get; private set; }
 
-            public IFakeOptionsBuilder<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
+            public IFakeOptions<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
             {
                 this.Options.ArgumentsForConstructor = argumentsForConstructor;
                 return this;
             }
 
-            public IFakeOptionsBuilder<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
+            public IFakeOptions<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
             {
                 this.Options.ArgumentsForConstructor = GetConstructorArgumentsFromExpression(constructorCall);
                 return this;
             }
 
-            public IFakeOptionsBuilder<T> WithAdditionalAttributes(
+            public IFakeOptions<T> WithAdditionalAttributes(
                 IEnumerable<CustomAttributeBuilder> customAttributeBuilders)
             {
                 Guard.AgainstNull(customAttributeBuilders, "customAttributeBuilders");
@@ -115,25 +115,25 @@ namespace FakeItEasy.Creation
                 return this;
             }
 
-            public IFakeOptionsBuilderForWrappers<T> Wrapping(T wrappedInstance)
+            public IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance)
             {
                 var wrapper = new FakeWrapperConfigurator<T>(this, wrappedInstance);
                 this.ConfigureFake(fake => wrapper.ConfigureFakeToWrap(fake));
                 return wrapper;
             }
 
-            public IFakeOptionsBuilder<T> Implements(Type interfaceType)
+            public IFakeOptions<T> Implements(Type interfaceType)
             {
                 this.Options.AddInterfaceToImplement(interfaceType);
                 return this;
             }
 
-            public IFakeOptionsBuilder<T> Implements<TInterface>()
+            public IFakeOptions<T> Implements<TInterface>()
             {
                 return this.Implements(typeof(TInterface));
             }
 
-            public IFakeOptionsBuilder<T> ConfigureFake(Action<T> action)
+            public IFakeOptions<T> ConfigureFake(Action<T> action)
             {
                 this.Options.AddProxyConfigurationAction(x => action((T)x));
                 return this;

--- a/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
@@ -35,9 +35,9 @@ namespace FakeItEasy.Creation
         {
             Guard.AgainstNull(options, "options");
 
-            var fakeOptions = BuildFakeOptions(options);
+            var proxyOptions = BuildProxyOptions(options);
 
-            return (T)this.fakeAndDummyManager.CreateFake(typeof(T), fakeOptions);
+            return (T)this.fakeAndDummyManager.CreateFake(typeof(T), proxyOptions);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace FakeItEasy.Creation
             return (T)this.fakeAndDummyManager.CreateDummy(typeof(T));
         }
 
-        private static FakeOptions BuildFakeOptions<T>(Action<IFakeOptionsBuilder<T>> options)
+        private static ProxyOptions BuildProxyOptions<T>(Action<IFakeOptionsBuilder<T>> options)
         {
             var builder = new FakeOptionsBuilder<T>();
             options.Invoke(builder);
@@ -85,10 +85,10 @@ namespace FakeItEasy.Creation
         {
             public FakeOptionsBuilder()
             {
-                this.Options = new FakeOptions();
+                this.Options = new ProxyOptions();
             }
 
-            public FakeOptions Options { get; private set; }
+            public ProxyOptions Options { get; private set; }
 
             public IFakeOptionsBuilder<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
             {

--- a/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
@@ -135,7 +135,7 @@ namespace FakeItEasy.Creation
 
             public IFakeOptionsBuilder<T> ConfigureFake(Action<T> action)
             {
-                this.Options.AddFakeConfigurationAction(x => action((T)x));
+                this.Options.AddProxyConfigurationAction(x => action((T)x));
                 return this;
             }
 

--- a/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
+++ b/Source/FakeItEasy/Creation/DefaultFakeCreatorFacade.cs
@@ -81,29 +81,43 @@ namespace FakeItEasy.Creation
         }
 
         private class FakeOptions<T>
-            : IFakeOptions<T>
+            : IFakeOptions<T>, IProxyOptions
         {
-            private readonly ProxyOptions proxyOptions;
+            private readonly List<Type> additionalInterfacesToImplement = new List<Type>();
+            private readonly List<Action<object>> proxyConfigurationActions = new List<Action<object>>();
+            private readonly List<CustomAttributeBuilder> additionalAttributes = new List<CustomAttributeBuilder>();
 
-            public FakeOptions()
+            public IEnumerable<object> ArgumentsForConstructor { get; private set; }
+
+            public IEnumerable<Type> AdditionalInterfacesToImplement
             {
-                this.proxyOptions = new ProxyOptions();
+                get { return this.additionalInterfacesToImplement; }
+            }
+
+            public IEnumerable<Action<object>> ProxyConfigurationActions
+            {
+                get { return this.proxyConfigurationActions; }
+            }
+
+            public IEnumerable<CustomAttributeBuilder> AdditionalAttributes
+            {
+                get { return this.additionalAttributes; }
             }
 
             public IProxyOptions ProxyOptions
             {
-                get { return this.proxyOptions; }
+                get { return this; }
             }
 
             public IFakeOptions<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
             {
-                this.proxyOptions.ArgumentsForConstructor = argumentsForConstructor;
+                this.ArgumentsForConstructor = argumentsForConstructor;
                 return this;
             }
 
             public IFakeOptions<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
             {
-                this.proxyOptions.ArgumentsForConstructor = GetConstructorArgumentsFromExpression(constructorCall);
+                this.ArgumentsForConstructor = GetConstructorArgumentsFromExpression(constructorCall);
                 return this;
             }
 
@@ -114,7 +128,7 @@ namespace FakeItEasy.Creation
 
                 foreach (var customAttributeBuilder in customAttributeBuilders)
                 {
-                    this.proxyOptions.AddAttribute(customAttributeBuilder);
+                    this.additionalAttributes.Add(customAttributeBuilder);
                 }
 
                 return this;
@@ -129,7 +143,7 @@ namespace FakeItEasy.Creation
 
             public IFakeOptions<T> Implements(Type interfaceType)
             {
-                this.proxyOptions.AddInterfaceToImplement(interfaceType);
+                this.additionalInterfacesToImplement.Add(interfaceType);
                 return this;
             }
 
@@ -140,7 +154,7 @@ namespace FakeItEasy.Creation
 
             public IFakeOptions<T> ConfigureFake(Action<T> action)
             {
-                this.proxyOptions.AddProxyConfigurationAction(x => action((T)x));
+                this.proxyConfigurationActions.Add(x => action((T)x));
                 return this;
             }
 

--- a/Source/FakeItEasy/Creation/FakeObjectCreator.cs
+++ b/Source/FakeItEasy/Creation/FakeObjectCreator.cs
@@ -19,7 +19,7 @@ namespace FakeItEasy.Creation
             this.fakeCallProcessorProviderFactory = fakeCallProcessorProviderFactory;
         }
 
-        public object CreateFake(Type typeOfFake, ProxyOptions proxyOptions, IDummyValueCreationSession session, bool throwOnFailure)
+        public object CreateFake(Type typeOfFake, IProxyOptions proxyOptions, IDummyValueCreationSession session, bool throwOnFailure)
         {
             var result = this.GenerateProxy(typeOfFake, proxyOptions, proxyOptions.ArgumentsForConstructor);
 
@@ -74,7 +74,7 @@ namespace FakeItEasy.Creation
                        };
         }
 
-        private void AssertThatProxyWasGeneratedWhenArgumentsForConstructorAreSpecified(Type typeOfFake, ProxyGeneratorResult result, ProxyOptions proxyOptions)
+        private void AssertThatProxyWasGeneratedWhenArgumentsForConstructorAreSpecified(Type typeOfFake, ProxyGeneratorResult result, IProxyOptions proxyOptions)
         {
             if (!result.ProxyWasSuccessfullyGenerated && proxyOptions.ArgumentsForConstructor != null)
             {
@@ -82,7 +82,7 @@ namespace FakeItEasy.Creation
             }
         }
 
-        private ProxyGeneratorResult TryCreateFakeWithDummyArgumentsForConstructor(Type typeOfFake, ProxyOptions proxyOptions, IDummyValueCreationSession session, string failReasonForDefaultConstructor, bool throwOnFailure)
+        private ProxyGeneratorResult TryCreateFakeWithDummyArgumentsForConstructor(Type typeOfFake, IProxyOptions proxyOptions, IDummyValueCreationSession session, string failReasonForDefaultConstructor, bool throwOnFailure)
         {
             var constructors = ResolveConstructors(typeOfFake, session);
 
@@ -106,7 +106,7 @@ namespace FakeItEasy.Creation
             return null;
         }
 
-        private ProxyGeneratorResult GenerateProxy(Type typeOfFake, ProxyOptions proxyOptions, IEnumerable<object> argumentsForConstructor)
+        private ProxyGeneratorResult GenerateProxy(Type typeOfFake, IProxyOptions proxyOptions, IEnumerable<object> argumentsForConstructor)
         {
             var fakeCallProcessorProvider = this.fakeCallProcessorProviderFactory(typeOfFake, proxyOptions);
 

--- a/Source/FakeItEasy/Creation/FakeObjectCreator.cs
+++ b/Source/FakeItEasy/Creation/FakeObjectCreator.cs
@@ -19,18 +19,18 @@ namespace FakeItEasy.Creation
             this.fakeCallProcessorProviderFactory = fakeCallProcessorProviderFactory;
         }
 
-        public object CreateFake(Type typeOfFake, FakeOptions fakeOptions, IDummyValueCreationSession session, bool throwOnFailure)
+        public object CreateFake(Type typeOfFake, ProxyOptions proxyOptions, IDummyValueCreationSession session, bool throwOnFailure)
         {
-            var result = this.GenerateProxy(typeOfFake, fakeOptions, fakeOptions.ArgumentsForConstructor);
+            var result = this.GenerateProxy(typeOfFake, proxyOptions, proxyOptions.ArgumentsForConstructor);
 
             if (throwOnFailure)
             {
-                this.AssertThatProxyWasGeneratedWhenArgumentsForConstructorAreSpecified(typeOfFake, result, fakeOptions);
+                this.AssertThatProxyWasGeneratedWhenArgumentsForConstructorAreSpecified(typeOfFake, result, proxyOptions);
             }
 
-            if (!result.ProxyWasSuccessfullyGenerated && fakeOptions.ArgumentsForConstructor == null)
+            if (!result.ProxyWasSuccessfullyGenerated && proxyOptions.ArgumentsForConstructor == null)
             {
-                result = this.TryCreateFakeWithDummyArgumentsForConstructor(typeOfFake, fakeOptions, session, result.ReasonForFailure, throwOnFailure);
+                result = this.TryCreateFakeWithDummyArgumentsForConstructor(typeOfFake, proxyOptions, session, result.ReasonForFailure, throwOnFailure);
             }
 
             return result != null ? result.GeneratedProxy : null;
@@ -74,21 +74,21 @@ namespace FakeItEasy.Creation
                        };
         }
 
-        private void AssertThatProxyWasGeneratedWhenArgumentsForConstructorAreSpecified(Type typeOfFake, ProxyGeneratorResult result, FakeOptions fakeOptions)
+        private void AssertThatProxyWasGeneratedWhenArgumentsForConstructorAreSpecified(Type typeOfFake, ProxyGeneratorResult result, ProxyOptions proxyOptions)
         {
-            if (!result.ProxyWasSuccessfullyGenerated && fakeOptions.ArgumentsForConstructor != null)
+            if (!result.ProxyWasSuccessfullyGenerated && proxyOptions.ArgumentsForConstructor != null)
             {
                 this.thrower.ThrowFailedToGenerateProxyWithArgumentsForConstructor(typeOfFake, result.ReasonForFailure);
             }
         }
 
-        private ProxyGeneratorResult TryCreateFakeWithDummyArgumentsForConstructor(Type typeOfFake, FakeOptions fakeOptions, IDummyValueCreationSession session, string failReasonForDefaultConstructor, bool throwOnFailure)
+        private ProxyGeneratorResult TryCreateFakeWithDummyArgumentsForConstructor(Type typeOfFake, ProxyOptions proxyOptions, IDummyValueCreationSession session, string failReasonForDefaultConstructor, bool throwOnFailure)
         {
             var constructors = ResolveConstructors(typeOfFake, session);
 
             foreach (var constructor in constructors.Where(x => x.WasSuccessfullyResolved))
             {
-                var result = this.GenerateProxy(typeOfFake, fakeOptions, constructor.Arguments.Select(x => x.ResolvedValue));
+                var result = this.GenerateProxy(typeOfFake, proxyOptions, constructor.Arguments.Select(x => x.ResolvedValue));
 
                 if (result.ProxyWasSuccessfullyGenerated)
                 {
@@ -106,15 +106,15 @@ namespace FakeItEasy.Creation
             return null;
         }
 
-        private ProxyGeneratorResult GenerateProxy(Type typeOfFake, FakeOptions fakeOptions, IEnumerable<object> argumentsForConstructor)
+        private ProxyGeneratorResult GenerateProxy(Type typeOfFake, ProxyOptions proxyOptions, IEnumerable<object> argumentsForConstructor)
         {
-            var fakeCallProcessorProvider = this.fakeCallProcessorProviderFactory(typeOfFake, fakeOptions);
+            var fakeCallProcessorProvider = this.fakeCallProcessorProviderFactory(typeOfFake, proxyOptions);
 
             return this.proxyGenerator.GenerateProxy(
                     typeOfFake,
-                    fakeOptions.AdditionalInterfacesToImplement,
+                    proxyOptions.AdditionalInterfacesToImplement,
                     argumentsForConstructor,
-                    fakeOptions.AdditionalAttributes,
+                    proxyOptions.AdditionalAttributes,
                     fakeCallProcessorProvider);
         }
     }

--- a/Source/FakeItEasy/Creation/FakeOptions.cs
+++ b/Source/FakeItEasy/Creation/FakeOptions.cs
@@ -7,7 +7,7 @@ namespace FakeItEasy.Creation
     internal class FakeOptions
     {
         private readonly List<Type> additionalInterfacesToImplement = new List<Type>();
-        private readonly List<Action<object>> fakeConfigurationActions = new List<Action<object>>();
+        private readonly List<Action<object>> proxyConfigurationActions = new List<Action<object>>();
         private readonly List<CustomAttributeBuilder> additionalAttributes = new List<CustomAttributeBuilder>();
 
         public IEnumerable<object> ArgumentsForConstructor { get; set; }
@@ -17,9 +17,9 @@ namespace FakeItEasy.Creation
             get { return this.additionalInterfacesToImplement; }
         }
 
-        public IEnumerable<Action<object>> FakeConfigurationActions
+        public IEnumerable<Action<object>> ProxyConfigurationActions
         {
-            get { return this.fakeConfigurationActions; }
+            get { return this.proxyConfigurationActions; }
         }
 
         public IEnumerable<CustomAttributeBuilder> AdditionalAttributes
@@ -32,9 +32,9 @@ namespace FakeItEasy.Creation
             this.additionalInterfacesToImplement.Add(interfaceType);
         }
 
-        public void AddFakeConfigurationAction(Action<object> action)
+        public void AddProxyConfigurationAction(Action<object> action)
         {
-            this.fakeConfigurationActions.Add(action);
+            this.proxyConfigurationActions.Add(action);
         }
 
         public void AddAttribute(CustomAttributeBuilder attribute)

--- a/Source/FakeItEasy/Creation/IFakeAndDummyManager.cs
+++ b/Source/FakeItEasy/Creation/IFakeAndDummyManager.cs
@@ -20,10 +20,10 @@ namespace FakeItEasy.Creation
         /// Creates a fake object of the specified type.
         /// </summary>
         /// <param name="typeOfFake">The type of fake object to generate.</param>
-        /// <param name="options">Options for building the fake object.</param>
+        /// <param name="options">Options for building the proxy that will act as the fake.</param>
         /// <returns>A fake object.</returns>
         /// <exception cref="FakeItEasy.Core.FakeCreationException">The current IProxyGenerator is not able to generate a fake of the specified type.</exception>
-        object CreateFake(Type typeOfFake, FakeOptions options);
+        object CreateFake(Type typeOfFake, ProxyOptions options);
 
         /// <summary>
         /// Tries to create a dummy of the specified type.
@@ -37,9 +37,9 @@ namespace FakeItEasy.Creation
         /// Tries to create a fake object of the specified type.
         /// </summary>
         /// <param name="typeOfFake">The type of fake to create.</param>
-        /// <param name="options">Options for the creation of the fake.</param>
+        /// <param name="options">Options for building the proxy that will act as the fake.</param>
         /// <param name="result">The created fake object when creation is successful.</param>
         /// <returns>A value indicating whether the creation was successful.</returns>
-        bool TryCreateFake(Type typeOfFake, FakeOptions options, out object result);
+        bool TryCreateFake(Type typeOfFake, ProxyOptions options, out object result);
     }
 }

--- a/Source/FakeItEasy/Creation/IFakeAndDummyManager.cs
+++ b/Source/FakeItEasy/Creation/IFakeAndDummyManager.cs
@@ -23,7 +23,7 @@ namespace FakeItEasy.Creation
         /// <param name="options">Options for building the proxy that will act as the fake.</param>
         /// <returns>A fake object.</returns>
         /// <exception cref="FakeItEasy.Core.FakeCreationException">The current IProxyGenerator is not able to generate a fake of the specified type.</exception>
-        object CreateFake(Type typeOfFake, ProxyOptions options);
+        object CreateFake(Type typeOfFake, IProxyOptions options);
 
         /// <summary>
         /// Tries to create a dummy of the specified type.
@@ -40,6 +40,6 @@ namespace FakeItEasy.Creation
         /// <param name="options">Options for building the proxy that will act as the fake.</param>
         /// <param name="result">The created fake object when creation is successful.</param>
         /// <returns>A value indicating whether the creation was successful.</returns>
-        bool TryCreateFake(Type typeOfFake, ProxyOptions options, out object result);
+        bool TryCreateFake(Type typeOfFake, IProxyOptions options, out object result);
     }
 }

--- a/Source/FakeItEasy/Creation/IFakeCreatorFacade.cs
+++ b/Source/FakeItEasy/Creation/IFakeCreatorFacade.cs
@@ -12,10 +12,10 @@ namespace FakeItEasy.Creation
         /// Creates a fake object of the specified type.
         /// </summary>
         /// <typeparam name="T">The type of fake to create.</typeparam>
-        /// <param name="options">Options for the created fake object.</param>
+        /// <param name="optionsBuilder">Action that builds options for the created fake object.</param>
         /// <returns>The created fake object.</returns>
         /// <exception cref="FakeItEasy.Core.FakeCreationException">Was unable to generate the fake in the current configuration.</exception>
-        T CreateFake<T>(Action<IFakeOptionsBuilder<T>> options);
+        T CreateFake<T>(Action<IFakeOptions<T>> optionsBuilder);
 
         /// <summary>
         /// Creates a dummy object, this can be a fake object or an object resolved

--- a/Source/FakeItEasy/Creation/IFakeOptions.cs
+++ b/Source/FakeItEasy/Creation/IFakeOptions.cs
@@ -11,7 +11,7 @@ namespace FakeItEasy.Creation
     /// Provides options for generating fake object.
     /// </summary>
     /// <typeparam name="T">The type of fake object generated.</typeparam>
-    public interface IFakeOptionsBuilder<T>
+    public interface IFakeOptions<T>
         : IHideObjectMembers
     {
         /// <summary>
@@ -19,7 +19,7 @@ namespace FakeItEasy.Creation
         /// </summary>
         /// <param name="argumentsForConstructor">The arguments to pass to the constructor of the faked class.</param>
         /// <returns>Options object.</returns>
-        IFakeOptionsBuilder<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor);
+        IFakeOptions<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor);
 
         /// <summary>
         /// Specifies arguments for the constructor of the faked class by giving an expression with the call to
@@ -28,7 +28,7 @@ namespace FakeItEasy.Creation
         /// <param name="constructorCall">The constructor call to use when creating a class proxy.</param>
         /// <returns>Options object.</returns>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design when using the Expression-, Action- and Func-types.")]
-        IFakeOptionsBuilder<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall);
+        IFakeOptions<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall);
 
         /// <summary>
         /// Specifies that the fake should delegate calls to the specified instance.
@@ -45,14 +45,14 @@ namespace FakeItEasy.Creation
         /// used to wrap another object, the <c>Wrapping</c> directive takes precedence.
         /// </para>
         /// </remarks>
-        IFakeOptionsBuilderForWrappers<T> Wrapping(T wrappedInstance);
+        IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);
 
         /// <summary>
         /// Specifies that the fake should be created with these additional attributes.
         /// </summary>
         /// <param name="customAttributeBuilders">The attributes to build into the proxy.</param>
         /// <returns>Options object.</returns>
-        IFakeOptionsBuilder<T> WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders);
+        IFakeOptions<T> WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders);
 
         /// <summary>
         /// Sets up the fake to implement the specified interface in addition to the
@@ -63,7 +63,7 @@ namespace FakeItEasy.Creation
         /// <exception cref="ArgumentException">The specified type is not an interface.</exception>
         /// <exception cref="ArgumentNullException">The specified type is null.</exception>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Implements", Justification = "Would be a breaking change, might be changed in a later major version.")]
-        IFakeOptionsBuilder<T> Implements(Type interfaceType);
+        IFakeOptions<T> Implements(Type interfaceType);
 
         /// <summary>
         /// Sets up the fake to implement the specified interface in addition to the
@@ -74,7 +74,7 @@ namespace FakeItEasy.Creation
         /// <exception cref="ArgumentException">The specified type is not an interface.</exception>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Implements", Justification = "Would be a breaking change, might be changed in a later major version.")]
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Used to provide a strongly typed fluent API.")]
-        IFakeOptionsBuilder<T> Implements<TInterface>();
+        IFakeOptions<T> Implements<TInterface>();
 
         /// <summary>
         /// Specifies an action that should be run over the fake object for the initial configuration (during the creation of the fake proxy).
@@ -98,6 +98,6 @@ namespace FakeItEasy.Creation
         /// used to configure the fake as well, the <c>ConfigureFake</c> actions take precedence.
         /// </para>
         /// </remarks>
-        IFakeOptionsBuilder<T> ConfigureFake(Action<T> action);
+        IFakeOptions<T> ConfigureFake(Action<T> action);
     }
 }

--- a/Source/FakeItEasy/Creation/IFakeOptionsForWrappers.cs
+++ b/Source/FakeItEasy/Creation/IFakeOptionsForWrappers.cs
@@ -6,14 +6,14 @@ namespace FakeItEasy.Creation
     /// Provides options for fake wrappers.
     /// </summary>
     /// <typeparam name="T">The type of the fake object generated.</typeparam>
-    public interface IFakeOptionsBuilderForWrappers<T>
-        : IFakeOptionsBuilder<T>
+    public interface IFakeOptionsForWrappers<T>
+        : IFakeOptions<T>
     {
         /// <summary>
         /// Specifies a fake recorder to use.
         /// </summary>
         /// <param name="recorder">The recorder to use.</param>
         /// <returns>Options object.</returns>
-        IFakeOptionsBuilder<T> RecordedBy(ISelfInitializingFakeRecorder recorder);
+        IFakeOptions<T> RecordedBy(ISelfInitializingFakeRecorder recorder);
     }
 }

--- a/Source/FakeItEasy/Creation/ProxyOptions.cs
+++ b/Source/FakeItEasy/Creation/ProxyOptions.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy.Creation
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Reflection.Emit;
 
     internal interface IProxyOptions
@@ -15,42 +16,35 @@ namespace FakeItEasy.Creation
         IEnumerable<CustomAttributeBuilder> AdditionalAttributes { get; }
     }
 
-    internal class ProxyOptions : IProxyOptions
+    internal static class ProxyOptions
     {
-        private readonly List<Type> additionalInterfacesToImplement = new List<Type>();
-        private readonly List<Action<object>> proxyConfigurationActions = new List<Action<object>>();
-        private readonly List<CustomAttributeBuilder> additionalAttributes = new List<CustomAttributeBuilder>();
+        public static readonly IProxyOptions Empty = new EmptyProxyOptions();
 
-        public IEnumerable<object> ArgumentsForConstructor { get; set; }
-
-        public IEnumerable<Type> AdditionalInterfacesToImplement
+        private class EmptyProxyOptions : IProxyOptions
         {
-            get { return this.additionalInterfacesToImplement; }
-        }
+            private readonly IEnumerable<Type> additionalInterfacesToImplement = new Type[0];
+            private readonly IEnumerable<Action<object>> proxyConfigurationActions = new Action<object>[0];
+            private readonly IEnumerable<CustomAttributeBuilder> customAttributeBuilders = new CustomAttributeBuilder[0];
 
-        public IEnumerable<Action<object>> ProxyConfigurationActions
-        {
-            get { return this.proxyConfigurationActions; }
-        }
+            public IEnumerable<object> ArgumentsForConstructor
+            {
+                get { return null; }
+            }
 
-        public IEnumerable<CustomAttributeBuilder> AdditionalAttributes
-        {
-            get { return this.additionalAttributes; }
-        }
+            public IEnumerable<Type> AdditionalInterfacesToImplement
+            {
+                get { return this.additionalInterfacesToImplement; }
+            }
 
-        public void AddInterfaceToImplement(Type interfaceType)
-        {
-            this.additionalInterfacesToImplement.Add(interfaceType);
-        }
+            public IEnumerable<Action<object>> ProxyConfigurationActions
+            {
+                get { return this.proxyConfigurationActions; }
+            }
 
-        public void AddProxyConfigurationAction(Action<object> action)
-        {
-            this.proxyConfigurationActions.Add(action);
-        }
-
-        public void AddAttribute(CustomAttributeBuilder attribute)
-        {
-            this.additionalAttributes.Add(attribute);
+            public IEnumerable<CustomAttributeBuilder> AdditionalAttributes
+            {
+                get { return this.customAttributeBuilders; }
+            }
         }
     }
 }

--- a/Source/FakeItEasy/Creation/ProxyOptions.cs
+++ b/Source/FakeItEasy/Creation/ProxyOptions.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Creation
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    internal class FakeOptions
+    internal class ProxyOptions
     {
         private readonly List<Type> additionalInterfacesToImplement = new List<Type>();
         private readonly List<Action<object>> proxyConfigurationActions = new List<Action<object>>();

--- a/Source/FakeItEasy/Creation/ProxyOptions.cs
+++ b/Source/FakeItEasy/Creation/ProxyOptions.cs
@@ -4,7 +4,18 @@ namespace FakeItEasy.Creation
     using System.Collections.Generic;
     using System.Reflection.Emit;
 
-    internal class ProxyOptions
+    internal interface IProxyOptions
+    {
+        IEnumerable<object> ArgumentsForConstructor { get; }
+
+        IEnumerable<Type> AdditionalInterfacesToImplement { get; }
+
+        IEnumerable<Action<object>> ProxyConfigurationActions { get; }
+
+        IEnumerable<CustomAttributeBuilder> AdditionalAttributes { get; }
+    }
+
+    internal class ProxyOptions : IProxyOptions
     {
         private readonly List<Type> additionalInterfacesToImplement = new List<Type>();
         private readonly List<Action<object>> proxyConfigurationActions = new List<Action<object>>();

--- a/Source/FakeItEasy/Fake.of.T.cs
+++ b/Source/FakeItEasy/Fake.of.T.cs
@@ -26,17 +26,17 @@ namespace FakeItEasy
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Fake{T}"/> class. 
-        /// Creates a new fake object using the specified options.
+        /// Creates a new fake object using options built by <paramref name="optionsBuilder"/>.
         /// </summary>
-        /// <param name="options">
-        /// Options used to create the fake object.
+        /// <param name="optionsBuilder">
+        /// Action that builds options used to create the fake object.
         /// </param>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design when using the Expression-, Action- and Func-types.")]
-        public Fake(Action<IFakeOptionsBuilder<T>> options)
+        public Fake(Action<IFakeOptions<T>> optionsBuilder)
         {
-            Guard.AgainstNull(options, "options");
+            Guard.AgainstNull(optionsBuilder, "optionsBuilder");
 
-            this.FakedObject = CreateFake(options);
+            this.FakedObject = CreateFake(optionsBuilder);
         }
 
         /// <summary>
@@ -98,9 +98,9 @@ namespace FakeItEasy
             return this.StartConfiguration.AnyCall();
         }
 
-        private static T CreateFake(Action<IFakeOptionsBuilder<T>> options)
+        private static T CreateFake(Action<IFakeOptions<T>> optionsBuilder)
         {
-            return FakeCreator.CreateFake(options);
+            return FakeCreator.CreateFake(optionsBuilder);
         }
     }
 }

--- a/Source/FakeItEasy/FakeItEasy.csproj
+++ b/Source/FakeItEasy/FakeItEasy.csproj
@@ -419,10 +419,10 @@
     <Compile Include="Creation\IFakeObjectCreator.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Creation\IFakeOptionsBuilder.cs">
+    <Compile Include="Creation\IFakeOptions.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Creation\IFakeOptionsBuilderForWrappers.cs">
+    <Compile Include="Creation\IFakeOptionsForWrappers.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Creation\IProxyGenerator.cs">

--- a/Source/FakeItEasy/FakeItEasy.csproj
+++ b/Source/FakeItEasy/FakeItEasy.csproj
@@ -404,7 +404,7 @@
     <Compile Include="Creation\FakeObjectCreator.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Creation\FakeOptions.cs">
+    <Compile Include="Creation\ProxyOptions.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Creation\IDummyValueCreationSession.cs">

--- a/Source/FakeItEasy/FakeOptionsBuilderExtensions.cs
+++ b/Source/FakeItEasy/FakeOptionsBuilderExtensions.cs
@@ -6,7 +6,7 @@ namespace FakeItEasy
     using FakeItEasy.Creation;
 
     /// <summary>
-    /// Provides extension methods for <see cref="IFakeOptionsBuilder{T}"/>.
+    /// Provides extension methods for <see cref="IFakeOptions{T}"/>.
     /// </summary>
     public static class FakeOptionsBuilderExtensions
     {
@@ -15,31 +15,31 @@ namespace FakeItEasy
         /// that has not been explicitly configured will throw an exception.
         /// </summary>
         /// <typeparam name="T">The type of fake object.</typeparam>
-        /// <param name="options">The configuration.</param>
+        /// <param name="optionsBuilder">Action that builds options used to create the fake object.</param>
         /// <returns>A configuration object.</returns>
-        public static IFakeOptionsBuilder<T> Strict<T>(this IFakeOptionsBuilder<T> options)
+        public static IFakeOptions<T> Strict<T>(this IFakeOptions<T> optionsBuilder)
         {
-            Guard.AgainstNull(options, "options");
+            Guard.AgainstNull(optionsBuilder, "optionsBuilder");
 
             Action<IFakeObjectCall> thrower = call =>
                 {
                     throw new ExpectationException("Call to non configured method \"{0}\" of strict fake.".FormatInvariant(call.Method.Name));
                 };
 
-            return options.ConfigureFake(fake => A.CallTo(fake).Invokes(thrower));
+            return optionsBuilder.ConfigureFake(fake => A.CallTo(fake).Invokes(thrower));
         }
 
         /// <summary>
         /// Makes the fake default to calling base methods, so long as they aren't abstract.
         /// </summary>
         /// <typeparam name="T">The type of fake object.</typeparam>
-        /// <param name="options">The configuration.</param>
+        /// <param name="optionsBuilder">Action that builds options used to create the fake object.</param>
         /// <returns>A configuration object.</returns>
-        public static IFakeOptionsBuilder<T> CallsBaseMethods<T>(this IFakeOptionsBuilder<T> options)
+        public static IFakeOptions<T> CallsBaseMethods<T>(this IFakeOptions<T> optionsBuilder)
         {
-            Guard.AgainstNull(options, "options");
+            Guard.AgainstNull(optionsBuilder, "optionsBuilder");
 
-            return options.ConfigureFake(fake => A.CallTo(fake)
+            return optionsBuilder.ConfigureFake(fake => A.CallTo(fake)
                                                   .Where(call => !call.Method.IsAbstract)
                                                   .CallsBaseMethod());
         }

--- a/Source/FakeItEasy/RootModule.cs
+++ b/Source/FakeItEasy/RootModule.cs
@@ -57,8 +57,8 @@
                 (fakeObjectType, proxy) => new FakeManager(fakeObjectType, proxy));
 
             container.RegisterSingleton<FakeCallProcessorProvider.Factory>(c =>
-                (typeOfFake, fakeOptions) =>
-                    new FakeManagerProvider(c.Resolve<FakeManager.Factory>(), c.Resolve<IFakeManagerAccessor>(), c.Resolve<IFakeObjectContainer>(), typeOfFake, fakeOptions));
+                (typeOfFake, proxyOptions) =>
+                    new FakeManagerProvider(c.Resolve<FakeManager.Factory>(), c.Resolve<IFakeManagerAccessor>(), c.Resolve<IFakeObjectContainer>(), typeOfFake, proxyOptions));
 
             container.RegisterSingleton<IFakeObjectCallFormatter>(c =>
                 new DefaultFakeObjectCallFormatter(c.Resolve<ArgumentValueFormatter>(), c.Resolve<IFakeManagerAccessor>()));
@@ -173,7 +173,7 @@
 
             public bool TryCreateFakeObject(Type typeOfFake, DummyValueCreationSession session, out object result)
             {
-                result = this.Creator.CreateFake(typeOfFake, new FakeOptions(), session, false);
+                result = this.Creator.CreateFake(typeOfFake, new ProxyOptions(), session, false);
                 return result != null;
             }
         }

--- a/Source/FakeItEasy/RootModule.cs
+++ b/Source/FakeItEasy/RootModule.cs
@@ -173,7 +173,7 @@
 
             public bool TryCreateFakeObject(Type typeOfFake, DummyValueCreationSession session, out object result)
             {
-                result = this.Creator.CreateFake(typeOfFake, new ProxyOptions(), session, false);
+                result = this.Creator.CreateFake(typeOfFake, ProxyOptions.Empty, session, false);
                 return result != null;
             }
         }


### PR DESCRIPTION
This is the general approach I'd like to take to fix #520, but wasn't quite sure about the ending and wanted some feedback.

1. After #522 was merged, the old `FakeOptions.fakeConfigurationActions` member was only used to configure our proxies, so I renamed to `proxyConfigurationActions`.
2. Then it was clear that `FakeOptions` was only used to set proxies' options, so I renamed that class to `ProxyOptions` (in order to make way for `FakeOptionsBuilder` to become `FakeOptions`)
3. At this point, I was able to rename `IFakeOptionsBuilder`, `IFakeOptionsBuilderForWrappers`, and `DefaultFakeCreatorFacade.FakeOptionsBuilder`, dropping the `Builder`. (At this point, I renamed parameters of type `<Action<FakeOptions>>` to `optionsBuilder`, rather than just `options`.)
4. Now `ProxyOptions` is used quite a bit internally, but only the `FakeOptions` class really needs to use the mutators on the class, so I extracted `IProxyOptions`, a read-only interface, to be used elsewhere.
5. Finally, I had `FakeOptions` absorb `ProxyOptions`, as @adamralph and I had discussed.

I'm generally happy with the arrangement, but before proceeding with a PR, I wanted feedback on a few points.

1. Do you think step 4 brings value? I like separating the read-only interface, just so it's clear that once the `ProxyOptions` are constructed, they aren't changed
2. `ProxyOptions` and `IProxyOptions` are not the best pair of names. I could rename to emphasize readonlyness of one or mutability of the other. `MutableProxyOptions` and `IProxyOptions`, or `ProxyOptions` and `IReadonlyProxyOptions`?
3. I'm not convinced that absorbing `ProxyOptions` is the best step. I was happy after step 4, and found that, due to `ProxyOptions`'s non-genericness, I had to introduce a new `EmptyProxyOptions` class in order to create a default proxy options object in the cases where this was used. I'd probably stop at step 4, if it were up to me.

Thoughts?

Thanks!
  B