### PR TITLE
Rationalize priority values

### DIFF
--- a/Source/FakeItEasy.IntegrationTests/DummyTests.cs
+++ b/Source/FakeItEasy.IntegrationTests/DummyTests.cs
@@ -76,9 +76,9 @@ namespace FakeItEasy.IntegrationTests
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "Tidier.")]
     public class DummyTestsDummyFactory : IDummyFactory
     {
-        public int Priority
+        public Priority Priority
         {
-            get { return 0; }
+            get { return new Priority(0); }
         }
 
         internal static int CanCreateDummyCallCount { get; private set; }

--- a/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
+++ b/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
@@ -620,6 +620,9 @@
     <Compile Include="..\FakeItEasy\OutputWriterExtensions.cs">
       <Link>OutputWriterExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\FakeItEasy\Priority.cs">
+      <Link>Priority.cs</Link>
+    </Compile>
     <Compile Include="..\FakeItEasy\Raise.cs">
       <Link>Raise.cs</Link>
     </Compile>

--- a/Source/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
+++ b/Source/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
@@ -9,7 +9,7 @@
         [Scenario]
         public static void GenericArgumentValueFormatterDefaultPriority(
             IArgumentValueFormatter formatter,
-            int priority)
+            Priority priority)
         {
             "Given an argument value formatter that extends the generic base"
                 .x(() => formatter = new SomeArgumentValueFormatter());
@@ -18,7 +18,7 @@
                 .x(() => priority = formatter.Priority);
 
             "Then it should be 0"
-                .x(() => priority.Should().Be(0));
+                .x(() => priority.Should().Be(new Priority(0)));
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Required for testing.")]

--- a/Source/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
+++ b/Source/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
@@ -1,0 +1,37 @@
+﻿namespace FakeItEasy.Specs
+{
+    using System.Diagnostics.CodeAnalysis;
+    using FluentAssertions;
+    using Xbehave;
+
+    public static class ArgumentValueFormatterSpecs
+    {
+        [Scenario]
+        public static void GenericArgumentValueFormatterDefaultPriority(
+            IArgumentValueFormatter formatter,
+            int priority)
+        {
+            "Given an argument value formatter that extends the generic base"
+                .x(() => formatter = new SomeArgumentValueFormatter());
+
+            "When I fetch the Priority"
+                .x(() => priority = formatter.Priority);
+
+            "Then it should be 0"
+                .x(() => priority.Should().Be(0));
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Required for testing.")]
+        private class SomeClass
+        {
+        }
+
+        private class SomeArgumentValueFormatter : ArgumentValueFormatter<SomeClass>
+        {
+            protected override string GetStringValue(SomeClass argumentValue)
+            {
+                return "formatted SomeClass";
+            }
+        }
+    }
+}

--- a/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
+++ b/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
@@ -31,7 +31,7 @@ namespace FakeItEasy.Specs
         [Scenario]
         public static void GenericDummyFactoryDefaultPriority(
             IDummyFactory formatter,
-            int priority)
+            Priority priority)
         {
             "Given a dummy factory that extends the generic base"
                 .x(() => formatter = new SomeDummyFactory());
@@ -40,7 +40,7 @@ namespace FakeItEasy.Specs
                 .x(() => priority = formatter.Priority);
 
             "Then it should be 0"
-                .x(() => priority.Should().Be(0));
+                .x(() => priority.Should().Be(new Priority(0)));
         }
 
         private class SomeClass
@@ -60,9 +60,9 @@ namespace FakeItEasy.Specs
     {
         private int nextID = 1;
 
-        public int Priority
+        public Priority Priority
         {
-            get { return -3; }
+            get { return new Priority(0); }
         }
 
         public bool CanCreate(Type type)
@@ -80,6 +80,11 @@ namespace FakeItEasy.Specs
 
     public class RobotRunsAmokEventDummyFactory : DummyFactory<RobotRunsAmokEvent>
     {
+        public override Priority Priority
+        {
+            get { return new Priority(3); }
+        }
+
         protected override RobotRunsAmokEvent Create()
         {
             return new RobotRunsAmokEvent { ID = -17 };

--- a/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
+++ b/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
@@ -27,6 +27,33 @@ namespace FakeItEasy.Specs
             "it should use the one with higher priority"
                 .x(() => dummy.ID.Should().Be(-17));
         }
+
+        [Scenario]
+        public static void GenericDummyFactoryDefaultPriority(
+            IDummyFactory formatter,
+            int priority)
+        {
+            "Given a dummy factory that extends the generic base"
+                .x(() => formatter = new SomeDummyFactory());
+
+            "When I fetch the Priority"
+                .x(() => priority = formatter.Priority);
+
+            "Then it should be 0"
+                .x(() => priority.Should().Be(0));
+        }
+
+        private class SomeClass
+        {
+        }
+
+        private class SomeDummyFactory : DummyFactory<SomeClass>
+        {
+            protected override SomeClass Create()
+            {
+                return new SomeClass();
+            }
+        }
     }
 
     public class DomainEventDummyFactory : IDummyFactory

--- a/Source/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/Source/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -71,6 +71,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArgumentValueFormatterSpecs.cs" />
     <Compile Include="AssertingOnSetOnlyPropertiesSpecs.cs" />
     <Compile Include="TaskSpecs.cs" />
     <Compile Include="ConfigurationSpecs.cs" />

--- a/Source/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
+++ b/Source/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
@@ -158,7 +158,7 @@ namespace FakeItEasy.Specs
         [Scenario]
         public void GenericFakeOptionsBuilderDefaultPriority(
             IFakeOptionsBuilder builder,
-            int priority)
+            Priority priority)
         {
             "Given an options builder that extends the generic base"
                 .x(() => builder = new SomeClassOptionsBuilder());
@@ -167,7 +167,7 @@ namespace FakeItEasy.Specs
                 .x(() => priority = builder.Priority);
 
             "Then it should be 0"
-                .x(() => priority.Should().Be(0));
+                .x(() => priority.Should().Be(new Priority(0)));
         }
 
         [Scenario]
@@ -232,9 +232,9 @@ namespace FakeItEasy.Specs
 
     public abstract class ConventionBasedOptionsBuilder : IFakeOptionsBuilder
     {
-        public int Priority
+        public Priority Priority
         {
-            get { return 0; }
+            get { return new Priority(0); }
         }
 
         public bool CanBuildOptionsForFakeOfType(Type type)
@@ -401,9 +401,9 @@ namespace FakeItEasy.Specs
     {
         private int nextID = 1;
 
-        public int Priority
+        public Priority Priority
         {
-            get { return -1; }
+            get { return new Priority(0); }
         }
 
         public bool CanBuildOptionsForFakeOfType(Type type)
@@ -439,6 +439,11 @@ namespace FakeItEasy.Specs
     public class RobotRunsAmokEventFakeOptionsBuilder : FakeOptionsBuilder<RobotRunsAmokEvent>
     {
         public static readonly DateTime ConfiguredTimestamp = new DateTime(1997, 8, 29, 2, 14, 03);
+
+        public override Priority Priority
+        {
+            get { return new Priority(5); }
+        }
 
         protected override void BuildOptions(IFakeOptions<RobotRunsAmokEvent> options)
         {

--- a/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
+++ b/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
@@ -154,7 +154,7 @@ namespace FakeItEasy.Tests.Core
 
             // Act
             var typesWithNonNegativePriority = allArgumentValueFormatters
-                .Where(f => f.Priority >= 0)
+                .Where(f => f.Priority >= new Priority(0))
                 .Select(f => f.GetType());
 
             // Assert
@@ -171,15 +171,15 @@ namespace FakeItEasy.Tests.Core
 
         private void AddTypeFormatter(Type type, string formattedValue)
         {
-            this.AddTypeFormatter(type, formattedValue, int.MinValue);
+            this.AddTypeFormatter(type, formattedValue, short.MinValue);
         }
 
-        private void AddTypeFormatter(Type type, string formattedValue, int priority)
+        private void AddTypeFormatter(Type type, string formattedValue, short priority)
         {
             var formatter = A.Fake<IArgumentValueFormatter>();
             A.CallTo(() => formatter.ForType).Returns(type);
             A.CallTo(() => formatter.GetArgumentValueAsString(A<object>._)).Returns(formattedValue);
-            A.CallTo(() => formatter.Priority).Returns(priority);
+            A.CallTo(() => formatter.Priority).Returns(new Priority(priority));
             this.registeredTypeFormatters.Add(formatter);
         }
     }

--- a/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
+++ b/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
@@ -5,6 +5,7 @@ namespace FakeItEasy.Tests.Core
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
+    using System.Linq;
     using FakeItEasy.Core;
     using NUnit.Framework;
 
@@ -140,6 +141,27 @@ namespace FakeItEasy.Tests.Core
 
             // Assert
             Assert.That(result, Is.EqualTo("a string"));
+        }
+
+        [Test]
+        public void Provided_formatters_should_have_negative_priority()
+        {
+            // Arrange
+            var allArgumentValueFormatters = typeof(A).Assembly.GetTypes()
+                .Where(t => t.CanBeInstantiatedAs(typeof(IArgumentValueFormatter)))
+                .Select(Activator.CreateInstance)
+                .Cast<IArgumentValueFormatter>();
+
+            // Act
+            var typesWithNonNegativePriority = allArgumentValueFormatters
+                .Where(f => f.Priority >= 0)
+                .Select(f => f.GetType());
+
+            // Assert
+            Assert.That(
+                typesWithNonNegativePriority,
+                Is.Empty,
+                "because no formatters should have non-negative priority");
         }
 
         private void AddTypeFormatter<T>(string formattedValue)

--- a/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
+++ b/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
@@ -7,16 +7,14 @@ namespace FakeItEasy.Tests.Core
     using System.IO;
     using System.Linq;
     using FakeItEasy.Core;
+    using FluentAssertions;
     using NUnit.Framework;
 
     [TestFixture]
     public class ArgumentValueFormatterTests
     {
-        private ArgumentValueFormatter formatter;
-        private List<IArgumentValueFormatter> registeredTypeFormatters;
-
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Used reflectively.")]
-        private object[] specificCases = TestCases.Create(
+        private readonly object[] specificCases = TestCases.Create(
             new
             {
                 LessSpecific = typeof(object),
@@ -36,6 +34,9 @@ namespace FakeItEasy.Tests.Core
                 Value = (object)A.Fake<IFoo>()
             }).AsTestCaseSource();
 
+        private ArgumentValueFormatter formatter;
+        private List<IArgumentValueFormatter> registeredTypeFormatters;
+
         [SetUp]
         public void Setup()
         {
@@ -53,7 +54,7 @@ namespace FakeItEasy.Tests.Core
             var description = this.formatter.GetArgumentValueAsString(null);
 
             // Assert
-            Assert.That(description, Is.EqualTo("<NULL>"));
+            description.Should().Be("<NULL>");
         }
 
         [Test]
@@ -65,7 +66,7 @@ namespace FakeItEasy.Tests.Core
             var description = this.formatter.GetArgumentValueAsString(1);
 
             // Assert
-            Assert.That(description, Is.EqualTo("1"));
+            description.Should().Be("1");
         }
 
         [Test]
@@ -78,7 +79,7 @@ namespace FakeItEasy.Tests.Core
             var result = this.formatter.GetArgumentValueAsString(new DateTime(2000, 1, 1));
 
             // Assert
-            Assert.That(result, Is.EqualTo("Y2K"));
+            result.Should().Be("Y2K");
         }
 
         [Test]
@@ -91,7 +92,7 @@ namespace FakeItEasy.Tests.Core
             var result = this.formatter.GetArgumentValueAsString(new MemoryStream());
 
             // Assert
-            Assert.That(result, Is.EqualTo("stream"));
+            result.Should().Be("stream");
         }
 
         [TestCaseSource("specificCases")]
@@ -119,7 +120,7 @@ namespace FakeItEasy.Tests.Core
             var result = this.formatter.GetArgumentValueAsString("string value");
 
             // Assert
-            Assert.That(result, Is.EqualTo("high priority"));
+            result.Should().Be("high priority");
         }
 
         [TestCase("", Result = "string.Empty")]
@@ -140,7 +141,7 @@ namespace FakeItEasy.Tests.Core
             var result = this.formatter.GetArgumentValueAsString("string value");
 
             // Assert
-            Assert.That(result, Is.EqualTo("a string"));
+            result.Should().Be("a string");
         }
 
         [Test]
