### PR TITLE
refactor: clean up some specs

### DIFF
--- a/Source/FakeItEasy.Specs/FakeConfiguratorSpecs.cs
+++ b/Source/FakeItEasy.Specs/FakeConfiguratorSpecs.cs
@@ -15,6 +15,9 @@
 
             "then it should be configured"
                 .x(() => fake.ID.Should().BeGreaterThan(0));
+
+            "and it should be configured before its constructor is run"
+                .x(() => fake.Timestamp.Should().Be(DomainEventFakeConfigurator.ConfiguredTimestamp));
         }
 
         [Scenario]
@@ -27,21 +30,12 @@
             "then it should be configured by the one with higher priority"
                 .x(() => fake.ID.Should().Be(-99));
         }
-
-        [Scenario]
-        public static void DuringConstruction(
-            RobotRunsAmokEvent fake)
-        {
-            "when creating a fake that has a matching configurator"
-                .x(() => fake = A.Fake<RobotRunsAmokEvent>());
-
-            "then it should be configured before its constructor is run"
-                .x(() => fake.Timestamp.Should().Be(RobotRunsAmokEventFakeConfigurator.ConfiguredTimestamp));
-        }
     }
 
     public class DomainEventFakeConfigurator : IFakeConfigurator
     {
+        public static readonly DateTime ConfiguredTimestamp = new DateTime(1997, 8, 29, 2, 14, 03);
+
         private int nextID = 1;
 
         public int Priority
@@ -56,19 +50,18 @@
 
         public void ConfigureFake(object fakeObject)
         {
-            ((DomainEvent)fakeObject).ID = this.nextID++;
+            var domainEvent = (DomainEvent)fakeObject;
+            domainEvent.ID = this.nextID++;
+            A.CallTo(() => domainEvent.CalculateTimestamp()).Returns(ConfiguredTimestamp);
         }
     }
 
     public class RobotRunsAmokEventFakeConfigurator : FakeConfigurator<RobotRunsAmokEvent>
     {
-        public static readonly DateTime ConfiguredTimestamp = new DateTime(1997, 8, 29, 2, 14, 03);
-
         protected override void ConfigureFake(RobotRunsAmokEvent fakeObject)
         {
             if (fakeObject != null)
             {
-                A.CallTo(() => fakeObject.CalculateTimestamp()).Returns(ConfiguredTimestamp);
                 fakeObject.ID = -99;
             }
         }

--- a/Source/FakeItEasy.Specs/FakeConfiguratorSpecs.cs
+++ b/Source/FakeItEasy.Specs/FakeConfiguratorSpecs.cs
@@ -7,14 +7,13 @@
     public static class FakeConfiguratorSpecs
     {
         [Scenario]
-        public static void DefinedFakeConfigurator()
+        public static void DefinedFakeConfigurator(
+            RobotActivatedEvent fake)
         {
-            RobotActivatedEvent fake = null;
-
-            "when a fake configurator is defined for a set of types"
+            "when creating a fake that has a matching configurator"
                 .x(() => fake = A.Fake<RobotActivatedEvent>());
 
-            "it should configure the fake"
+            "then it should be configured"
                 .x(() => fake.ID.Should().BeGreaterThan(0));
         }
 
@@ -22,10 +21,10 @@
         public static void FakeConfiguratorPriority(
             RobotRunsAmokEvent fake)
         {
-            "when two fake configurators apply to the same type"
+            "when creating a fake that has two matching configurators"
                 .x(() => fake = A.Fake<RobotRunsAmokEvent>());
 
-            "it should use the one with higher priority"
+            "then it should be configured by the one with higher priority"
                 .x(() => fake.ID.Should().Be(-99));
         }
 
@@ -33,10 +32,10 @@
         public static void DuringConstruction(
             RobotRunsAmokEvent fake)
         {
-            "when configuring a method called by a constructor"
+            "when creating a fake that has a matching configurator"
                 .x(() => fake = A.Fake<RobotRunsAmokEvent>());
 
-            "it should use the configured behavior in the constructor"
+            "then it should be configured before its constructor is run"
                 .x(() => fake.Timestamp.Should().Be(RobotRunsAmokEventFakeConfigurator.ConfiguredTimestamp));
         }
     }

--- a/Source/FakeItEasy.Specs/FakeScopeSpecs.cs
+++ b/Source/FakeItEasy.Specs/FakeScopeSpecs.cs
@@ -14,17 +14,10 @@
             MakesVirtualCallInConstructor fake)
         {
             "given an object container"
-                .x(() =>
-                {
-                    fakeObjectContainer = A.Fake<IFakeObjectContainer>();
-                    A.CallTo(() => fakeObjectContainer.ConfigureFake(A<Type>._, A<object>._))
-                        .Invokes(
-                            (Type t, object options) =>
-                                A.CallTo(options).WithReturnType<string>().Returns("configured value in fake scope"));
-                });
+                .x(() => fakeObjectContainer = CreateFakeObjectContainer("configured value in fake scope"));
 
             "and a fake scope using that container"
-                .x(() => scope = Fake.CreateScope(fakeObjectContainer));
+                .x(context => scope = Fake.CreateScope(fakeObjectContainer).Using(context));
 
             "when a fake is created inside the scope"
                 .x(() => fake = A.Fake<MakesVirtualCallInConstructor>());
@@ -38,13 +31,41 @@
 
             "and the object container's configuration should be used after the constructor"
                 .x(() => fake.VirtualMethod("call after constructor").Should().Be("configured value in fake scope"));
+        }
 
