### PR TITLE
making CreationOptionsSpecs static

### DIFF
--- a/Source/FakeItEasy.Specs/CreationOptionsSpecs.cs
+++ b/Source/FakeItEasy.Specs/CreationOptionsSpecs.cs
@@ -12,7 +12,7 @@
     using Xbehave;
 
     [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Required for testing.")]
-    public class CreationOptionsSpecs
+    public static class CreationOptionsSpecs
     {
         [SuppressMessage("Microsoft.Design", "CA1040:AvoidEmptyInterfaces", Justification = "It's just used for testing.")]
         public interface IInterfaceThatWeWillAddAttributesTo1


### PR DESCRIPTION
fixes a code analysis warning that I introduced in e884223d0ceb1034879e94513a67070b45f58602 / #546.