### PR TITLE
Rationalize priority values

### DIFF
--- a/Source/FakeItEasy.IntegrationTests/DummyTests.cs
+++ b/Source/FakeItEasy.IntegrationTests/DummyTests.cs
@@ -76,9 +76,9 @@ namespace FakeItEasy.IntegrationTests
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "Tidier.")]
     public class DummyTestsDummyFactory : IDummyFactory
     {
-        public int Priority
+        public Priority Priority
         {
-            get { return 0; }
+            get { return Priority.Default; }
         }
 
         internal static int CanCreateDummyCallCount { get; private set; }

--- a/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
+++ b/Source/FakeItEasy.Net35/FakeItEasy.Net35.csproj
@@ -620,6 +620,9 @@
     <Compile Include="..\FakeItEasy\OutputWriterExtensions.cs">
       <Link>OutputWriterExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\FakeItEasy\Priority.cs">
+      <Link>Priority.cs</Link>
+    </Compile>
     <Compile Include="..\FakeItEasy\Raise.cs">
       <Link>Raise.cs</Link>
     </Compile>

--- a/Source/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
+++ b/Source/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
@@ -9,7 +9,7 @@
         [Scenario]
         public static void GenericArgumentValueFormatterDefaultPriority(
             IArgumentValueFormatter formatter,
-            int priority)
+            Priority priority)
         {
             "Given an argument value formatter that does not override priority"
                 .x(() => formatter = new SomeArgumentValueFormatter());
@@ -17,8 +17,8 @@
             "When I fetch the Priority"
                 .x(() => priority = formatter.Priority);
 
-            "Then it should be 0"
-                .x(() => priority.Should().Be(0));
+            "Then it should be the default priority"
+                .x(() => priority.Should().Be(Priority.Default));
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Required for testing.")]

--- a/Source/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
+++ b/Source/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
@@ -1,0 +1,37 @@
+﻿namespace FakeItEasy.Specs
+{
+    using System.Diagnostics.CodeAnalysis;
+    using FluentAssertions;
+    using Xbehave;
+
+    public static class ArgumentValueFormatterSpecs
+    {
+        [Scenario]
+        public static void GenericArgumentValueFormatterDefaultPriority(
+            IArgumentValueFormatter formatter,
+            int priority)
+        {
+            "Given an argument value formatter that does not override priority"
+                .x(() => formatter = new SomeArgumentValueFormatter());
+
+            "When I fetch the Priority"
+                .x(() => priority = formatter.Priority);
+
+            "Then it should be 0"
+                .x(() => priority.Should().Be(0));
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Required for testing.")]
+        private class SomeClass
+        {
+        }
+
+        private class SomeArgumentValueFormatter : ArgumentValueFormatter<SomeClass>
+        {
+            protected override string GetStringValue(SomeClass argumentValue)
+            {
+                return "formatted SomeClass";
+            }
+        }
+    }
+}

--- a/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
+++ b/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
@@ -31,7 +31,7 @@ namespace FakeItEasy.Specs
         [Scenario]
         public static void GenericDummyFactoryDefaultPriority(
             IDummyFactory formatter,
-            int priority)
+            Priority priority)
         {
             "Given an argument value formatter that does not override priority"
                 .x(() => formatter = new SomeDummyFactory());
@@ -39,8 +39,8 @@ namespace FakeItEasy.Specs
             "When I fetch the Priority"
                 .x(() => priority = formatter.Priority);
 
-            "Then it should be 0"
-                .x(() => priority.Should().Be(0));
+            "Then it should be the default priority"
+                .x(() => priority.Should().Be(Priority.Default));
         }
 
         private class SomeClass
@@ -60,9 +60,9 @@ namespace FakeItEasy.Specs
     {
         private int nextID = 1;
 
-        public int Priority
+        public Priority Priority
         {
-            get { return -3; }
+            get { return Priority.Default; }
         }
 
         public bool CanCreate(Type type)
@@ -80,6 +80,11 @@ namespace FakeItEasy.Specs
 
     public class RobotRunsAmokEventDummyFactory : DummyFactory<RobotRunsAmokEvent>
     {
+        public override Priority Priority
+        {
+            get { return new Priority(3); }
+        }
+
         protected override RobotRunsAmokEvent Create()
         {
             return new RobotRunsAmokEvent { ID = -17 };

--- a/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
+++ b/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
@@ -10,10 +10,10 @@ namespace FakeItEasy.Specs
         public static void DummyFactoryUsage(
             RobotActivatedEvent dummy)
         {
-            "when a dummy factory is defined for a set of types"
+            "When I create a Dummy of a type that has a dummy factory defined"
                 .x(() => dummy = A.Dummy<RobotActivatedEvent>());
 
-            "it should create a dummy from the factory"
+            "Then it should be created by the factory"
                 .x(() => dummy.ID.Should().BeGreaterThan(0));
         }
 
@@ -21,10 +21,13 @@ namespace FakeItEasy.Specs
         public static void DummyFactoryPriority(
             RobotRunsAmokEvent dummy)
         {
-            "when two dummy factories apply to the same type"
+            "Given two dummy factories which apply to the same type"
+                .x(() => { }); // see DomainEventDummyFactory and RobotRunsAmokEventDummyFactory
+
+            "When I create a Dummy of the type"
                 .x(() => dummy = A.Dummy<RobotRunsAmokEvent>());
 
-            "it should use the one with higher priority"
+            "Then it should be created by the factory with the higher priority"
                 .x(() => dummy.ID.Should().Be(-17));
         }
 

--- a/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
+++ b/Source/FakeItEasy.Specs/DummyFactorySpecs.cs
@@ -27,6 +27,33 @@ namespace FakeItEasy.Specs
             "it should use the one with higher priority"
                 .x(() => dummy.ID.Should().Be(-17));
         }
+
+        [Scenario]
+        public static void GenericDummyFactoryDefaultPriority(
+            IDummyFactory formatter,
+            int priority)
+        {
+            "Given an argument value formatter that does not override priority"
+                .x(() => formatter = new SomeDummyFactory());
+
+            "When I fetch the Priority"
+                .x(() => priority = formatter.Priority);
+
+            "Then it should be 0"
+                .x(() => priority.Should().Be(0));
+        }
+
+        private class SomeClass
+        {
+        }
+
+        private class SomeDummyFactory : DummyFactory<SomeClass>
+        {
+            protected override SomeClass Create()
+            {
+                return new SomeClass();
+            }
+        }
     }
 
     public class DomainEventDummyFactory : IDummyFactory

--- a/Source/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/Source/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -75,6 +75,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArgumentValueFormatterSpecs.cs" />
     <Compile Include="AssertingOnSetOnlyPropertiesSpecs.cs" />
     <Compile Include="TaskSpecs.cs" />
     <Compile Include="ConfigurationSpecs.cs" />

--- a/Source/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
+++ b/Source/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
@@ -158,7 +158,7 @@ namespace FakeItEasy.Specs
         [Scenario]
         public void GenericFakeOptionsBuilderDefaultPriority(
             IFakeOptionsBuilder builder,
-            int priority)
+            Priority priority)
         {
             "Given a fake options builder that does not override priority"
                 .x(() => builder = new SomeClassOptionsBuilder());
@@ -166,8 +166,8 @@ namespace FakeItEasy.Specs
             "When the default priority is fetched"
                 .x(() => priority = builder.Priority);
 
-            "Then it should be 0"
-                .x(() => priority.Should().Be(0));
+            "Then it should be the default priority"
+                .x(() => priority.Should().Be(Priority.Default));
         }
 
         [Scenario]
@@ -232,9 +232,9 @@ namespace FakeItEasy.Specs
 
     public abstract class ConventionBasedOptionsBuilder : IFakeOptionsBuilder
     {
-        public int Priority
+        public Priority Priority
         {
-            get { return 0; }
+            get { return Priority.Default; }
         }
 
         public bool CanBuildOptionsForFakeOfType(Type type)
@@ -401,9 +401,9 @@ namespace FakeItEasy.Specs
     {
         private int nextID = 1;
 
-        public int Priority
+        public Priority Priority
         {
-            get { return -1; }
+            get { return Priority.Default; }
         }
 
         public bool CanBuildOptionsForFakeOfType(Type type)
@@ -439,6 +439,11 @@ namespace FakeItEasy.Specs
     public class RobotRunsAmokEventFakeOptionsBuilder : FakeOptionsBuilder<RobotRunsAmokEvent>
     {
         public static readonly DateTime ConfiguredTimestamp = new DateTime(1997, 8, 29, 2, 14, 03);
+
+        public override Priority Priority
+        {
+            get { return new Priority(5); }
+        }
 
         protected override void BuildOptions(IFakeOptions<RobotRunsAmokEvent> options)
         {

--- a/Source/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
+++ b/Source/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
@@ -160,7 +160,7 @@ namespace FakeItEasy.Specs
             IFakeOptionsBuilder builder,
             int priority)
         {
-            "Given an options builder that extends the generic base"
+            "Given a fake options builder that does not override priority"
                 .x(() => builder = new SomeClassOptionsBuilder());
 
             "When the default priority is fetched"

--- a/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
+++ b/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
@@ -5,6 +5,7 @@ namespace FakeItEasy.Tests.Core
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
+    using System.Linq;
     using FakeItEasy.Core;
     using NUnit.Framework;
 
@@ -140,6 +141,27 @@ namespace FakeItEasy.Tests.Core
 
             // Assert
             Assert.That(result, Is.EqualTo("a string"));
+        }
+
+        [Test]
+        public void Built_in_formatters_should_have_negative_priority()
+        {
+            // Arrange
+            var allArgumentValueFormatters = typeof(A).Assembly.GetTypes()
+                .Where(t => t.CanBeInstantiatedAs(typeof(IArgumentValueFormatter)))
+                .Select(Activator.CreateInstance)
+                .Cast<IArgumentValueFormatter>();
+
+            // Act
+            var typesWithNonNegativePriority = allArgumentValueFormatters
+                .Where(f => f.Priority >= 0)
+                .Select(f => f.GetType());
+
+            // Assert
+            Assert.That(
+                typesWithNonNegativePriority,
+                Is.Empty,
+                "because no built-in formatters should have non-negative priority");
         }
 
         private void AddTypeFormatter<T>(string formattedValue)

--- a/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
+++ b/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
@@ -112,8 +112,8 @@ namespace FakeItEasy.Tests.Core
         public void Should_use_formatter_with_highest_priority_when_multiple_exists_for_the_same_type()
         {
             // Arrange
-            this.AddTypeFormatter(typeof(string), "low priority", 0);
-            this.AddTypeFormatter(typeof(string), "high priority", 1);
+            this.AddTypeFormatter(typeof(string), "low priority", new Priority(0));
+            this.AddTypeFormatter(typeof(string), "high priority", new Priority(1));
 
             // Act
             var result = this.formatter.GetArgumentValueAsString("string value");
@@ -133,8 +133,8 @@ namespace FakeItEasy.Tests.Core
         public void Should_prefer_exact_type_formatter_to_interface_formatter()
         {
             // Arrange
-            this.AddTypeFormatter(typeof(IEnumerable), "an enumerable", 0);
-            this.AddTypeFormatter(typeof(string), "a string", 0);
+            this.AddTypeFormatter(typeof(IEnumerable), "an enumerable");
+            this.AddTypeFormatter(typeof(string), "a string");
 
             // Act
             var result = this.formatter.GetArgumentValueAsString("string value");
@@ -144,7 +144,7 @@ namespace FakeItEasy.Tests.Core
         }
 
         [Test]
-        public void Built_in_formatters_should_have_negative_priority()
+        public void Built_in_formatters_should_have_lower_than_default_priority()
         {
             // Arrange
             var allArgumentValueFormatters = typeof(A).Assembly.GetTypes()
@@ -154,14 +154,14 @@ namespace FakeItEasy.Tests.Core
 
             // Act
             var typesWithNonNegativePriority = allArgumentValueFormatters
-                .Where(f => f.Priority >= 0)
+                .Where(f => f.Priority >= Priority.Default)
                 .Select(f => f.GetType());
 
             // Assert
             Assert.That(
                 typesWithNonNegativePriority,
                 Is.Empty,
-                "because no built-in formatters should have non-negative priority");
+                "because no built-in formatters should have priority equal to or greater than the default");
         }
 
         private void AddTypeFormatter<T>(string formattedValue)
@@ -171,10 +171,10 @@ namespace FakeItEasy.Tests.Core
 
         private void AddTypeFormatter(Type type, string formattedValue)
         {
-            this.AddTypeFormatter(type, formattedValue, int.MinValue);
+            this.AddTypeFormatter(type, formattedValue, Priority.Default);
         }
 
-        private void AddTypeFormatter(Type type, string formattedValue, int priority)
+        private void AddTypeFormatter(Type type, string formattedValue, Priority priority)
         {
             var formatter = A.Fake<IArgumentValueFormatter>();
             A.CallTo(() => formatter.ForType).Returns(type);

--- a/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
+++ b/Source/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
@@ -7,16 +7,14 @@ namespace FakeItEasy.Tests.Core
     using System.IO;
     using System.Linq;
     using FakeItEasy.Core;
+    using FluentAssertions;
     using NUnit.Framework;
 
     [TestFixture]
     public class ArgumentValueFormatterTests
     {
-        private ArgumentValueFormatter formatter;
-        private List<IArgumentValueFormatter> registeredTypeFormatters;
-
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Used reflectively.")]
-        private object[] specificCases = TestCases.Create(
+        private readonly object[] specificCases = TestCases.Create(
             new
             {
                 LessSpecific = typeof(object),
@@ -36,6 +34,9 @@ namespace FakeItEasy.Tests.Core
                 Value = (object)A.Fake<IFoo>()
             }).AsTestCaseSource();
 
+        private ArgumentValueFormatter formatter;
+        private List<IArgumentValueFormatter> registeredTypeFormatters;
+
         [SetUp]
         public void Setup()
         {
@@ -53,7 +54,7 @@ namespace FakeItEasy.Tests.Core
             var description = this.formatter.GetArgumentValueAsString(null);
 
             // Assert
-            Assert.That(description, Is.EqualTo("<NULL>"));
+            description.Should().Be("<NULL>");
         }
 
         [Test]
@@ -65,7 +66,7 @@ namespace FakeItEasy.Tests.Core
             var description = this.formatter.GetArgumentValueAsString(1);
 
             // Assert
-            Assert.That(description, Is.EqualTo("1"));
+            description.Should().Be("1");
         }
 
         [Test]
@@ -78,7 +79,7 @@ namespace FakeItEasy.Tests.Core
             var result = this.formatter.GetArgumentValueAsString(new DateTime(2000, 1, 1));
 
             // Assert
-            Assert.That(result, Is.EqualTo("Y2K"));
+            result.Should().Be("Y2K");
         }
 
         [Test]
@@ -91,7 +92,7 @@ namespace FakeItEasy.Tests.Core
             var result = this.formatter.GetArgumentValueAsString(new MemoryStream());
 
             // Assert
-            Assert.That(result, Is.EqualTo("stream"));
+            result.Should().Be("stream");
         }
 
         [TestCaseSource("specificCases")]
@@ -105,7 +106,7 @@ namespace FakeItEasy.Tests.Core
             var result = this.formatter.GetArgumentValueAsString(value);
 
             // Assert
-            Assert.That(result, Is.EqualTo("more specific"), "Less specific type formatter was used.");
+            result.Should().Be("more specific");
         }
 
         [Test]
@@ -119,7 +120,7 @@ namespace FakeItEasy.Tests.Core
             var result = this.formatter.GetArgumentValueAsString("string value");
 
             // Assert
-            Assert.That(result, Is.EqualTo("high priority"));
+            result.Should().Be("high priority");
         }
 
         [TestCase("", Result = "string.Empty")]
@@ -140,7 +141,7 @@ namespace FakeItEasy.Tests.Core
             var result = this.formatter.GetArgumentValueAsString("string value");
 
             // Assert
-            Assert.That(result, Is.EqualTo("a string"));
+            result.Should().Be("a string");
         }
 
         [Test]
@@ -158,10 +159,7 @@ namespace FakeItEasy.Tests.Core
                 .Select(f => f.GetType());
 
             // Assert
-            Assert.That(
-                typesWithNonNegativePriority,
-                Is.Empty,
-                "because no built-in formatters should have priority equal to or greater than the default");
+            typesWithNonNegativePriority.Should().BeEmpty("because no built-in formatters should have priority equal to or greater than the default");
         }
 
         private void AddTypeFormatter<T>(string formattedValue)
