### PR TITLE
Prevent redefining the behavior for a call rule

### DIFF
--- a/Source/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
+++ b/Source/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
@@ -1,6 +1,8 @@
 ﻿namespace FakeItEasy.Specs
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
+    using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using Xbehave;
 
@@ -91,6 +93,31 @@
                         subject.MightReturnAKnownValue(out value);
                         value.Should().BeEquivalentTo(knownOutput);
                     });
+        }
+
+        [Scenario]
+        public static void MultipleAssignOutAndRefParameters(
+            IHaveAnOut subject,
+            string outValue,
+            Exception exception)
+        {
+            "establish"
+                .x(() => subject = A.Fake<IHaveAnOut>());
+
+            "when configuring a fake to assign out and ref parameters multiple times"
+                .x(() =>
+                {
+                    var callSpec =
+                        A.CallTo(() => subject.MightReturnAKnownValue(out outValue))
+                            .WithAnyArguments();
+
+                    callSpec.AssignsOutAndRefParameters(new object[] { "test1" });
+
+                    exception = Record.Exception(() => callSpec.AssignsOutAndRefParameters(new object[] { "test2" }));
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
         }
     }
 }

--- a/Source/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/Source/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -1,5 +1,8 @@
 ﻿namespace FakeItEasy.Specs
 {
+    using System;
+    using FakeItEasy.Configuration;
+    using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using Xbehave;
 
@@ -86,6 +89,90 @@
 
             "it should invoke the callback"
                 .x(() => callbackWasInvoked.Should().BeTrue());
+        }
+
+        [Scenario]
+        public static void MultipleReturns(
+            IFoo fake,
+            IReturnValueArgumentValidationConfiguration<int> configuration,
+            Exception exception)
+        {
+            "establish"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "when configuring multiple returns on the same configuration"
+                .x(() =>
+                {
+                    configuration = A.CallTo(() => fake.Baz());
+                    configuration.Returns(42);
+                    exception = Record.Exception(() => configuration.Returns(0));
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
+        }
+
+        [Scenario]
+        public static void ReturnThenThrow(
+            IFoo fake,
+            IReturnValueArgumentValidationConfiguration<int> configuration,
+            Exception exception)
+        {
+            "establish"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "when configuring a return then a throw on the same configuration"
+                .x(() =>
+                {
+                    configuration = A.CallTo(() => fake.Baz());
+                    configuration.Returns(42);
+                    exception = Record.Exception(() => configuration.Throws(new Exception()));
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
+        }
+
+        [Scenario]
+        public static void ReturnThenCallsBaseMethod(
+            IFoo fake,
+            IReturnValueArgumentValidationConfiguration<int> configuration,
+            Exception exception)
+        {
+            "establish"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "when configuring a return then base method call on the same configuration"
+                .x(() =>
+                {
+                    configuration = A.CallTo(() => fake.Baz());
+                    configuration.Returns(42);
+                    exception = Record.Exception(() => configuration.CallsBaseMethod());
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
+        }
+
+        [Scenario]
+        public static void MultipleThrows(
+            IFoo fake,
+            IReturnValueArgumentValidationConfiguration<int> configuration,
+            Exception exception)
+        {
+            "establish"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "when configuring a return then a throw on the same configuration"
+                .x(() =>
+                {
+                    configuration = A.CallTo(() => fake.Baz());
+                    configuration.Throws(new ArgumentNullException());
+                    exception = Record.Exception(() => configuration.Throws(new ArgumentException()));
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
         }
 
         public class BaseClass

--- a/Source/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
+++ b/Source/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
@@ -258,6 +258,22 @@ namespace FakeItEasy.Tests.Configuration
             descriptionWriter.Builder.ToString().Should().Be(expectedDescription);
         }
 
+        [Test]
+        public void Applicator_should_not_be_settable_more_than_once()
+        {
+            this.rule.Applicator = x => { };
+
+            Assert.Throws<InvalidOperationException>(() => this.rule.Applicator = x => { });
+        }
+
+        [Test]
+        public void OutAndRefParameterProducer_should_not_be_settable_more_than_once()
+        {
+            this.rule.OutAndRefParametersValueProducer = x => new object[0];
+
+            Assert.Throws<InvalidOperationException>(() => this.rule.OutAndRefParametersValueProducer = x => new object[] { "test" });
+        }
+
         private class TestableCallRule
             : BuildableCallRule
         {

--- a/Source/FakeItEasy.Tests/Expressions/ExpressionCallRuleTests.cs
+++ b/Source/FakeItEasy.Tests/Expressions/ExpressionCallRuleTests.cs
@@ -100,7 +100,7 @@
 
         private ExpressionCallRule CreateRule()
         {
-            return new ExpressionCallRule(this.callMatcher) { Applicator = x => { } };
+            return new ExpressionCallRule(this.callMatcher) { };
         }
     }
 }

--- a/Source/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/Source/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -12,11 +12,17 @@ namespace FakeItEasy.Configuration
         : IFakeObjectCallRule
     {
         private readonly List<Tuple<Func<IFakeObjectCall, bool>, Action<IOutputWriter>>> wherePredicates;
+        private Action<IInterceptedFakeObjectCall> applicator;
+        private bool canSetApplicator;
+        private Func<IFakeObjectCall, ICollection<object>> outAndRefParametersValueProducer;
+        private bool canSetOutAndRefParametersValueProducer;
 
         protected BuildableCallRule()
         {
             this.Actions = new LinkedList<Action<IFakeObjectCall>>();
-            this.Applicator = call => call.SetReturnValue(call.Method.ReturnType.GetDefaultValue());
+            this.applicator = call => call.SetReturnValue(call.Method.ReturnType.GetDefaultValue());
+            this.canSetApplicator = true;
+            this.canSetOutAndRefParametersValueProducer = true;
             this.wherePredicates = new List<Tuple<Func<IFakeObjectCall, bool>, Action<IOutputWriter>>>();
         }
 
@@ -24,7 +30,24 @@ namespace FakeItEasy.Configuration
         /// Gets or sets an action that is called by the Apply method to apply this
         /// rule to a fake object call.
         /// </summary>
-        public Action<IInterceptedFakeObjectCall> Applicator { get; set; }
+        public Action<IInterceptedFakeObjectCall> Applicator
+        {
+            get
+            {
+                return this.applicator;
+            }
+
+            set
+            {
+                if (!this.canSetApplicator)
+                {
+                    throw new InvalidOperationException("The behavior for this call has already been defined");
+                }
+
+                this.applicator = value;
+                this.canSetApplicator = false;
+            }
+        }
 
         /// <summary>
         /// Gets a collection of actions that should be invoked when the configured
@@ -35,7 +58,24 @@ namespace FakeItEasy.Configuration
         /// <summary>
         /// Gets or sets a function that provides values to apply to output and reference variables.
         /// </summary>
-        public Func<IFakeObjectCall, ICollection<object>> OutAndRefParametersValueProducer { get; set; }
+        public Func<IFakeObjectCall, ICollection<object>> OutAndRefParametersValueProducer
+        {
+            get
+            {
+                return this.outAndRefParametersValueProducer;
+            }
+
+            set
+            {
+                if (!this.canSetOutAndRefParametersValueProducer)
+                {
+                    throw new InvalidOperationException("How to assign out and ref parameters has already been defined for this call");
+                }
+
+                this.outAndRefParametersValueProducer = value;
+                this.canSetOutAndRefParametersValueProducer = false;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether the base method of the fake object call should be
@@ -119,6 +159,16 @@ namespace FakeItEasy.Configuration
         public abstract void UsePredicateToValidateArguments(Func<ArgumentCollection, bool> predicate);
 
         protected abstract bool OnIsApplicableTo(IFakeObjectCall fakeObjectCall);
+
+        /// <summary>
+        /// Sets the OutAndRefParametersValueProducer directly, bypassing the public setter logic, hence allowing
+        /// it to be set again later.
+        /// </summary>
+        /// <param name="value">The new value for OutAndRefParametersValueProducer.</param>
+        protected void SetOutAndRefParametersValueProducer(Func<IFakeObjectCall, ICollection<object>> value)
+        {
+            this.outAndRefParametersValueProducer = value;
+        }
 
         private static ICollection<int> GetIndexesOfOutAndRefParameters(IInterceptedFakeObjectCall fakeObjectCall)
         {

--- a/Source/FakeItEasy/Configuration/RecordingRuleBuilder.cs
+++ b/Source/FakeItEasy/Configuration/RecordingRuleBuilder.cs
@@ -14,8 +14,6 @@ namespace FakeItEasy.Configuration
         {
             this.rule = rule;
             this.wrappedBuilder = wrappedBuilder;
-
-            rule.Applicator = x => { };
         }
 
         public delegate RecordingRuleBuilder Factory(RecordedCallRule rule, FakeManager fakeObject);

--- a/Source/FakeItEasy/Expressions/ExpressionCallRule.cs
+++ b/Source/FakeItEasy/Expressions/ExpressionCallRule.cs
@@ -21,7 +21,7 @@ namespace FakeItEasy.Expressions
             Guard.AgainstNull(expressionMatcher, "expressionMatcher");
 
             this.ExpressionMatcher = expressionMatcher;
-            this.OutAndRefParametersValueProducer = expressionMatcher.GetOutAndRefParametersValueProducer();
+            this.SetOutAndRefParametersValueProducer(expressionMatcher.GetOutAndRefParametersValueProducer());
         }
         
         /// <summary>


### PR DESCRIPTION
This is in order to prevent an unsupported scenario where the user keeps
the result of A.CallTo(...) and uses it to define multiple behaviors.
Doing so would override the existing behavior, not stack the new one,
even though it's not necessarily what the user would expect. Making it
illegal prevents confusion. It remains possible to keep the result of
A.CallTo to make later calls to MustHaveHappened and friends.

See the comments in FakeItEasy/FakeItEasy#534 for more details.