### PR TITLE
Exclude dynamic assemblies from Bootstrapper Locator scan

### DIFF
--- a/Source/FakeItEasy/Core/AssemblyExtensions.cs
+++ b/Source/FakeItEasy/Core/AssemblyExtensions.cs
@@ -5,8 +5,6 @@
 
     internal static class AssemblyExtensions
     {
-        private static readonly string FakeItEasyAssemblyName = Assembly.GetExecutingAssembly().FullName;
-
         /// <summary>
         /// Determines whether an assembly references FakeItEasy.
         /// </summary>
@@ -16,7 +14,7 @@
         {
             Guard.AgainstNull(assembly, "assembly");
 
-            return assembly.GetReferencedAssemblies().Any(r => r.FullName == FakeItEasyAssemblyName);
+            return assembly.GetReferencedAssemblies().Any(r => r.FullName == TypeCatalogue.FakeItEasyAssembly.FullName);
         }
 
         /// <summary>
@@ -27,6 +25,21 @@
         public static string Name(this Assembly assembly)
         {
             return new AssemblyName(assembly.FullName).Name;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether a given assembly was generated dynamically by using reflection emit.
+        /// </summary>
+        /// <remarks>This extension works in .NET 3.5, where <c>Type.IsDynamic</c> does not exist.</remarks>
+        /// <param name="assembly">The assembly to check.</param>
+        /// <returns>Whether or not the assembly is dynamically generated.</returns>
+        public static bool IsDynamic(this Assembly assembly)
+        {
+#if NET40
+            return assembly.IsDynamic;
+#else
+            return assembly.ManifestModule.GetType().Namespace == "System.Reflection.Emit";
+#endif
         }
     }
 }

--- a/Source/FakeItEasy/Core/BootstrapperLocator.cs
+++ b/Source/FakeItEasy/Core/BootstrapperLocator.cs
@@ -25,7 +25,9 @@
             var bootstrapperInterface = typeof(IBootstrapper);
 
             var appDomainAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-            var appDomainAssembliesReferencingFakeItEasy = appDomainAssemblies.Where(assembly => assembly.ReferencesFakeItEasy());
+            var appDomainAssembliesReferencingFakeItEasy = appDomainAssemblies
+                .Where(assembly => !assembly.IsDynamic())
+                .Where(assembly => assembly.ReferencesFakeItEasy());
 
             var candidateTypes = appDomainAssembliesReferencingFakeItEasy
                 .SelectMany(assembly => assembly.GetExportedTypes())

--- a/Source/FakeItEasy/Core/TypeCatalogue.cs
+++ b/Source/FakeItEasy/Core/TypeCatalogue.cs
@@ -16,8 +16,16 @@
     /// </summary>
     internal class TypeCatalogue : ITypeCatalogue
     {
-        private static readonly Assembly FakeItEasyAssembly = Assembly.GetExecutingAssembly();
+        private static readonly Assembly ExecutingAssembly = Assembly.GetExecutingAssembly();
         private readonly List<Type> availableTypes = new List<Type>();
+
+        /// <summary>
+        /// Gets the <c>FakeItEasy</c> assembly
+        /// </summary>
+        public static Assembly FakeItEasyAssembly
+        {
+            get { return ExecutingAssembly; }
+        }
 
         /// <summary>
         /// Loads the available types into the <see cref="TypeCatalogue"/>.
@@ -62,12 +70,10 @@
             var loadedAssembliesReferencingFakeItEasy = loadedAssemblies.Where(assembly => assembly.ReferencesFakeItEasy());
 
             // Find the paths of already loaded assemblies so we don't double scan them.
-            // Checking Assembly.IsDynamic would be preferable to the business with the Namespace
-            // but the former isn't available in .NET 3.5.
             // Exclude the ReflectionOnly assemblies because we want to be able to fully load them if we need to.
             var loadedAssemblyFiles = new HashSet<string>(
                 loadedAssemblies
-                    .Where(a => !a.ReflectionOnly && a.ManifestModule.GetType().Namespace != "System.Reflection.Emit")
+                    .Where(a => !a.ReflectionOnly && !a.IsDynamic())
                     .Select(a => a.Location),
                 StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
In my hacks around Sledgehammer, I am dynamically creating objects using [Impromptu-interface](https://github.com/ekonbenefits/impromptu-interface), and using reflected FakeItEasy types to construct these object. This causes the FakeItEasy assembly to be added as a reference to the dynamic assembly, that is generated with Impromptu-interface.

This causes FIE to throw an exception during the Bootstrapper Locator scan: attempting to call `assembly.GetExportedTypes()` on a dynamic assembly throws a `NotSupportedException`. Since my generated dynamic assembly does indeed include a reference to FIE, it is picked up for scanning.

This PR adds a Where, excluding Dynamic assemblies from the scan.