@@ -176,11 +174,11 @@ namespace FakeItEasy.Tests.Core
 
         private void AddTypeFormatter(Type type, string formattedValue, Priority priority)
         {
-            var formatter = A.Fake<IArgumentValueFormatter>();
-            A.CallTo(() => formatter.ForType).Returns(type);
-            A.CallTo(() => formatter.GetArgumentValueAsString(A<object>._)).Returns(formattedValue);
-            A.CallTo(() => formatter.Priority).Returns(priority);
-            this.registeredTypeFormatters.Add(formatter);
+            var newFormatter = A.Fake<IArgumentValueFormatter>();
+            A.CallTo(() => newFormatter.ForType).Returns(type);
+            A.CallTo(() => newFormatter.GetArgumentValueAsString(A<object>._)).Returns(formattedValue);
+            A.CallTo(() => newFormatter.Priority).Returns(priority);
+            this.registeredTypeFormatters.Add(newFormatter);
         }
     }
 }

--- a/Source/FakeItEasy.Tests/Core/DummyFactoryTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DummyFactoryTests.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy.Tests.Core
 {
     using System;
     using System.Globalization;
+    using System.Linq;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using NUnit.Framework;
@@ -35,6 +36,24 @@ namespace FakeItEasy.Tests.Core
                 .BeAnExceptionOfType<ArgumentException>()
                 .WithMessage(expectedMessage)
                 .And.ParamName.Should().Be("type");
+        }
+
+        [Test]
+        public void Built_in_factories_should_have_negative_priority()
+        {
+            // Arrange
+            var allDummyFactories = typeof(A).Assembly.GetTypes()
+                .Where(t => t.CanBeInstantiatedAs(typeof(IDummyFactory)))
+                .Select(Activator.CreateInstance)
+                .Cast<IDummyFactory>();
+
+            // Act
+            var typesWithNonNegativePriority = allDummyFactories
+                .Where(f => f.Priority >= 0)
+                .Select(f => f.GetType());
+
+            // Assert
+            typesWithNonNegativePriority.Should().BeEmpty("because no built-in factories should have non-negative priority");
         }
 
         public class SomeType

