### PR TITLE
Move .NET 3.5 shims to proper namespaces

### DIFF
--- a/src/FakeItEasy.Net35/Compatibility/ConditionalWeakTable.cs
+++ b/src/FakeItEasy.Net35/Compatibility/ConditionalWeakTable.cs
@@ -1,4 +1,4 @@
-namespace FakeItEasy
+namespace System.Runtime.CompilerServices
 {
     using System;
     using System.Collections.Generic;

--- a/src/FakeItEasy.Net35/Compatibility/EnumerableExtensions.cs
+++ b/src/FakeItEasy.Net35/Compatibility/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-namespace FakeItEasy
+namespace System.Linq
 {
     using System;
     using System.Collections;

--- a/tests/FakeItEasy.Net35.Tests/ConditionalWeakTableTests.cs
+++ b/tests/FakeItEasy.Net35.Tests/ConditionalWeakTableTests.cs
@@ -1,7 +1,10 @@
 namespace FakeItEasy
 {
+    extern alias FakeItEasy;
+
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using FakeItEasy::System.Runtime.CompilerServices;
     using NUnit.Framework;
 
     [TestFixture]

--- a/tests/FakeItEasy.Net35.Tests/ZipTests.cs
+++ b/tests/FakeItEasy.Net35.Tests/ZipTests.cs
@@ -1,7 +1,10 @@
 namespace FakeItEasy
 {
+    extern alias FakeItEasy;
+
     using System;
-    using System.Linq;
+    using System.Collections.Generic;
+    using FakeItEasy::System.Linq;
     using NUnit.Framework;
 
     [TestFixture]
@@ -15,12 +18,10 @@ namespace FakeItEasy
             var numbers = new[] { 1, 2 };
 
             // Act
-            var zipped = letters.Zip(numbers, (f, s) => new { Letter = f, Number = s }).ToList();
+            var zipped = new List<string>(letters.Zip(numbers, (l, n) => l + n));
 
             // Assert
-            Assert.That(zipped, Has.Count.EqualTo(2));
-            Assert.That(zipped[0], Has.Property("Letter").EqualTo("a").And.Property("Number").EqualTo(1));
-            Assert.That(zipped[1], Has.Property("Letter").EqualTo("b").And.Property("Number").EqualTo(2));
+            Assert.That(zipped, Is.EqualTo(new[] { "a1", "b2" }));
         }
     }
 }


### PR DESCRIPTION
From https://github.com/FakeItEasy/FakeItEasy/pull/620#issuecomment-190708031.