@@ -176,11 +177,11 @@ namespace FakeItEasy.Tests.Core
 
         private void AddTypeFormatter(Type type, string formattedValue, short priority)
         {
-            var formatter = A.Fake<IArgumentValueFormatter>();
-            A.CallTo(() => formatter.ForType).Returns(type);
-            A.CallTo(() => formatter.GetArgumentValueAsString(A<object>._)).Returns(formattedValue);
-            A.CallTo(() => formatter.Priority).Returns(new Priority(priority));
-            this.registeredTypeFormatters.Add(formatter);
+            var newFormatter = A.Fake<IArgumentValueFormatter>();
+            A.CallTo(() => newFormatter.ForType).Returns(type);
+            A.CallTo(() => newFormatter.GetArgumentValueAsString(A<object>._)).Returns(formattedValue);
+            A.CallTo(() => newFormatter.Priority).Returns(new Priority(priority));
+            this.registeredTypeFormatters.Add(newFormatter);
         }
     }
 }

--- a/Source/FakeItEasy.Tests/Core/DummyFactoryTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DummyFactoryTests.cs
@@ -49,7 +49,7 @@ namespace FakeItEasy.Tests.Core
 
             // Act
             var typesWithNonNegativePriority = allDummyFactories
-                .Where(f => f.Priority >= 0)
+                .Where(f => f.Priority >= new Priority(0))
                 .Select(f => f.GetType());
 
             // Assert