--- a/Source/FakeItEasy.Tests/Core/DummyFactoryTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DummyFactoryTests.cs
@@ -39,7 +39,7 @@ namespace FakeItEasy.Tests.Core
         }
 
         [Test]
-        public void Built_in_factories_should_have_negative_priority()
+        public void Built_in_factories_should_have_lower_than_default_priority()
         {
             // Arrange
             var allDummyFactories = typeof(A).Assembly.GetTypes()
@@ -49,11 +49,11 @@ namespace FakeItEasy.Tests.Core
 
             // Act
             var typesWithNonNegativePriority = allDummyFactories
-                .Where(f => f.Priority >= 0)
+                .Where(f => f.Priority >= Priority.Default)
                 .Select(f => f.GetType());
 
             // Assert
-            typesWithNonNegativePriority.Should().BeEmpty("because no built-in factories should have non-negative priority");
+            typesWithNonNegativePriority.Should().BeEmpty("because no built-in factories should have priority equal to or greater than the default");
         }
 
         public class SomeType

--- a/Source/FakeItEasy.Tests/Core/DynamicContainerTests.cs
+++ b/Source/FakeItEasy.Tests/Core/DynamicContainerTests.cs
@@ -116,9 +116,9 @@ namespace FakeItEasy.Tests.Core
 
         public class OptionsBuilderForTypeWithDummyFactory : IFakeOptionsBuilder
         {
-            public int Priority
+            public Priority Priority
             {
-                get { return 0; }
+                get { return Priority.Default; }
             }
 
             public bool CanBuildOptionsForFakeOfType(Type type)
@@ -139,9 +139,9 @@ namespace FakeItEasy.Tests.Core
 
         public class DuplicateOptionsBuilderForTypeWithDummyFactory : IFakeOptionsBuilder
         {
-            public int Priority
+            public Priority Priority
             {
-                get { return 0; }
+                get { return Priority.Default; }
             }
 
             public bool CanBuildOptionsForFakeOfType(Type type)

--- a/Source/FakeItEasy.Tests/FakeItEasy.Tests.csproj
+++ b/Source/FakeItEasy.Tests/FakeItEasy.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="DefaultBootstrapperTests.cs" />
     <Compile Include="FakeOptionsBuilderTests.cs" />
     <Compile Include="OutAndRefParametersConfigurationExtensionsTests.cs" />
+    <Compile Include="PriorityTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Configuration\DefaultInterceptionAsserterTests.cs" />
     <Compile Include="AutoInitializedFixture.cs" />

--- a/Source/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
+++ b/Source/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
@@ -24,7 +24,7 @@ namespace FakeItEasy.Tests
         }
 
         [Test]
-        public void Built_in_options_builders_should_have_negative_priority()
+        public void Built_in_options_builders_should_have_lower_than_default_priority()
         {
             // Arrange
             var allOptionsBuilders = typeof(A).Assembly.GetTypes()
@@ -34,11 +34,11 @@ namespace FakeItEasy.Tests
 
             // Act
             var typesWithNonNegativePriority = allOptionsBuilders
-                .Where(f => f.Priority >= 0)
+                .Where(f => f.Priority >= Priority.Default)
                 .Select(f => f.GetType());
 
             // Assert
-            typesWithNonNegativePriority.Should().BeEmpty("because no built-in options builders should have non-negative priority");
+            typesWithNonNegativePriority.Should().BeEmpty("because no built-in options builders should have priority equal to or greater than the default");
         }
 
         private class FakeOptionsBuilderTestsOptionsBuilder : FakeOptionsBuilder<FakeOptionsBuilderTests>

--- a/Source/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
+++ b/Source/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy.Tests
 {
     using System;
+    using System.Linq;
     using FakeItEasy.Creation;
     using FluentAssertions;
     using NUnit.Framework;
@@ -20,6 +21,24 @@ namespace FakeItEasy.Tests
             // Assert
             exception.Should().BeAnExceptionOfType<InvalidOperationException>()
                 .WithMessage("Specified type 'System.String' is not valid. Only 'FakeItEasy.Tests.FakeOptionsBuilderTests' is allowed.");
+        }
+
+        [Test]
+        public void Built_in_options_builders_should_have_negative_priority()
+        {
+            // Arrange
+            var allOptionsBuilders = typeof(A).Assembly.GetTypes()
+                .Where(t => t.CanBeInstantiatedAs(typeof(IFakeOptionsBuilder)))
+                .Select(Activator.CreateInstance)
+                .Cast<IFakeOptionsBuilder>();
+
+            // Act
+            var typesWithNonNegativePriority = allOptionsBuilders
+                .Where(f => f.Priority >= 0)
+                .Select(f => f.GetType());
+
+            // Assert
+            typesWithNonNegativePriority.Should().BeEmpty("because no built-in options builders should have non-negative priority");
         }
 
         private class FakeOptionsBuilderTestsOptionsBuilder : FakeOptionsBuilder<FakeOptionsBuilderTests>

--- a/Source/FakeItEasy.Tests/PriorityTests.cs
+++ b/Source/FakeItEasy.Tests/PriorityTests.cs
@@ -1,0 +1,198 @@
+﻿namespace FakeItEasy.Tests
+{
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    public class PriorityTests
+    {
+        private static readonly Priority[][] EqualCases =
+        {
+            new[] { Priority.Default, Priority.Default },
+            new[] { Priority.Default, new Priority(0) },
+            new[] { new Priority(0), new Priority(0) },
+            new[] { new Priority(1), new Priority(1) },
+            new[] { new Priority(byte.MaxValue), new Priority(byte.MaxValue) },
+            new[] { Priority.Internal, Priority.Internal },
+        };
+
+        private static readonly Priority[][] LessThanCases =
+        {
+            new[] { Priority.Internal, Priority.Default },
+            new[] { Priority.Internal, new Priority(0) },
+            new[] { Priority.Internal, new Priority(1) },
+            new[] { Priority.Default, new Priority(1) },
+            new[] { new Priority(1), new Priority(2) },
+            new[] { new Priority(3), new Priority(byte.MaxValue) }
+        };
+
+        [TestCaseSource("EqualCases")]
+        public void CompareTo_should_return_zero_when_left_value_is_equal_to_right(Priority left, Priority right)
+        {
+            left.CompareTo(right).Should().Be(0);
+        }
+
+        [TestCaseSource("LessThanCases")]
+        public void CompareTo_should_return_negative_when_left_value_is_less_than_right(Priority left, Priority right)
+        {
+            left.CompareTo(right).Should().BeNegative();
+        }
+
+        [TestCaseSource("GreaterThanCases")]
+        public void CompareTo_should_return_positive_when_left_value_is_greater_than_right(Priority left, Priority right)
+        {
+            left.CompareTo(right).Should().BePositive();
+        }
+
+        [TestCaseSource("LessThanCases")]
+        public void Less_than_operator_should_return_true_when_left_value_is_less_than_right(Priority left, Priority right)
+        {
+            (left < right).Should().BeTrue();
+        }
+
+        [TestCaseSource("GreaterThanOrEqualToCases")]
+        public void Less_than_operator_should_return_false_when_left_value_is_not_less_than_right(Priority left, Priority right)
+        {
+            (left < right).Should().BeFalse();
+        }
+
+        [TestCaseSource("GreaterThanCases")]
+        public void Greater_than_operator_should_return_true_when_left_value_is_greater_than_right(Priority left, Priority right)
+        {
+            (left > right).Should().BeTrue();
+        }
+
+        [TestCaseSource("LessThanOrEqualToCases")]
+        public void Greater_than_operator_should_return_false_when_left_value_is_not_greater_than_right(Priority left, Priority right)
+        {
+            (left > right).Should().BeFalse();
+        }
+
+        [TestCaseSource("LessThanOrEqualToCases")]
+        public void Less_than_or_equal_to_operator_should_return_true_when_left_value_is_less_than_or_equal_to_right(Priority left, Priority right)
+        {
+            (left <= right).Should().BeTrue();
+        }
+
+        [TestCaseSource("GreaterThanCases")]
+        public void Less_than_or_equal_to_operator_should_return_false_when_left_value_is_greater_than_right(Priority left, Priority right)
+        {
+            (left <= right).Should().BeFalse();
+        }
+
+        [TestCaseSource("GreaterThanOrEqualToCases")]
+        public void
+            Greater_than_or_equal_to_operator_should_return_true_when_left_value_is_greater_than_or_equal_to_right(Priority left, Priority right)
+        {
+            (left >= right).Should().BeTrue();
+        }
+
+        [TestCaseSource("LessThanCases")]
+        public void Greater_than_or_equal_to_operator_should_return_false_when_left_value_is_less_than_right(Priority left, Priority right)
+        {
+            (left >= right).Should().BeFalse();
+        }
+
+        [TestCaseSource("EqualCases")]
+        public void Equals_priority_should_return_true_when_this_value_is_equal_to_other(Priority left, Priority right)
+        {
+            left.Equals(right).Should().BeTrue();
+        }
+
+        [TestCaseSource("UnequalCases")]
+        public void Equals_priority_should_return_false_when_this_value_is_not_equal_to_other(Priority left, Priority right)
+        {
+            left.Equals(right).Should().BeFalse();
+        }
+
+        [TestCaseSource("EqualCases")]
+        public void Equals_object_should_return_true_when_this_value_is_equal_to_other(Priority left, object right)
+        {
+            left.Equals(right).Should().BeTrue();
+        }
+
+        [TestCaseSource("UnequalCases")]
+        public void Equals_object_should_return_false_when_this_value_is_not_equal_to_other(Priority left, object right)
+        {
+            left.Equals(right).Should().BeFalse();
+        }
+
+        [TestCase(null)]
+        [TestCase(0)]
+        [TestCase((byte)0)]
+        [TestCase("zero")]
+        public void Equals_object_should_return_false_when_other_value_is_another_type(object other)
+        {
+            Priority.Default.Equals(other).Should().BeFalse();
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(47)]
+        [TestCase(byte.MaxValue)]
+        public void GetHashCode_should_return_same_hash_code_as_wrapped_value(byte value)
+        {
+            new Priority(value).GetHashCode().Should().Be(value.GetHashCode());
+        }
+
+        [Test]
+        public void GetHashCode_for_internal_priority_should_return_same_hash_code_as_negative_one()
+        {
+            Priority.Internal.GetHashCode().Should().Be(-1.GetHashCode());
+        }
+
+        [TestCaseSource("EqualCases")]
+        public void Equality_operator_should_return_true_when_left_value_is_equal_to_right(Priority left, Priority right)
+        {
+            (left == right).Should().BeTrue();
+        }
+
+        [TestCaseSource("UnequalCases")]
+        public void Equality_operator_should_return_false_when_left_value_is_not_equal_to_right(Priority left, Priority right)
+        {
+            (left == right).Should().BeFalse();
+        }
+
+        [TestCaseSource("EqualCases")]
+        public void Inequality_operator_should_return_false_when_left_value_is_equal_to_right(Priority left, Priority right)
+        {
+            (left != right).Should().BeFalse();
+        }
+
+        [TestCaseSource("UnequalCases")]
+        public void Inequality_operator_should_return_true_when_left_value_is_not_equal_to_right(Priority left, Priority right)
+        {
+            (left != right).Should().BeTrue();
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode",
+            Justification = "Required for testing.")]
+        private static IEnumerable<Priority[]> UnequalCases()
+        {
+            return LessThanCases.Concat(GreaterThanCases());
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode",
+            Justification = "Required for testing.")]
+        private static IEnumerable<Priority[]> GreaterThanCases()
+        {
+            return LessThanCases.Select(pair => new[] { pair[1], pair[0] });
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode",
+            Justification = "Required for testing.")]
+        private static IEnumerable<Priority[]> LessThanOrEqualToCases()
+        {
+            return LessThanCases.Concat(EqualCases);
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode",
+            Justification = "Required for testing.")]
+        private static IEnumerable<Priority[]> GreaterThanOrEqualToCases()
+        {
+            return GreaterThanCases().Concat(EqualCases);
+        }
+    }
+}

