### PR TITLE
making most specs static

### DIFF
--- a/Source/FakeItEasy.Specs/AssertingOnSetOnlyPropertiesSpecs.cs
+++ b/Source/FakeItEasy.Specs/AssertingOnSetOnlyPropertiesSpecs.cs
@@ -3,7 +3,7 @@
     using System.Diagnostics.CodeAnalysis;
     using Xbehave;
 
-    public class AssertingOnSetOnlyPropertiesSpecs
+    public static class AssertingOnSetOnlyPropertiesSpecs
     {
         public interface ISetOnly
         {
@@ -15,7 +15,7 @@
         }
 
         [Scenario]
-        public void SetOnlyProperties(
+        public static void SetOnlyProperties(
             ISetOnly setOnly)
         {
             "establish"

--- a/Source/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
+++ b/Source/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
@@ -10,10 +10,10 @@
         void MightReturnAKnownValue(out string andThisIsWhoReallyDidIt);
     }
 
-    public class AssignsOutAndRefParametersSpecs
+    public static class AssignsOutAndRefParametersSpecs
     {
         [Scenario]
-        public void AssignOutAndRefParametersLazilyUsingFunc(
+        public static void AssignOutAndRefParametersLazilyUsingFunc(
             IHaveAnOut subject,
             string outValue)
         {
@@ -41,7 +41,7 @@
         }
 
         [Scenario]
-        public void AssignOutAndRefParametersLazilyUsingCall(
+        public static void AssignOutAndRefParametersLazilyUsingCall(
             IHaveAnOut subject,
             string outValue)
         {
@@ -69,7 +69,7 @@
         }
 
         [Scenario]
-        public void AssignOutAndRefParameters(
+        public static void AssignOutAndRefParameters(
             IHaveAnOut subject,
             string outValue)
         {

--- a/Source/FakeItEasy.Specs/AsyncAwaitSpecs.cs
+++ b/Source/FakeItEasy.Specs/AsyncAwaitSpecs.cs
@@ -11,10 +11,10 @@
         Task<int> QueryAsync();
     }
 
-    public class AsyncAwaitSpecs
+    public static class AsyncAwaitSpecs
     {
         [Scenario]
-        public void DefinedMethodWithReturnValue(
+        public static void DefinedMethodWithReturnValue(
             FooAsyncAwait foo,
             Task task)
         {
@@ -34,7 +34,7 @@
         }
 
         [Scenario]
-        public void DefinedVoidMethod(
+        public static void DefinedVoidMethod(
             FooAsyncAwait foo,
             Task task)
         {
@@ -54,7 +54,7 @@
         }
 
         [Scenario]
-        public void UndefinedMethodWithReturnValue(
+        public static void UndefinedMethodWithReturnValue(
             FooAsyncAwait foo,
             Task task)
         {
@@ -69,7 +69,7 @@
         }
 
         [Scenario]
-        public void UndefinedVoidMethod(
+        public static void UndefinedVoidMethod(
             FooAsyncAwait foo,
             Task task)
         {

--- a/Source/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/Source/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -8,7 +8,7 @@
     using Xbehave;
     using Xunit;
 
-    public class CallMatchingSpecs
+    public static class CallMatchingSpecs
     {
         public interface ITypeWithParameterArray
         {
@@ -43,7 +43,7 @@
         }
 
         [Scenario]
-        public void ParameterArrays(
+        public static void ParameterArrays(
             ITypeWithParameterArray fake)
         {
             "establish"
@@ -66,7 +66,7 @@
         }
 
         [Scenario]
-        public void FailingMatchOfNonGenericCalls(
+        public static void FailingMatchOfNonGenericCalls(
             IHaveNoGenericParameters fake,
             Exception exception)
         {
@@ -95,7 +95,7 @@
         }
 
         [Scenario]
-        public void FailingMatchOfGenericCalls(
+        public static void FailingMatchOfGenericCalls(
             IHaveTwoGenericParameters fake,
             Exception exception)
         {
@@ -124,7 +124,7 @@
         }
 
         [Scenario]
-        public void NoNonGenericCalls(
+        public static void NoNonGenericCalls(
             IHaveNoGenericParameters fake,
             Exception exception)
         {
@@ -146,7 +146,7 @@
         }
 
         [Scenario]
-        public void NoGenericCalls(
+        public static void NoGenericCalls(
             IHaveOneGenericParameter fake,
             Exception exception)
         {
@@ -168,7 +168,7 @@
         }
 
         [Scenario]
-        public void OutParameter(
+        public static void OutParameter(
             IDictionary<string, string> subject)
         {
             "establish"
@@ -203,7 +203,7 @@
         }
 
         [Scenario]
-        public void FailingMatchOfOutParameter(
+        public static void FailingMatchOfOutParameter(
             IDictionary<string, string> subject,
             Exception exception)
         {
@@ -233,7 +233,7 @@
         }
 
         [Scenario]
-        public void RefParameter(
+        public static void RefParameter(
             IHaveARefParameter subject)
         {
             "establish"
@@ -284,7 +284,7 @@
         /// </summary>
         /// <param name="subject">The subject of the test.</param>
         [Scenario]
-        public void ParameterHavingAnOutAttribute(
+        public static void ParameterHavingAnOutAttribute(
              IHaveAnOutParameter subject)
         {
             "establish"

--- a/Source/FakeItEasy.Specs/CallsBaseMethodsFakeSpecs.cs
+++ b/Source/FakeItEasy.Specs/CallsBaseMethodsFakeSpecs.cs
@@ -3,20 +3,10 @@
     using FluentAssertions;
     using Xbehave;
 
-    public abstract class AbstractBaseClass
-    {
-        public virtual string ConcreteMethod()
-        {
-            return "result from base method";
-        }
-
-        public abstract string AbstractMethod();
-    }
-
-    public class CallsBaseMethodsFakeSpecs
+    public static class CallsBaseMethodsFakeSpecs
     {
         [Scenario]
-        public void ConcreteMethod(
+        public static void ConcreteMethod(
             AbstractBaseClass fake,
             string result)
         {
@@ -31,7 +21,7 @@
         }
 
         [Scenario]
-        public void AbstractMethod(
+        public static void AbstractMethod(
             AbstractBaseClass fake,
             string result)
         {
@@ -44,5 +34,15 @@
             "it should return default value"
                 .x(() => result.Should().BeEmpty());
         }
+    }
+
+    public abstract class AbstractBaseClass
+    {
+        public virtual string ConcreteMethod()
+        {
+            return "result from base method";
+        }
+
+        public abstract string AbstractMethod();
     }
 }

--- a/Source/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/Source/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -3,7 +3,7 @@
     using FluentAssertions;
     using Xbehave;
 
-    public class ConfigurationSpecs
+    public static class ConfigurationSpecs
     {
         public interface IFoo
         {
@@ -13,7 +13,7 @@
         }
 
         [Scenario]
-        public void Callback(
+        public static void Callback(
             IFoo fake,
             bool wasCalled)
         {
@@ -32,7 +32,7 @@
         }
 
         [Scenario]
-        public void MultipleCallbacks(
+        public static void MultipleCallbacks(
             IFoo fake,
             bool firstWasCalled,
             bool secondWasCalled,
@@ -63,7 +63,7 @@
         }
 
         [Scenario]
-        public void CallBaseMethod(
+        public static void CallBaseMethod(
             BaseClass fake,
             int returnValue,
             bool callbackWasInvoked)

--- a/Source/FakeItEasy.Specs/CreationSpecs.cs
+++ b/Source/FakeItEasy.Specs/CreationSpecs.cs
@@ -8,18 +8,10 @@
     using Xbehave;
     using Xunit;
 
-    public class ClassWhoseConstructorThrows
-    {
-        public ClassWhoseConstructorThrows()
-        {
-            throw new NotSupportedException("I don't like being constructed.");
-        }
-    }
-
-    public class CreationSpecs
+    public static class CreationSpecs
     {
         [Scenario]
-        public void ThrowingConstructor(
+        public static void ThrowingConstructor(
             Exception exception)
         {
             "when faking a class whose constructor throws"
@@ -40,7 +32,7 @@
 
         // This spec proves that we can cope with throwing constructors (e.g. ensures that FakeManagers won't be reused):
         [Scenario]
-        public void UseSuccessfulConstructor(
+        public static void UseSuccessfulConstructor(
             FakedClass fake)
         {
             "when faking a class whose first constructor fails"
@@ -94,6 +86,14 @@
             public virtual bool WasParameterlessConstructorCalled { get; set; }
 
             public virtual bool WasTwoParameterConstructorCalled { get; set; }
+        }
+    }
+
+    public class ClassWhoseConstructorThrows
+    {
+        public ClassWhoseConstructorThrows()
+        {
+            throw new NotSupportedException("I don't like being constructed.");
         }
     }
 }

--- a/Source/FakeItEasy.Specs/DisposableSpecs.cs
+++ b/Source/FakeItEasy.Specs/DisposableSpecs.cs
@@ -5,13 +5,13 @@
     using FluentAssertions;
     using Xbehave;
 
-    public class DisposableSpecs
+    public static class DisposableSpecs
     {
         private static Exception exception;
 
         [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.GC.Collect", Justification = "Required for testing.")]
         [Scenario]
-        public void FakingDisposable(
+        public static void FakingDisposable(
             IDisposable fake)
         {
             "establish"

--- a/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
+++ b/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
@@ -4,10 +4,10 @@
     using FluentAssertions;
     using Xbehave;
 
-    public class DummyFactorySpecs
+    public static class DummyFactorySpecs
     {
         [Scenario]
-        public void DummyFactoryUsage(
+        public static void DummyFactoryUsage(
             RobotActivatedEvent dummy)
         {
             "when a dummy factory is defined for a set of types"
@@ -18,7 +18,7 @@
         }
 
         [Scenario]
-        public void DummyFactoryPriority(
+        public static void DummyFactoryPriority(
             RobotRunsAmokEvent dummy)
         {
             "when two dummy factories apply to the same type"

--- a/Source/FakeItEasy.Specs/FakeConfiguratorSpecs.cs
+++ b/Source/FakeItEasy.Specs/FakeConfiguratorSpecs.cs
@@ -4,10 +4,10 @@
     using FluentAssertions;
     using Xbehave;
 
-    public class FakeConfiguratorSpecs
+    public static class FakeConfiguratorSpecs
     {
         [Scenario]
-        public void DefinedFakeConfigurator()
+        public static void DefinedFakeConfigurator()
         {
             RobotActivatedEvent fake = null;
 
@@ -19,7 +19,7 @@
         }
 
         [Scenario]
-        public void FakeConfiguratorPriority(
+        public static void FakeConfiguratorPriority(
             RobotRunsAmokEvent fake)
         {
             "when two fake configurators apply to the same type"
@@ -30,7 +30,7 @@
         }
 
         [Scenario]
-        public void DuringConstruction(
+        public static void DuringConstruction(
             RobotRunsAmokEvent fake)
         {
             "when configuring a method called by a constructor"

--- a/Source/FakeItEasy.Specs/FakeScopeSpecs.cs
+++ b/Source/FakeItEasy.Specs/FakeScopeSpecs.cs
@@ -5,10 +5,10 @@
     using FluentAssertions;
     using Xbehave;
 
-    public class FakeScopeSpecs
+    public static class FakeScopeSpecs
     {
         [Scenario]
-        public void CallFromConstructor(
+        public static void CallFromConstructor(
             IFakeObjectContainer fakeObjectContainer,
             MakesVirtualCallInConstructor fake,
             string virtualMethodValueInsideOfScope,

--- a/Source/FakeItEasy.Specs/FakingDelegates.cs
+++ b/Source/FakeItEasy.Specs/FakingDelegates.cs
@@ -5,10 +5,10 @@
     using Xbehave;
     using Xunit;
 
-    public class FakingDelegates
+    public static class FakingDelegates
     {
         [Scenario]
-        public void WithoutConfiguration(
+        public static void WithoutConfiguration(
             Func<string, int> fakedDelegate)
         {
             "establish"
@@ -25,7 +25,7 @@
         }
 
         [Scenario]
-        public void WithConfiguration(
+        public static void WithConfiguration(
             Func<string, int> fakedDelegate,
             int result)
         {
@@ -43,7 +43,7 @@
         }
 
         [Scenario]
-        public void Throws(
+        public static void Throws(
             Func<string, int> fakedDelegate,
             FormatException expectedException,
             Exception exception)
@@ -66,7 +66,7 @@
         }
 
         [Scenario]
-        public void MissingInvoke(
+        public static void MissingInvoke(
             Func<string, int> fakedDelegate,
             int result)
         {

--- a/Source/FakeItEasy.Specs/FakingInternalsSpecs.cs
+++ b/Source/FakeItEasy.Specs/FakingInternalsSpecs.cs
@@ -11,18 +11,10 @@
     {
     }
 
-    public class TypeWithInternalMethod
-    {
-        internal virtual int InternalMethod()
-        {
-            return 8;
-        }
-    }
-
-    public class FakingInternalsSpecs
+    public static class FakingInternalsSpecs
     {
         [Scenario]
-        public void InvisibleInternals(
+        public static void InvisibleInternals(
             Exception exception)
         {
             "when trying to fake invisible internals"
@@ -37,7 +29,7 @@
         }
    
         [Scenario]
-        public void GenericTypeWithInternalTypeParameters(
+        public static void GenericTypeWithInternalTypeParameters(
             Exception exception)
         {
             "when trying to fake generic type with internal type parameters"
@@ -52,7 +44,7 @@
         }
    
         [Scenario]
-        public void OverrideInternalMethod(
+        public static void OverrideInternalMethod(
             TypeWithInternalMethod fake, 
             Exception exception)
         {
@@ -65,6 +57,14 @@
             "it should throw an exception with a message complaining about accessibility"
                 .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
                              .And.Message.Should().Contain("not accessible to DynamicProxyGenAssembly2"));
+        }
+    }
+
+    public class TypeWithInternalMethod
+    {
+        internal virtual int InternalMethod()
+        {
+            return 8;
         }
     }
 }

--- a/Source/FakeItEasy.Specs/FixtureInitializationSpecs.cs
+++ b/Source/FakeItEasy.Specs/FixtureInitializationSpecs.cs
@@ -5,12 +5,12 @@
     using FluentAssertions;
     using Xbehave;
 
-    public class FixtureInitializationSpecs
+    public static class FixtureInitializationSpecs
     {
         public static ExampleFixture Fixture { get; set; }
 
         [Scenario]
-        public void Initialization()
+        public static void Initialization()
         {
             "establish"
                 .x(() => Fixture = new ExampleFixture());

--- a/Source/FakeItEasy.Specs/LazySpecs.cs
+++ b/Source/FakeItEasy.Specs/LazySpecs.cs
@@ -6,7 +6,7 @@
     using FluentAssertions;
     using Xbehave;
 
-    public class LazySpecs
+    public static class LazySpecs
     {
         public interface ILazyFactory
         {
@@ -19,7 +19,7 @@
         }
 
         [Scenario]
-        public void LazyReturnValue(
+        public static void LazyReturnValue(
             ILazyFactory fake,
             Lazy<IFoo> lazy)
         {

--- a/Source/FakeItEasy.Specs/OrderedCallMatchingSpecs.cs
+++ b/Source/FakeItEasy.Specs/OrderedCallMatchingSpecs.cs
@@ -5,7 +5,7 @@
     using Xbehave;
     using Xunit;
 
-    public class OrderedCallMatchingSpecs
+    public static class OrderedCallMatchingSpecs
     {
         public interface IHaveNoGenericParameters
         {
@@ -18,7 +18,7 @@
         }
 
         [Scenario]
-        public void NonGenericCalls(
+        public static void NonGenericCalls(
             IHaveNoGenericParameters fake,
             Exception exception)
         {
@@ -54,7 +54,7 @@
         }
 
         [Scenario]
-        public void GenericCalls(
+        public static void GenericCalls(
             IHaveOneGenericParameter fake,
             Exception exception)
         {

--- a/Source/FakeItEasy.Specs/PropertySpecs.cs
+++ b/Source/FakeItEasy.Specs/PropertySpecs.cs
@@ -18,26 +18,10 @@
         List<string> this[int index1, bool index2] { get; set; }
     }
 
-    public sealed class UnfakeableClass
-    {
-        private static int nextId;
-        private readonly int id;
-
-        public UnfakeableClass()
-        {
-            this.id = ++nextId;
-        }
-
-        public override string ToString()
-        {
-            return string.Concat("UnfakeableClass ", this.id);
-        }
-    }
-
-    public class PropertySpecs
+    public static class PropertySpecs
     {
         [Scenario]
-        public void SettingIndexedProperty(
+        public static void SettingIndexedProperty(
             IHaveInterestingProperties subject)
         {
             "establish"
@@ -76,7 +60,7 @@
         }
 
         [Scenario]
-        public void SettingIndexedPropertyForDifferentIndexes(
+        public static void SettingIndexedPropertyForDifferentIndexes(
             IHaveInterestingProperties subject)
         {
             "establish"
@@ -97,7 +81,7 @@
         }
 
         [Scenario]
-        public void GettingUnconfiguredFakeableProperty(
+        public static void GettingUnconfiguredFakeableProperty(
             IHaveInterestingProperties subject, 
             IHaveInterestingProperties firstValue, 
             IHaveInterestingProperties secondValue)
@@ -120,7 +104,7 @@
         }
 
         [Scenario]
-        public void GettingUnconfiguredUnfakeableProperty(
+        public static void GettingUnconfiguredUnfakeableProperty(
             IHaveInterestingProperties subject, 
             UnfakeableClass firstValue, 
             UnfakeableClass secondValue)
@@ -140,6 +124,22 @@
 
             "it should return the same instance on a subsequent get"
                 .x(() => secondValue.Should().BeSameAs(firstValue));
+        }
+    }
+
+    public sealed class UnfakeableClass
+    {
+        private static int nextId;
+        private readonly int id;
+
+        public UnfakeableClass()
+        {
+            this.id = ++nextId;
+        }
+
+        public override string ToString()
+        {
+            return string.Concat("UnfakeableClass ", this.id);
         }
     }
 }

--- a/Source/FakeItEasy.Specs/SelfInitializedFakesSpecs.cs
+++ b/Source/FakeItEasy.Specs/SelfInitializedFakesSpecs.cs
@@ -14,10 +14,10 @@
         int GetCount(string internationalStandardBookNumber);
     }
 
-    public class SelfInitializedFakesSpecs
+    public static class SelfInitializedFakesSpecs
     {
         [Scenario]
-        public void SelfInitializing(
+        public static void SelfInitializing(
             InMemoryStorage inMemoryStorage, 
             ILibraryService realServiceWhileRecording, 
             ILibraryService realServiceDuringPlayback,
@@ -86,7 +86,7 @@
 
         [Trait("explicit", "yes")]
         [Scenario]
-        public void SelfInitializingWithFileRecorder(
+        public static void SelfInitializingWithFileRecorder(
             string fileRecorderPath,
             ILibraryService realServiceWhileRecording,
             ILibraryService realServiceDuringPlayback,

--- a/Source/FakeItEasy.Specs/StrictFakeSpecs.cs
+++ b/Source/FakeItEasy.Specs/StrictFakeSpecs.cs
@@ -10,10 +10,10 @@
         void DoIt(Guid id);
     }
 
-    public class StrictFakeSpecs
+    public static class StrictFakeSpecs
     {
         [Scenario]
-        public void RepeatedAssertion(
+        public static void RepeatedAssertion(
             IMyInterface fake,
             Exception exception)
         {

--- a/Source/FakeItEasy.Specs/UnconfiguredFakeSpecs.cs
+++ b/Source/FakeItEasy.Specs/UnconfiguredFakeSpecs.cs
@@ -4,10 +4,10 @@
     using FluentAssertions;
     using Xbehave;
 
-    public class UnconfiguredFakeSpecs
+    public static class UnconfiguredFakeSpecs
     {
         [Scenario]
-        public void VirtualMethod(
+        public static void VirtualMethod(
             MakesVirtualCallInConstructor fake)
         {
             "when faking a class with a virtual method"
@@ -27,7 +27,7 @@
         }
 
         [Scenario]
-        public void VirtualProperties(
+        public static void VirtualProperties(
             FakedClass fake)
         {
             "when faking a class with virtual properties"


### PR DESCRIPTION
It seems they work as static classes, so why not?
I'm about to hit a few Specs in my work on #461 and preferred not to mix the "staticking" in with the other changes.