### PR TITLE
Fix style warning in TypeCatalogue docs

### DIFF
--- a/Source/FakeItEasy/Core/TypeCatalogue.cs
+++ b/Source/FakeItEasy/Core/TypeCatalogue.cs
@@ -20,7 +20,7 @@
         private readonly List<Type> availableTypes = new List<Type>();
 
         /// <summary>
-        /// Gets the <c>FakeItEasy</c> assembly
+        /// Gets the <c>FakeItEasy</c> assembly.
         /// </summary>
         public static Assembly FakeItEasyAssembly
         {


### PR DESCRIPTION
The warning was introduced in 4081cba1a0f215e840122171a34f545d6e700759.