-            "and the object container's configuration should not be used outside the scope"
+        [Scenario]
+        public static void UsingFakeOutsideOfScope(
+            IFakeObjectContainer fakeObjectContainer,
+            MakesVirtualCallInConstructor fake,
+            string virtualMethodValueOutsideOfScope)
+        {
+            "given an object container"
+                .x(() => fakeObjectContainer = CreateFakeObjectContainer("configured value in fake scope"));
+
+            "and a fake created within a scope using that container"
                 .x(() =>
                 {
-                    scope.Dispose();
-                    fake.VirtualMethod("call outside scope").Should().Be(string.Empty);
+                    using (Fake.CreateScope(fakeObjectContainer))
+                    {
+                        fake = A.Fake<MakesVirtualCallInConstructor>();
+                    }
                 });
+
+            "when the fake is accessed outside the scope"
+                .x(() => virtualMethodValueOutsideOfScope = fake.VirtualMethod("call outside scope"));
+
+            "then the object container's configuration should not be used"
+                .x(() => virtualMethodValueOutsideOfScope.Should().Be(string.Empty));
+        }
+
+        private static IFakeObjectContainer CreateFakeObjectContainer(string stringMethodValue)
+        {
+            var fakeObjectContainer = A.Fake<IFakeObjectContainer>();
+            A.CallTo(() => fakeObjectContainer.ConfigureFake(A<Type>._, A<object>._))
+                .Invokes(
+                    (Type t, object options) =>
+                        A.CallTo(options).WithReturnType<string>().Returns(stringMethodValue));
+            return fakeObjectContainer;
         }
     }
 }

--- a/Source/FakeItEasy.Specs/FixtureInitializationSpecs.cs
+++ b/Source/FakeItEasy.Specs/FixtureInitializationSpecs.cs
@@ -19,14 +19,14 @@
             "then the sut should be set"
                 .x(() => fixture.Sut.Should().NotBeNull());
 
-            "and dependencies of the same type should be the same instance"
-                .x(() => fixture.Sut.Foo.Should().BeSameAs(fixture.Sut.Foo2));
-
             "and dependencies should be injected into the sut from the fixture"
                 .x(() => fixture.Sut.Foo.Should().BeSameAs(fixture.Foo));
 
             "and dependencies should be injected into the sut even when not available in fixture"
                 .x(() => fixture.Sut.ServiceProvider.Should().NotBeNull());
+
+            "and dependencies of the same type should be the same instance"
+                .x(() => fixture.Sut.Foo.Should().BeSameAs(fixture.Sut.Foo2));
         }
 
         public class ExampleFixture

--- a/Source/FakeItEasy.Specs/FixtureInitializationSpecs.cs
+++ b/Source/FakeItEasy.Specs/FixtureInitializationSpecs.cs
@@ -7,28 +7,26 @@
 
     public static class FixtureInitializationSpecs
     {
-        public static ExampleFixture Fixture { get; set; }
-
         [Scenario]
-        public static void Initialization()
+        public static void Initialization(ExampleFixture fixture)
         {
-            "establish"
-                .x(() => Fixture = new ExampleFixture());
+            "given a test fixture"
+                .x(() => fixture = new ExampleFixture());
 
-            "when initializing fixture"
-                .x(() => Fake.InitializeFixture(Fixture));
+            "when the fixture is initialized"
+                .x(() => Fake.InitializeFixture(fixture));
 
-            "it should set sut"
-                .x(() => Fixture.Sut.Should().NotBeNull());
+            "then the sut should be set"
+                .x(() => fixture.Sut.Should().NotBeNull());
 
-            "it should use the same instance when more than one dependency is of the same type"
-                .x(() => Fixture.Sut.Foo.Should().BeSameAs(Fixture.Sut.Foo2));
+            "and dependencies of the same type should be the same instance"
+                .x(() => fixture.Sut.Foo.Should().BeSameAs(fixture.Sut.Foo2));
 
-            "it should inject fake from fixture"
-                .x(() => Fixture.Sut.Foo.Should().BeSameAs(Fixture.Foo));
+            "and dependencies should be injected into the sut from the fixture"
+                .x(() => fixture.Sut.Foo.Should().BeSameAs(fixture.Foo));
 
-            "it should inject fake when not available in fixture"
-                .x(() => Fixture.Sut.ServiceProvider.Should().NotBeNull());
+            "and dependencies should be injected into the sut even when not available in fixture"
+                .x(() => fixture.Sut.ServiceProvider.Should().NotBeNull());
         }
 
         public class ExampleFixture


### PR DESCRIPTION
I'll be touching these in my #461 work, so I figured I might as well get them tidy beforehand. 
Besides, I get to practice my BDD naming.
First commit is a fairly straightforward "name things better". 
Then I saw improvements for `FixtureInitializationSpecs` and `FakeConfiguratorSpecs`