### PR TITLE
Fix FxCop warnings

### DIFF
--- a/Source/FakeItEasy.Dictionary.Tests.xml
+++ b/Source/FakeItEasy.Dictionary.Tests.xml
@@ -6,6 +6,7 @@
       <Word>Taggable</Word>
       <Word>Sut</Word>
       <Word>Fakeable</Word>
+      <Word>Dummyable</Word>
       <Word>Facaded</Word>
       <Word>Baz</Word>
       <Word>Bazz</Word>

--- a/Source/FakeItEasy.Specs/TaskSpecs.cs
+++ b/Source/FakeItEasy.Specs/TaskSpecs.cs
@@ -12,8 +12,10 @@
 
             Task<int> QueryAsync();
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate in this case")]
             Task<Foo> GetFooAsync();
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate in this case")]
             Task<Bar> GetBarAsync();
         }
 


### PR DESCRIPTION
Add "dummyable" to the dictionary
Suppress warnings on `GetFooAsync` and `GetBarAsync` in `TaskSpecs`