### PR TITLE
Make FakeScope thread-safe

### DIFF
--- a/Source/FakeItEasy.Net35/Compatibility/ConcurrentDictionary.cs
+++ b/Source/FakeItEasy.Net35/Compatibility/ConcurrentDictionary.cs
@@ -51,5 +51,27 @@
                 return this.dictionary.TryGetValue(key, out value) && this.dictionary.Remove(key);
             }
         }
+
+        public bool TryAdd(TKey key, TValue value)
+        {
+            lock (this.dictionary)
+            {
+                if (this.dictionary.ContainsKey(key))
+                {
+                    return false;
+                }
+
+                this.dictionary.Add(key, value);
+                return true;
+            }
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            lock (this.dictionary)
+            {
+                return this.dictionary.TryGetValue(key, out value);
+            }
+        }
     }
 }


### PR DESCRIPTION
connects to #484

FakeScope.Current modified to store the value in ExecutionContext instead of static field. This makes all fakes a bit slower but allows child contexts in parallel tests including async code support.

There is currently a problem with pull request however. It breaks FakeScopeSpecs.CreatingFakeInsideScope scenario. Xbehave executes each step as seperate async task. So the ExecutionContext (and FakeScope with it) doesn't flow between steps. Does anyone have any idea how to fix that scenario?