--- a/Source/FakeItEasy.Tests/Core/DummyFactoryTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DummyFactoryTests.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy.Tests.Core
 {
     using System;
     using System.Globalization;
+    using System.Linq;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using NUnit.Framework;
@@ -35,6 +36,24 @@ namespace FakeItEasy.Tests.Core
                 .BeAnExceptionOfType<ArgumentException>()
                 .WithMessage(expectedMessage)
                 .And.ParamName.Should().Be("type");
+        }
+
+        [Test]
+        public void Provided_factories_should_have_negative_priority()
+        {
+            // Arrange
+            var allDummyFactories = typeof(A).Assembly.GetTypes()
+                .Where(t => t.CanBeInstantiatedAs(typeof(IDummyFactory)))
+                .Select(Activator.CreateInstance)
+                .Cast<IDummyFactory>();
+
+            // Act
+            var typesWithNonNegativePriority = allDummyFactories
+                .Where(f => f.Priority >= 0)
+                .Select(f => f.GetType());
+
+            // Assert
+            typesWithNonNegativePriority.Should().BeEmpty("because no factories should have non-negative priority");
         }
 
         public class SomeType

--- a/Source/FakeItEasy.Tests/Core/DynamicContainerTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DynamicContainerTests.cs
@@ -116,9 +116,9 @@ namespace FakeItEasy.Tests.Core
 
         public class OptionsBuilderForTypeWithDummyFactory : IFakeOptionsBuilder
         {
-            public int Priority
+            public Priority Priority
             {
-                get { return 0; }
+                get { return new Priority(0); }
             }
 
             public bool CanBuildOptionsForFakeOfType(Type type)
@@ -139,9 +139,9 @@ namespace FakeItEasy.Tests.Core
 
         public class DuplicateOptionsBuilderForTypeWithDummyFactory : IFakeOptionsBuilder
         {
-            public int Priority
+            public Priority Priority
             {
-                get { return 0; }
+                get { return new Priority(0); }
             }
 
             public bool CanBuildOptionsForFakeOfType(Type type)

--- a/Source/FakeItEasy.Tests/FakeItEasy.Tests.csproj
+++ b/Source/FakeItEasy.Tests/FakeItEasy.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DefaultBootstrapperTests.cs" />
     <Compile Include="FakeOptionsBuilderTests.cs" />
     <Compile Include="OutAndRefParametersConfigurationExtensionsTests.cs" />
+    <Compile Include="PriorityTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Configuration\DefaultInterceptionAsserterTests.cs" />
     <Compile Include="AutoInitializedFixture.cs" />

--- a/Source/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
+++ b/Source/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
@@ -34,7 +34,7 @@ namespace FakeItEasy.Tests
 
             // Act
             var typesWithNonNegativePriority = allOptionsBuilders
-                .Where(f => f.Priority >= 0)
+                .Where(f => f.Priority >= new Priority(0))
                 .Select(f => f.GetType());
 
             // Assert

--- a/Source/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
+++ b/Source/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy.Tests
 {
     using System;
+    using System.Linq;
     using FakeItEasy.Creation;
     using FluentAssertions;
     using NUnit.Framework;
@@ -20,6 +21,24 @@ namespace FakeItEasy.Tests
             // Assert
             exception.Should().BeAnExceptionOfType<InvalidOperationException>()
                 .WithMessage("Specified type 'System.String' is not valid. Only 'FakeItEasy.Tests.FakeOptionsBuilderTests' is allowed.");
+        }
+
+        [Test]
+        public void Provided_options_builders_should_have_negative_priority()
+        {
+            // Arrange
+            var allOptionsBuilders = typeof(A).Assembly.GetTypes()
+                .Where(t => t.CanBeInstantiatedAs(typeof(IFakeOptionsBuilder)))
+                .Select(Activator.CreateInstance)
+                .Cast<IFakeOptionsBuilder>();
+
+            // Act
+            var typesWithNonNegativePriority = allOptionsBuilders
+                .Where(f => f.Priority >= 0)
+                .Select(f => f.GetType());
+
+            // Assert
+            typesWithNonNegativePriority.Should().BeEmpty("because no options builders should have non-negative priority");
         }
 
         private class FakeOptionsBuilderTestsOptionsBuilder : FakeOptionsBuilder<FakeOptionsBuilderTests>

--- a/Source/FakeItEasy.Tests/PriorityTests.cs
+++ b/Source/FakeItEasy.Tests/PriorityTests.cs
@@ -1,0 +1,214 @@
+﻿namespace FakeItEasy.Tests
+{
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class PriorityTests
+    {
+        private static readonly Priority[][] EqualCases =
+        {
+            new[] { BytePriority(0), BytePriority(0) },
+            new[] { BytePriority(1), BytePriority(1) },
+            new[] { BytePriority(byte.MaxValue), BytePriority(byte.MaxValue) },
+            new[] { ShortPriority(short.MinValue), ShortPriority(short.MinValue) },
+            new[] { ShortPriority(-1), ShortPriority(-1) },
+            new[] { ShortPriority(0), ShortPriority(0) },
+            new[] { ShortPriority(1), ShortPriority(1) },
+            new[] { ShortPriority(short.MaxValue), ShortPriority(short.MaxValue) },
+            new[] { BytePriority(0), ShortPriority(0) },
+            new[] { ShortPriority(1), BytePriority(1) },
+        };
+
+        private static readonly Priority[][] LessThanCases =
+        {
+            new[] { BytePriority(0), BytePriority(1) },
+            new[] { BytePriority(0), BytePriority(2) },
+            new[] { BytePriority(0), BytePriority(byte.MaxValue) },
+            new[] { ShortPriority(0), BytePriority(1) },
+            new[] { BytePriority(0), ShortPriority(2) },
+            new[] { BytePriority(byte.MaxValue), ShortPriority(short.MaxValue) },
+            new[] { ShortPriority(-1), BytePriority(0) },
+            new[] { ShortPriority(short.MinValue), ShortPriority(-1) },
+            new[] { ShortPriority(short.MinValue), BytePriority(5) },
+        };
+
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Required for testing.")]
+        private static readonly short[] VariousPriorityValues =
+        {
+            0,
+            1,
+            -1,
+            -19,
+            47,
+            byte.MaxValue,
+            short.MaxValue,
+            short.MaxValue,
+        };
+
+        [TestCaseSource("EqualCases")]
+        public void CompareTo_should_return_zero_when_left_value_is_equal_to_right(Priority left, Priority right)
+        {
+            left.CompareTo(right).Should().Be(0);
+        }
+
+        [TestCaseSource("LessThanCases")]
+        public void CompareTo_should_return_negative_when_left_value_is_less_than_right(Priority left, Priority right)
+        {
+            left.CompareTo(right).Should().BeNegative();
+        }
+
+        [TestCaseSource("GreaterThanCases")]
+        public void CompareTo_should_return_positive_when_left_value_is_greater_than_right(Priority left, Priority right)
+        {
+            left.CompareTo(right).Should().BePositive();
+        }
+
+        [TestCaseSource("LessThanCases")]
+        public void Less_than_operator_should_return_true_when_left_value_is_less_than_right(Priority left, Priority right)
+        {
+            (left < right).Should().BeTrue();
+        }
+
+        [TestCaseSource("GreaterThanOrEqualToCases")]
+        public void Less_than_operator_should_return_false_when_left_value_is_not_less_than_right(Priority left, Priority right)
+        {
+            (left < right).Should().BeFalse();
+        }
+
+        [TestCaseSource("GreaterThanCases")]
+        public void Greater_than_operator_should_return_true_when_left_value_is_greater_than_right(Priority left, Priority right)
+        {
+            (left > right).Should().BeTrue();
+        }
+
+        [TestCaseSource("LessThanOrEqualToCases")]
+        public void Greater_than_operator_should_return_false_when_left_value_is_not_greater_than_right(Priority left, Priority right)
+        {
+            (left > right).Should().BeFalse();
+        }
+
+        [TestCaseSource("LessThanOrEqualToCases")]
+        public void Less_than_or_equal_to_operator_should_return_true_when_left_value_is_less_than_or_equal_to_right(Priority left, Priority right)
+        {
+            (left <= right).Should().BeTrue();
+        }
+
+        [TestCaseSource("GreaterThanCases")]
+        public void Less_than_or_equal_to_operator_should_return_false_when_left_value_is_greater_than_right(Priority left, Priority right)
+        {
+            (left <= right).Should().BeFalse();
+        }
+
+        [TestCaseSource("GreaterThanOrEqualToCases")]
+        public void Greater_than_or_equal_to_operator_should_return_true_when_left_value_is_greater_than_or_equal_to_right(Priority left, Priority right)
+        {
+            (left >= right).Should().BeTrue();
+        }
+
+        [TestCaseSource("LessThanCases")]
+        public void Greater_than_or_equal_to_operator_should_return_false_when_left_value_is_less_than_right(Priority left, Priority right)
+        {
+            (left >= right).Should().BeFalse();
+        }
+
+        [TestCaseSource("EqualCases")]
+        public void Equals_priority_should_return_true_when_this_value_is_equal_to_other(Priority left, Priority right)
+        {
+            left.Equals(right).Should().BeTrue();
+        }
+
+        [TestCaseSource("UnequalCases")]
+        public void Equals_priority_should_return_false_when_this_value_is_not_equal_to_other(Priority left, Priority right)
+        {
+            left.Equals(right).Should().BeFalse();
+        }
+
+        [TestCaseSource("EqualCases")]
+        public void Equals_object_should_return_true_when_this_value_is_equal_to_other(Priority left, object right)
+        {
+            left.Equals(right).Should().BeTrue();
+        }
+
+        [TestCaseSource("UnequalCases")]
+        public void Equals_object_should_return_false_when_this_value_is_not_equal_to_other(Priority left, object right)
+        {
+            left.Equals(right).Should().BeFalse();
+        }
+
+        [TestCase(null)]
+        [TestCase(0)]
+        [TestCase((byte)0)]
+        [TestCase("zero")]
+        public void Equals_object_should_return_false_when_other_value_is_another_type(object other)
+        {
+            ShortPriority(0).Equals(other).Should().BeFalse();
+        }
+
+        [TestCaseSource("VariousPriorityValues")]
+        public void GetHashCode_should_return_same_hash_code_as_wrapped_value(short value)
+        {
+            ShortPriority(value).GetHashCode().Should().Be(value.GetHashCode());
+        }
+
+        [TestCaseSource("EqualCases")]
+        public void Equality_operator_should_return_true_when_left_value_is_equal_to_right(Priority left, Priority right)
+        {
+            (left == right).Should().BeTrue();
+        }
+
+        [TestCaseSource("UnequalCases")]
+        public void Equality_operator_should_return_false_when_left_value_is_not_equal_to_right(Priority left, Priority right)
+        {
+            (left == right).Should().BeFalse();
+        }
+
+        [TestCaseSource("EqualCases")]
+        public void Inequality_operator_should_return_false_when_left_value_is_equal_to_right(Priority left, Priority right)
+        {
+            (left != right).Should().BeFalse();
+        }
+
+        [TestCaseSource("UnequalCases")]
+        public void Inequality_operator_should_return_true_when_left_value_is_not_equal_to_right(Priority left, Priority right)
+        {
+            (left != right).Should().BeTrue();
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Required for testing.")]
+        private static IEnumerable<Priority[]> UnequalCases()
+        {
+            return LessThanCases.Concat(GreaterThanCases());
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Required for testing.")]
+        private static IEnumerable<Priority[]> GreaterThanCases()
+        {
+            return LessThanCases.Select(pair => new[] { pair[1], pair[0] });
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Required for testing.")]
+        private static IEnumerable<Priority[]> LessThanOrEqualToCases()
+        {
+            return LessThanCases.Concat(EqualCases);
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Required for testing.")]
+        private static IEnumerable<Priority[]> GreaterThanOrEqualToCases()
+        {
+            return GreaterThanCases().Concat(EqualCases);
+        }
+
+        private static Priority BytePriority(byte value)
+        {
+            return new Priority(value);
+        }
+
+        private static Priority ShortPriority(short value)
+        {
+            return new Priority(value);
+        }
+    }
+}

--- a/Source/FakeItEasy/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/ArgumentValueFormatter.cs
@@ -22,9 +22,10 @@ namespace FakeItEasy
         /// registered for the same type the one with the highest
         /// priority is used.
         /// </summary>
+        /// <remarks>The default implementation returns a priority of <code>0</code>.</remarks>
         public virtual int Priority
         {
-            get { return int.MinValue; }
+            get { return 0; }
         }
 
         /// <summary>

--- a/Source/FakeItEasy/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/ArgumentValueFormatter.cs
@@ -19,13 +19,12 @@ namespace FakeItEasy
 
         /// <summary>
         /// Gets the priority of the formatter, when two formatters are
-        /// registered for the same type the one with the highest
-        /// priority is used.
+        /// registered for the same type the one with the highest priority value is used.
         /// </summary>
-        /// <remarks>The default implementation returns a priority of <code>0</code>.</remarks>
-        public virtual int Priority
+        /// <remarks>The default implementation returns a priority with value <code>0</code>.</remarks>
+        public virtual Priority Priority
         {
-            get { return 0; }
+            get { return new Priority(0); }
         }
 
         /// <summary>

--- a/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -107,9 +107,9 @@ namespace FakeItEasy.Core
         private class DefaultFormatter
             : ArgumentValueFormatter<object>
         {
-            public override int Priority
+            public override Priority Priority
             {
-                get { return -1; }
+                get { return new Priority(-1); }
             }
 
             protected override string GetStringValue(object argumentValue)
@@ -123,9 +123,9 @@ namespace FakeItEasy.Core
         private class DefaultStringFormatter
             : ArgumentValueFormatter<string>
         {
-            public override int Priority
+            public override Priority Priority
             {
-                get { return -1; }
+                get { return new Priority(-1); }
             }
 
             protected override string GetStringValue(string argumentValue)

--- a/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -107,6 +107,11 @@ namespace FakeItEasy.Core
         private class DefaultFormatter
             : ArgumentValueFormatter<object>
         {
+            public override int Priority
+            {
+                get { return -1; }
+            }
+
             protected override string GetStringValue(object argumentValue)
             {
                 Guard.AgainstNull(argumentValue, "argumentValue");
@@ -118,6 +123,11 @@ namespace FakeItEasy.Core
         private class DefaultStringFormatter
             : ArgumentValueFormatter<string>
         {
+            public override int Priority
+            {
+                get { return -1; }
+            }
+
             protected override string GetStringValue(string argumentValue)
             {
                 Guard.AgainstNull(argumentValue, "argumentValue");

--- a/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -31,15 +31,14 @@ namespace FakeItEasy.Core
 
             var argumentType = argumentValue.GetType();
 
-            IArgumentValueFormatter formatter;
-            formatter = this.cachedFormatters.GetOrAdd(argumentType, this.ResolveTypeFormatter);
+            var formatter = this.cachedFormatters.GetOrAdd(argumentType, this.ResolveTypeFormatter);
 
             return formatter.GetArgumentValueAsString(argumentValue);
         }
 
         private static int GetDistanceFromKnownType(Type comparedType, Type knownType)
         {
-            if (knownType.Equals(comparedType))
+            if (knownType == comparedType)
             {
                 return 0;
             }
@@ -53,7 +52,7 @@ namespace FakeItEasy.Core
             var currentType = knownType.BaseType;
             while (currentType != null)
             {
-                if (currentType.Equals(comparedType))
+                if (currentType == comparedType)
                 {
                     return distance;
                 }

--- a/Source/FakeItEasy/DummyFactory.cs
+++ b/Source/FakeItEasy/DummyFactory.cs
@@ -13,10 +13,10 @@ namespace FakeItEasy
         /// Gets the priority of the dummy factory. When multiple factories that apply to the same type are registered,
         /// the one with the highest priority is used.
         /// </summary>
-        /// <remarks>The default implementation returns <c>0</c>.</remarks>
-        public virtual int Priority
+        /// <remarks>The default implementation returns a priority with value <code>0</code>.</remarks>
+        public virtual Priority Priority
         {
-            get { return 0; }
+            get { return new Priority(0); }
         }
 
         /// <summary>

--- a/Source/FakeItEasy/FakeItEasy.csproj
+++ b/Source/FakeItEasy/FakeItEasy.csproj
@@ -108,6 +108,7 @@
     <Compile Include="MethodBaseExtensions.cs" />
     <Compile Include="OutAndRefParametersConfigurationExtensions.cs" />
     <Compile Include="Core\DelegateRaiser.cs" />
+    <Compile Include="Priority.cs" />
     <Compile Include="TaskHelper.cs" />
     <Compile Include="TypeExtensions.cs" />
     <Compile Include="StringBuilderExtensions.cs" />

--- a/Source/FakeItEasy/FakeOptionsBuilder.cs
+++ b/Source/FakeItEasy/FakeOptionsBuilder.cs
@@ -12,12 +12,12 @@ namespace FakeItEasy
     {
         /// <summary>
         /// Gets the priority of the options builder. When multiple builders that apply to
-        /// the same type are registered, the one with the highest priority is used.
+        /// the same type are registered, the one with the highest priority value is used.
         /// </summary>
-        /// <remarks>Defaults to <c>0</c>. Negative values are reserved for use by FakeItEasy.</remarks>
-        public virtual int Priority
+        /// <remarks>The default implementation returns a priority with value <code>0</code>.</remarks>
+        public virtual Priority Priority
         {
-            get { return 0; }
+            get { return new Priority(0); }
         }
 
         /// <summary>

--- a/Source/FakeItEasy/IArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/IArgumentValueFormatter.cs
@@ -15,10 +15,9 @@ namespace FakeItEasy
 
         /// <summary>
         /// Gets the priority of the formatter, when two formatters are
-        /// registered for the same type the one with the highest
-        /// priority is used.
+        /// registered for the same type the one with the highest priority value is used.
         /// </summary>
-        int Priority { get; }
+        Priority Priority { get; }
 
         /// <summary>
         /// Gets a string representing the specified argument value.

--- a/Source/FakeItEasy/IDummyFactory.cs
+++ b/Source/FakeItEasy/IDummyFactory.cs
@@ -9,9 +9,9 @@ namespace FakeItEasy
     {
         /// <summary>
         /// Gets the priority of the dummy factory. When multiple factories that apply to the same type are registered,
-        /// the one with the highest priority is used.
+        /// the one with the highest priority value is used.
         /// </summary>
-        int Priority { get; }
+        Priority Priority { get; }
 
         /// <summary>
         /// Whether or not this object can create a dummy of type <paramref name="type"/>.

--- a/Source/FakeItEasy/IFakeOptionsBuilder.cs
+++ b/Source/FakeItEasy/IFakeOptionsBuilder.cs
@@ -10,10 +10,9 @@ namespace FakeItEasy
     {
         /// <summary>
         /// Gets the priority of the options builder. When multiple builders that apply to
-        /// the same type are registered, the one with the highest priority is used.
+        /// the same type are registered, the one with the highest priority value is used.
         /// </summary>
-        /// <remarks>Negative values are reserved for use by FakeItEasy.</remarks>
-        int Priority { get; }
+        Priority Priority { get; }
 
         /// <summary>
         /// Whether or not this object can build options for a Fake of type <paramref name="type"/>.

--- a/Source/FakeItEasy/Priority.cs
+++ b/Source/FakeItEasy/Priority.cs
@@ -1,0 +1,169 @@
+﻿namespace FakeItEasy
+{
+    using System;
+
+    /// <summary>
+    /// Indicates precedence between otherwise indistinguishable options, for example when deciding
+    /// which <see cref="IDummyFactory"/> should be used to create a Dummy of a given type.
+    /// In making such decisions, the higher-valued <c>Priority</c> will be used.
+    /// </summary>
+    public struct Priority : IComparable<Priority>, IEquatable<Priority>
+    {
+        private readonly short value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Priority"/> struct.
+        /// </summary>
+        /// <param name="value">The value of the <c>Priority</c>.</param>
+        /// <returns>A new <c>Priority</c> with the specified value.</returns>
+        public Priority(byte value)
+        {
+            this.value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Priority"/> struct.
+        /// </summary>
+        /// <param name="value">The value of the <c>Priority</c>.</param>
+        /// <returns>A new <c>Priority</c> with the specified value.</returns>
+        /// <remarks>
+        /// This constructor is provided to allow internal FakeItEasy classes
+        /// to construct negative-valued Priorities, while clients of FakeItEasy are
+        /// restricted to nonnegative values.
+        /// </remarks>
+        internal Priority(short value)
+        {
+            this.value = value;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is less than that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is less than that of <c>right</c>.</returns>
+        public static bool operator <(Priority left, Priority right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is greater than that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is greater than that of <c>right</c>.</returns>
+        public static bool operator >(Priority left, Priority right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is less than or equal to that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is less than or equal to that of <c>right</c>.</returns>
+        public static bool operator <=(Priority left, Priority right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is greater than or equal to that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is greater than or equal to that of <c>right</c>.</returns>
+        public static bool operator >=(Priority left, Priority right)
+        {
+            return left.CompareTo(right) >= 0;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is equal to that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is equal to that of <c>right</c>.</returns>
+        public static bool operator ==(Priority left, Priority right)
+        {
+            return left.CompareTo(right) == 0;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> not equal to that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is not equal to that of <c>right</c>.</returns>
+        public static bool operator !=(Priority left, Priority right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns an integer that indicates
+        /// whether the current instance precedes, follows, or occurs in the same position in the sort order as the
+        /// other object.
+        /// </summary>
+        /// <returns>
+        /// A value that indicates the relative order of the objects
+        /// being compared. The return value has these meanings:
+        /// <list type="bullet">
+        ///   <item>less than zero: this instance precedes <paramref name="other"/> in the sort order</item>
+        ///   <item>zero: this instance occurs in the same position in the sort order as <paramref name="other"/></item>
+        ///   <item>greater than zero: this instance follows <paramref name="other"/> in the sort order</item>
+        /// </list>
+        /// </returns>
+        /// <param name="other">An object to compare with this instance.</param>
+        public int CompareTo(Priority other)
+        {
+            return this.value.CompareTo(other.value);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <returns> True if the current object is equal to the <paramref name="other"/> parameter; otherwise, false.</returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(Priority other)
+        {
+            return this.CompareTo(other) == 0;
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object.
+        /// </summary>
+        /// <returns> True if the current object is equal to the <paramref name="obj"/> parameter; otherwise, false.</returns>
+        /// <param name="obj">An object to compare with this object.</param>
+        public override bool Equals(object obj)
+        {
+            return (obj is Priority) && this.Equals((Priority)obj);
+        }
+
+        /// <summary>
+        /// Gets a hash code for the current object.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            return this.value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns a textual description of this <see cref="Priority"/>.
+        /// </summary>
+        /// <returns>A textual description of this <see cref="Priority"/>, indicating its value.</returns>
+        public override string ToString()
+        {
+            return "Priority<" + this.value + ">";
+        }
+    }
+}


### PR DESCRIPTION
Fixes #525.
Using a custom Priority type to ensure clients can only make non-negative priorities.