### PR TITLE
#462 - Throw when IFakeOptionsBuilder.Implements is passed a non-interface

### DIFF
--- a/Source/FakeItEasy.Specs/CreationOptionsSpecs.cs
+++ b/Source/FakeItEasy.Specs/CreationOptionsSpecs.cs
@@ -341,6 +341,19 @@
         }
 
         [Scenario]
+        public static void ImplementsNonInterfaceType(
+            Exception exception)
+        {
+            "When a fake is built to implement a non-interface type"
+                .x(() => exception = Record.Exception(() => A.Fake<MakesVirtualCallInConstructor>(options => options
+                                                                .Implements(typeof(MakesVirtualCallInConstructor)))));
+
+            "Then it should throw an argument exception"
+                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
+                             .WithMessage("*The specified type 'FakeItEasy.Specs.MakesVirtualCallInConstructor' is not an interface*"));
+        }
+
+        [Scenario]
         public static void MultipleImplementsConfigurations(
             MakesVirtualCallInConstructor fake)
         {

--- a/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
+++ b/Source/FakeItEasy.Tests/Creation/DefaultFakeCreatorTests.cs
@@ -16,8 +16,8 @@ namespace FakeItEasy.Tests.Creation
 
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Used reflectively.")]
         private object[] optionBuilderCalls = TestCases.Create<Func<IFakeOptionsBuilder<Foo>, IFakeOptionsBuilder<Foo>>>(
-                x => x.Wrapping(A.Fake<Foo>()).Implements(typeof(Foo)),
-                x => x.Implements(typeof(Foo)),
+                x => x.Wrapping(A.Fake<Foo>()).Implements(typeof(IFoo)),
+                x => x.Implements(typeof(IFoo)),
                 x => x.WithArgumentsForConstructor(() => new Foo()),
                 x => x.WithArgumentsForConstructor(new object[] { A.Fake<IServiceProvider>() }),
                 x => x.Wrapping(A.Fake<Foo>()).RecordedBy(A.Fake<ISelfInitializingFakeRecorder>()))

--- a/Source/FakeItEasy/Creation/FakeOptions.cs
+++ b/Source/FakeItEasy/Creation/FakeOptions.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy.Creation
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Reflection.Emit;
 
     internal class FakeOptions
@@ -29,6 +30,17 @@ namespace FakeItEasy.Creation
 
         public void AddInterfaceToImplement(Type interfaceType)
         {
+            Guard.AgainstNull(interfaceType, "interfaceType");
+
+            if (!interfaceType.IsInterface)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        "The specified type '{0}' is not an interface",
+                        interfaceType.FullNameCSharp()));
+            }
+
             this.additionalInterfacesToImplement.Add(interfaceType);
         }
 


### PR DESCRIPTION
Modifications to throw when IFakeOptionsBuilder.Implements() is passed a non-interface
#462 