--- a/Source/FakeItEasy/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/ArgumentValueFormatter.cs
@@ -19,13 +19,12 @@ namespace FakeItEasy
 
         /// <summary>
         /// Gets the priority of the formatter, when two formatters are
-        /// registered for the same type the one with the highest
-        /// priority is used.
+        /// registered for the same type the one with the highest priority value is used.
         /// </summary>
-        /// <remarks>The default implementation returns a priority of <code>0</code>.</remarks>
-        public virtual int Priority
+        /// <remarks>The default implementation returns <see cref="FakeItEasy.Priority.Default"/>.</remarks>
+        public virtual Priority Priority
         {
-            get { return 0; }
+            get { return Priority.Default; }
         }
 
         /// <summary>

--- a/Source/FakeItEasy/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/ArgumentValueFormatter.cs
@@ -22,9 +22,10 @@ namespace FakeItEasy
         /// registered for the same type the one with the highest
         /// priority is used.
         /// </summary>
+        /// <remarks>The default implementation returns a priority of <code>0</code>.</remarks>
         public virtual int Priority
         {
-            get { return int.MinValue; }
+            get { return 0; }
         }
 
         /// <summary>

--- a/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -107,6 +107,11 @@ namespace FakeItEasy.Core
         private class DefaultFormatter
             : ArgumentValueFormatter<object>
         {
+            public override int Priority
+            {
+                get { return -1; }
+            }
+
             protected override string GetStringValue(object argumentValue)
             {
                 Guard.AgainstNull(argumentValue, "argumentValue");
@@ -118,6 +123,11 @@ namespace FakeItEasy.Core
         private class DefaultStringFormatter
             : ArgumentValueFormatter<string>
         {
+            public override int Priority
+            {
+                get { return -1; }
+            }
+
             protected override string GetStringValue(string argumentValue)
             {
                 Guard.AgainstNull(argumentValue, "argumentValue");

--- a/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -107,9 +107,9 @@ namespace FakeItEasy.Core
         private class DefaultFormatter
             : ArgumentValueFormatter<object>
         {
-            public override int Priority
+            public override Priority Priority
             {
-                get { return -1; }
+                get { return Priority.Internal; }
             }
 
             protected override string GetStringValue(object argumentValue)
@@ -123,9 +123,9 @@ namespace FakeItEasy.Core
         private class DefaultStringFormatter
             : ArgumentValueFormatter<string>
         {
-            public override int Priority
+            public override Priority Priority
             {
-                get { return -1; }
+                get { return Priority.Internal; }
             }
 
             protected override string GetStringValue(string argumentValue)

--- a/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -31,15 +31,14 @@ namespace FakeItEasy.Core
 
             var argumentType = argumentValue.GetType();
 
-            IArgumentValueFormatter formatter;
-            formatter = this.cachedFormatters.GetOrAdd(argumentType, this.ResolveTypeFormatter);
+            var formatter = this.cachedFormatters.GetOrAdd(argumentType, this.ResolveTypeFormatter);
 
             return formatter.GetArgumentValueAsString(argumentValue);
         }
 
         private static int GetDistanceFromKnownType(Type comparedType, Type knownType)
         {
-            if (knownType.Equals(comparedType))
+            if (knownType == comparedType)
             {
                 return 0;
             }
@@ -53,7 +52,7 @@ namespace FakeItEasy.Core
             var currentType = knownType.BaseType;
             while (currentType != null)
             {
-                if (currentType.Equals(comparedType))
+                if (currentType == comparedType)
                 {
                     return distance;
                 }

--- a/Source/FakeItEasy/DummyFactory.cs
+++ b/Source/FakeItEasy/DummyFactory.cs
@@ -13,10 +13,10 @@ namespace FakeItEasy
         /// Gets the priority of the dummy factory. When multiple factories that apply to the same type are registered,
         /// the one with the highest priority is used.
         /// </summary>
-        /// <remarks>The default implementation returns <c>0</c>.</remarks>
-        public virtual int Priority
+        /// <remarks>The default implementation returns <see cref="FakeItEasy.Priority.Default"/>.</remarks>
+        public virtual Priority Priority
         {
-            get { return 0; }
+            get { return Priority.Default; }
         }
 
         /// <summary>

--- a/Source/FakeItEasy/FakeItEasy.csproj
+++ b/Source/FakeItEasy/FakeItEasy.csproj
@@ -108,6 +108,7 @@
     <Compile Include="MethodBaseExtensions.cs" />
     <Compile Include="OutAndRefParametersConfigurationExtensions.cs" />
     <Compile Include="Core\DelegateRaiser.cs" />
+    <Compile Include="Priority.cs" />
     <Compile Include="TaskHelper.cs" />
     <Compile Include="TypeExtensions.cs" />
     <Compile Include="StringBuilderExtensions.cs" />

--- a/Source/FakeItEasy/FakeOptionsBuilder.cs
+++ b/Source/FakeItEasy/FakeOptionsBuilder.cs
@@ -12,12 +12,12 @@ namespace FakeItEasy
     {
         /// <summary>
         /// Gets the priority of the options builder. When multiple builders that apply to
-        /// the same type are registered, the one with the highest priority is used.
+        /// the same type are registered, the one with the highest priority value is used.
         /// </summary>
-        /// <remarks>Defaults to <c>0</c>. Negative values are reserved for use by FakeItEasy.</remarks>
-        public virtual int Priority
+        /// <remarks>The default implementation returns <see cref="FakeItEasy.Priority.Default"/>.</remarks>
+        public virtual Priority Priority
         {
-            get { return 0; }
+            get { return Priority.Default; }
         }
 
         /// <summary>

--- a/Source/FakeItEasy/IArgumentValueFormatter.cs
+++ b/Source/FakeItEasy/IArgumentValueFormatter.cs
@@ -15,10 +15,9 @@ namespace FakeItEasy
 
         /// <summary>
         /// Gets the priority of the formatter, when two formatters are
-        /// registered for the same type the one with the highest
-        /// priority is used.
+        /// registered for the same type the one with the highest priority value is used.
         /// </summary>
-        int Priority { get; }
+        Priority Priority { get; }
 
         /// <summary>
         /// Gets a string representing the specified argument value.

--- a/Source/FakeItEasy/IDummyFactory.cs
+++ b/Source/FakeItEasy/IDummyFactory.cs
@@ -9,9 +9,9 @@ namespace FakeItEasy
     {
         /// <summary>
         /// Gets the priority of the dummy factory. When multiple factories that apply to the same type are registered,
-        /// the one with the highest priority is used.
+        /// the one with the highest priority value is used.
         /// </summary>
-        int Priority { get; }
+        Priority Priority { get; }
 
         /// <summary>
         /// Whether or not this object can create a dummy of type <paramref name="type"/>.

--- a/Source/FakeItEasy/IFakeOptionsBuilder.cs
+++ b/Source/FakeItEasy/IFakeOptionsBuilder.cs
@@ -10,10 +10,9 @@ namespace FakeItEasy
     {
         /// <summary>
         /// Gets the priority of the options builder. When multiple builders that apply to
-        /// the same type are registered, the one with the highest priority is used.
+        /// the same type are registered, the one with the highest priority value is used.
         /// </summary>
-        /// <remarks>Negative values are reserved for use by FakeItEasy.</remarks>
-        int Priority { get; }
+        Priority Priority { get; }
 
         /// <summary>
         /// Whether or not this object can build options for a Fake of type <paramref name="type"/>.

--- a/Source/FakeItEasy/Priority.cs
+++ b/Source/FakeItEasy/Priority.cs
@@ -1,0 +1,193 @@
+﻿namespace FakeItEasy
+{
+    using System;
+
+    /// <summary>
+    /// Indicates precedence between otherwise indistinguishable options, for example when deciding
+    /// which <see cref="IDummyFactory"/> should be used to create a Dummy of a given type.
+    /// In making such decisions, the higher-valued <c>Priority</c> will be used.
+    /// </summary>
+    public struct Priority : IComparable<Priority>, IEquatable<Priority>
+    {
+        private static readonly Priority DefaultInstance = new Priority(0);
+
+        private static readonly Priority InternalInstance = new Priority(-1);
+
+        private readonly int value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Priority"/> struct.
+        /// </summary>
+        /// <param name="value">The value of the <c>Priority</c>.</param>
+        /// <returns>A new <c>Priority</c> with the specified value.</returns>
+        public Priority(byte value)
+        {
+            this.value = value;
+        }
+
+        private Priority(int value)
+        {
+            this.value = value;
+        }
+
+        /// <summary>
+        /// Gets the default <c>Priority</c> used by client-supplied <see cref="IDummyFactory"/>s,
+        /// <see cref="IFakeOptionsBuilder"/>s, and <see cref="IArgumentValueFormatter"/>s.
+        /// </summary>
+        /// <remarks>Equivalent to a Priority with value <c>0</c>.</remarks>
+        public static Priority Default
+        {
+            get { return DefaultInstance; }
+        }
+
+        /// <summary>
+        /// Gets the <c>Priority</c> used by all FakeItEasy-supplied <see cref="IDummyFactory"/>s,
+        /// <see cref="IFakeOptionsBuilder"/>s, and <see cref="IArgumentValueFormatter"/>s.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Equivalent to a Priority with value <c>-1</c>.
+        /// </para>
+        /// <para>
+        /// We have a single such Priority because it's all that's currently needed, and
+        /// we're unlikely to introduce built-in dummy factories, fake options builders, or
+        /// argument value formatters that would collide with one another.
+        /// Just in case, though, all negative values have been reserved for use by FakeItEasy.
+        /// </para>
+        /// </remarks>
+        internal static Priority Internal
+        {
+            get { return InternalInstance; }
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is less than that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is less than that of <c>right</c>.</returns>
+        public static bool operator <(Priority left, Priority right)
+        {
+            return left.value < right.value;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is greater than that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is greater than that of <c>right</c>.</returns>
+        public static bool operator >(Priority left, Priority right)
+        {
+            return left.value > right.value;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is less than or equal to that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is less than or equal to that of <c>right</c>.</returns>
+        public static bool operator <=(Priority left, Priority right)
+        {
+            return left.value <= right.value;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is greater than or equal to that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is greater than or equal to that of <c>right</c>.</returns>
+        public static bool operator >=(Priority left, Priority right)
+        {
+            return left.value >= right.value;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> is equal to that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is equal to that of <c>right</c>.</returns>
+        public static bool operator ==(Priority left, Priority right)
+        {
+            return left.value == right.value;
+        }
+
+        /// <summary>
+        /// Compares <see paramref="left"/> and <see paramref="right"/>, returning <c>true</c> if
+        /// and only if the value of <c>left</c> not equal to that of <c>right</c>.
+        /// </summary>
+        /// <param name="left">One priority to compare.</param>
+        /// <param name="right">The other priority to compare.</param>
+        /// <returns><c>true</c> if and only if the value of <c>left</c> is not equal to that of <c>right</c>.</returns>
+        public static bool operator !=(Priority left, Priority right)
+        {
+            return left.value != right.value;
+        }
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns an integer that indicates
+        /// whether the current instance precedes, follows, or occurs in the same position in the sort order as the
+        /// other object.
+        /// </summary>
+        /// <returns>
+        /// A value that indicates the relative order of the objects
+        /// being compared. The return value has these meanings:
+        /// <list type="bullet">
+        ///   <item>less than zero: this instance precedes <paramref name="other"/> in the sort order</item>
+        ///   <item>zero: this instance occurs in the same position in the sort order as <paramref name="other"/></item>
+        ///   <item>greater than zero: this instance follows <paramref name="other"/> in the sort order</item>
+        /// </list>
+        /// </returns>
+        /// <param name="other">An object to compare with this instance.</param>
+        public int CompareTo(Priority other)
+        {
+            return this.value.CompareTo(other.value);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <returns> True if the current object is equal to the <paramref name="other"/> parameter; otherwise, false.</returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public bool Equals(Priority other)
+        {
+            return this.value == other.value;
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object.
+        /// </summary>
+        /// <returns> True if the current object is equal to the <paramref name="obj"/> parameter; otherwise, false.</returns>
+        /// <param name="obj">An object to compare with this object.</param>
+        public override bool Equals(object obj)
+        {
+            return obj is Priority && this.Equals((Priority)obj);
+        }
+
+        /// <summary>
+        /// Gets a hash code for the current object.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            return this.value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns a textual description of this <see cref="Priority"/>.
+        /// </summary>
+        /// <returns>A textual description of this <see cref="Priority"/>, indicating its value.</returns>
+        public override string ToString()
+        {
+            return string.Concat("Priority<", this.value, ">");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #525.
Using a custom Priority type to ensure clients can only make non-negative priorities.