### PR TITLE
#530 - Say what the object is when A.CallTo complains "The specified object is not recognized as a fake object.”

### DIFF
--- a/Source/FakeItEasy.Tests/Core/DefaultFakeManagerAccessorTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DefaultFakeManagerAccessorTests.cs
@@ -110,7 +110,7 @@ namespace FakeItEasy.Tests.Core
             // Assert
             Assert.That(
                 () => this.accessor.GetFakeManager(proxy),
-                Throws.ArgumentException.With.Message.EqualTo("The specified object of type 'Object' is not recognized as a fake object."));
+                Throws.ArgumentException.With.Message.EqualTo("The specified object of type 'System.Object' is not recognized as a fake object."));
         }
     }
 }

--- a/Source/FakeItEasy.Tests/Core/DefaultFakeManagerAccessorTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DefaultFakeManagerAccessorTests.cs
@@ -95,7 +95,7 @@ namespace FakeItEasy.Tests.Core
             // Assert
             Assert.That(
                 () => this.accessor.GetFakeManager(proxy),
-                Throws.ArgumentException.With.Message.EqualTo("The specified object is not recognized as a fake object."));
+                Throws.ArgumentException.With.Message.EqualTo("The specified object does not have a FakeManager attached."));
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace FakeItEasy.Tests.Core
             // Assert
             Assert.That(
                 () => this.accessor.GetFakeManager(proxy),
-                Throws.ArgumentException.With.Message.EqualTo("The specified object is not recognized as a fake object."));
+                Throws.ArgumentException.With.Message.EqualTo("The specified object of type 'Object' is not recognized as a fake object."));
         }
     }
 }

--- a/Source/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
+++ b/Source/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
@@ -35,7 +35,7 @@ namespace FakeItEasy.Core
                     string.Format(
                         CultureInfo.CurrentCulture,
                         "The specified object of type '{0}' is not recognized as a fake object.",
-                        taggable.Tag.GetType().Name));
+                        taggable.Tag.GetType().FullNameCSharp()));
             }
 
             return result;

--- a/Source/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
+++ b/Source/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
@@ -1,8 +1,7 @@
 namespace FakeItEasy.Core
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
+    using System.Globalization;
     using System.Runtime.CompilerServices;
     using FakeItEasy.Creation;
 
@@ -23,11 +22,20 @@ namespace FakeItEasy.Core
 
             var taggable = AsTaggable(proxy);
 
+            if (taggable.Tag == null)
+            {
+                throw new ArgumentException("The specified object does not have a FakeManager attached.");
+            }
+
             var result = taggable.Tag as FakeManager;
 
             if (result == null)
             {
-                throw new ArgumentException("The specified object is not recognized as a fake object.");
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        "The specified object of type '{0}' is not recognized as a fake object.",
+                        taggable.Tag.GetType().Name));
             }
 
             return result;


### PR DESCRIPTION
#530 - Modifications to say what the object is when A.CallTo complains "The specified object is not recognized as a fake object.”

Previously both tests expected the same exception message, except that a ```Type.Name``` could not be resolved if the ```proxy.Tag == null```.  Therefore, I modified the logic of ```GetFakeManager``` to throw a separate exception which the first test now catches.  The second test continues to check for the original exception, only with the addition of the ```proxy.Tag.GetType().Name``` in the exception message.

connects to #530