### PR TITLE
Use MSBuild v12 if no MSBuild v14

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,6 +1,10 @@
 require 'albacore'
 
-msbuild_command = "C:/Program Files (x86)/MSBuild/12.0/Bin/MSBuild.exe"
+msbuild_command = [
+  "C:/Program Files (x86)/MSBuild/14.0/Bin/MSBuild.exe",
+  "C:/Program Files (x86)/MSBuild/12.0/Bin/MSBuild.exe"
+].find(lambda{ raise "MSBuild not found"}) { |msbuild| File.file?(msbuild) }
+
 nuget_command  = "packages/NuGet.CommandLine.3.3.0/tools/NuGet.exe"
 nunit_command  = "packages/NUnit.Runners.2.6.3/tools/nunit-console.exe"
 xunit_command = "packages/xunit.runner.console.2.0.0/tools/xunit.console.exe"


### PR DESCRIPTION
Fixes #537.