### PR TITLE
Put 1.25.3 docs in the repo

### DIFF
--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -1,0 +1,97 @@
+# Argument constraints
+
+When configuring and [asserting](assertion.md) calls in FakeItEasy, the arguments of the call can be constrained so that only calls to the configured method where the arguments matches the constraint are selected.
+
+# Matching values exactly
+
+Assume the following interface exists:
+```csharp
+public interface IFoo
+{
+    void Bar(string s, int i);
+}
+```
+
+Then the arguments to Bar can be constrained used to limit call matching:
+```csharp
+var foo = A.Fake<IFoo>();
+
+A.CallTo(() => foo.Bar("hello", 17).MustHaveHappened();
+```
+
+Then FakeItEasy will look _only_ for calls made with the arguments `"hello"` and `17` - no other calls will match the rule.
+
+When checking for argument equality, FakeItEasy uses `object.Equals`. If the type to be checked does not provide an adequate `Equals` method, you may have to use the `That.Matches` method described in [Custom Matching](#custom-matching). Be particularly careful of types whose `Equals` methods perform reference equality rather than value equality. In that case, the objects have to be _the same object_ in order to match, and this sometimes produces unexpected results. When in doubt, verify the type's `Equals` behaviour manually.
+
+# Other matchers
+## Ignoring arguments
+Suppose the value of the integer in the `Bar` call wasn't important, but the string was. Then the following constraint could be used:
+```csharp
+A.CallTo(() => foo.Bar("hello", A<int>.Ignored)).MustHaveHappened();
+```
+
+Then any call will match, so long as the string value was `"hello"`. The `Ignored` property can be used on any type.
+
+An underscore (`_`) can be used as a shorthand for `Ignored` as well:
+```csharp
+A.CallTo(() => foo.Bar("hello", A<int>._)).MustHaveHappened();
+```
+
+# More convenience matchers
+If more complicated constraints are needed, the `That` method can be used. There are a few built-in matchers:
+
+|Matcher|Tests for|
+|:------|:--------|
+|IsNull()|`null`|
+|IsEqualTo(other)|object equality using `object.Equals`|
+|IsSameAs(other)|object identity - like `object.ReferenceEquals`|
+|IsInstanceOf(type)|an argument that can be assigned to a variable of type `type`|
+|Contains(string)|substring match|
+|StartsWith(string)|substring at beginning of string|
+|EndsWith(string)|substring at end of string|
+|IsNullOrEmpty()|`null` or `""`|
+|IsEmpty()|empty enumerable|
+|Contains(item)|item's presence in an enumerable|
+|IsSameSequenceAs(enumerable)|sequence equality, like `System.Linq.Enumerable.SequenceEqual`|
+|Not|inverts the sense of the matcher|
+
+## Custom matching
+
+If none of the canned matchers are sufficient, you can provide a predicate to perform custom matching using `That.Matches`. Like in this rather contrived example:
+
+```csharp
+A<string>.That.Matches(s => s.Length == 3 && s[1] == 'X');
+``` 
+
+FakeItEasy will evaluate the predicate against any supplied argument. The predicate can be supplied as an `Expression<Func<T, bool>>` or as a `Func<T, bool>`. FakeItEasy can generate a description of the matcher when an `Expression` is supplied (although you may supply your own as well), but you must supply a description when using a `Func`.
+
+For another example of using `That.Matches`, see Jonathan Channon's [Comparing object instances with FakeItEasy](http://blog.jonathanchannon.com/2013/09/11/comparing-object-instances-with-fakeiteasy).
+
+## Always place `Ignored` and `That` inside `A.CallTo`
+
+The `Ignored` (and `_`) and `That` matchers must be placed within the expression inside the `A.CallTo` call. This is because these special constraint methods do not return an actual matcher object. They tell FakeItEasy how to match the parameter via a special event that's fired then the constraint method is invoked. FakeItEasy only 
+listens to the events in the context of an `A.CallTo`.
+
+So, tempting as it might be to save one of the constraints away in a handy variable, don't do it.
+
+# Out parameters
+
+The incoming argument value of out parameters is ignored when matching calls. The incoming value of an out parameter can't be seen by the method body anyhow, so there's no value in constraining by it.<sup><a href="#footnote-1">1</a></sup>
+
+For example, this test passes:
+
+```csharp
+string configurationValue = "lollipop";
+A.CallTo(()=>aFakeDictionary.TryGetValue(theKey, out configurationValue))
+ .Returns(true); 
+
+string fetchedValue = "licorice";
+var success = aFakeDictionary.TryGetValue(theKey, out fetchedValue);
+
+Assert.That(success, Is.True);
+```
+
+See [Implicitly Assigning out Parameter Values](assigning-out-and-ref-parameters#implicitly-assigning-out-parameter-values) to learn how the initial `configurationValue` is used in this case.
+
+----
+1. <span id="footnote-1"/>This is new behaviour as of 1.23.0. Previously, the argument value would have to be equal to the value supplied in `A.CallTo` in order for the call to match.

--- a/docs/assertion.md
+++ b/docs/assertion.md
@@ -1,0 +1,111 @@
+# Assertion
+
+Assertion uses exactly the same syntax as configuration to specify the
+call to be asserted, followed by `.MustHaveHappened(Repeated)`, where
+`Repeated` specifies the number of expected repetitions.
+
+Two extension methods are provided for convenience:
+
+* `MustHaveHappened()` (no arguments) ignores the number of times the call was made, and 
+* `MustNotHaveHappened()` asserts that the specified call did not happen at all.
+
+Arguments are constrained using
+[Argument Constraints](argument-constraints.md) just like when
+configuring calls.
+
+#Details
+##Syntax
+
+```csharp
+// Asserting that a call has happened at least once.
+// The following two lines are equivalent.
+A.CallTo(() => foo.Bar()).MustHaveHappened(Repeated.AtLeast.Once);    // or
+A.CallTo(() => foo.Bar()).MustHaveHappened();
+
+// To contrast, assert that a call has happened exactly once.
+A.CallTo(() => foo.Bar()).MustHaveHappened(Repeated.Exactly.Once);
+
+// Asserting that a call has not happened.
+// The following two lines are equivalent.
+A.CallTo(() => foo.Bar()).MustNotHaveHappened();    // or
+A.CallTo(() => foo.Bar()).MustHaveHappened(Repeated.Never);
+```
+
+#Specifying Repeat
+
+```csharp
+// Using the Repeated class:
+Repeated.AtLeast.Once // The call must have happened once or more.
+Repeated.Exactly.Once // The call must have happened exaclty one time
+    
+Repeated.AtLeast.Twice // The call must have happened twice or more.
+Repeated.Exactly.Twice // The call must have happened twice exactly.
+Repeated.NoMoreThan.Twice // The call must have happened zero, one, or two times.
+
+Repeated.AtLeast.Times(10) // The call must have happened ten times or more
+Repeated.Exactly.Times(10) // The call must have happened ten times exactly
+Repeated.NoMoreThan.Times(10) // The call must have happened any number of times between zero and ten.
+    
+// Using a predicate.
+Repeated.Like(x => x % 2 == 0) // The call must have happened an even number of times.
+```
+
+# Asserting Calls Made with Mutable Arguments
+
+When FakeItEasy records a method (or property) call, it remembers
+which objects were used as argument, but does not take a snapshot of
+the objects' state. This means that if an object is changed after
+being used as an argument, but before argument constraints are
+checked, expected matches may not happen. For example,
+
+```csharp
+var aList = new List<int> {1, 2, 3};
+
+A.CallTo(() => myFake.SaveList(A<List<int>>._))
+    .Returns(true);
+
+myFake.SaveList(aList);
+aList.Add(4);
+
+A.CallTo(() => myFake.SaveList(A<List<int>>.That.IsThisSequence(1, 2, 3)))
+    .MustHaveHappend();
+```
+
+The `MustHaveHappened` will fail, because at the time the
+`IsThisSequence` check is made, `aList` has 4 elements, not 3, and
+`IsThisSequence` only has the reference to `aList` to use in its
+check, not a deep copy or some other form of snapshot—it has to work
+with the _current_ state.
+
+If your test or production code must mutate call arguments between the
+time of the call and the assertion time, you must look for some other
+way to very the call. Perhaps using `IsSameAs` will suffice, if the
+correct behaviour of the System Under Test can otherwise be
+inferred. Or consider using [Invokes](invoking-custom-code.md) to
+create a snapshot of the object and interrogate it later:
+
+```csharp
+var aList = new List<int> {1, 2, 3};
+
+List<int> capturedList;
+A.CallTo(() => myFake.SaveList(A<List<int>>._))
+    .Invokes((List<int> list) => capturedList = new List<int>(list))
+    .Returns(true);
+
+myFake.SaveList(aList);
+aList.Add(4);
+
+Assert.That(capturedList, Is.EqualTo(new List<int> {1, 2, 3}));
+```
+
+#VB.Net
+
+```
+' Functions and Subs can be asserted using their respective keywords
+A.CallTo(Function() foo.Bar()).MustHaveHappened()
+A.CallTo(Sub() foo.Baz(A(Of String).Ignored)).MustHaveHappened()
+
+' Can also use the "FakeItEasy.VisualBasic.NextCall" class
+NextCall.To(foo).MustHaveHappened()
+foo.SomeSub()
+```

--- a/docs/assigning-out-and-ref-parameters.md
+++ b/docs/assigning-out-and-ref-parameters.md
@@ -1,0 +1,78 @@
+# Assigning out and ref parameters
+
+Sometimes methods have `out` or `ref` parameters that need to be
+filled in when the faked method is called. Use
+`AssignsOutAndRefParameters`:
+
+```csharp
+string theValue;
+A.CallTo(()=>aFakeDictionary.TryGetValue(theKey, out theValue))
+ .Returns(true) 
+ .AssignsOutAndRefParameters(someCoolValue);
+```
+
+`AssignsOutAndRefParameters` takes a `params object[]`, with one
+element (in order) for each of the `out` and `ref` parameters in the
+call being faked - the other arguments to the method should be
+omitted.
+
+While assigning out and ref parameters, the `Returns` method (or
+[some variant](specifying-return-values.md) should be used to specify
+the return value for the method - `AssignsOutAndRefParameters` does
+not do this on its own.
+
+##Assigning Values Calculated at Call Time
+
+When out or ref parameter values aren't known until the method is
+called, `AssignsOutAndRefParametersLazily` can be used.
+
+```csharp
+string theValue;
+A.CallTo(() => aFakeDictionary.TryGetValue(theKey, out theValue))
+ .Returns(true) 
+ .AssignsOutAndRefParametersLazily((string aKey, string aValue) => new [] { aValue + aValue });
+```
+
+As shown above, the inputs to the method may be used to calculate the
+values to assign. Convenient overloads exist for methods of up to four
+parameters.
+
+The type of the `Func` sent to `AssignsOutAndRefParametersLazily`
+isn't checked at compile time, but any _type_ mismatch should trigger
+a helpful error message.
+
+If more advanced decision-making is required, or the method has more
+than 4 parameters, the convenience methods won't work. Use the variant
+that takes an `IFakeObjectCall` instead:
+
+```csharp
+string theValue;
+A.CallTo(() => aFakeDictionary.TryGetValue(theKey, out theValue))
+ .Returns(true) 
+ .AssignsOutAndRefParametersLazily(objectCall => calculateValuesFrom(objectCall));
+```
+The `IFakeObjectCall` object provides access to
+
+* information about the `Method` being called, as a `MethodInfo`,
+* the `Arguments`, accessed by position or name, and
+* the original `FakedObject`
+
+# Implicitly Assigning `out` Parameter Values
+
+Any `Expression`-based `A.CallTo` configuration that's made on a
+method that has an out parameter will cause the value of the variable
+used in the `A.CallTo` to be assigned to the out parameter when the
+method is actually called. For example:
+
+```csharp
+string configurationValue = "lollipop";
+A.CallTo(()=>aFakeDictionary.TryGetValue(theKey, out configurationValue))
+ .Returns(true); 
+
+string fetchedValue;
+aFakeDictionary.TryGetValue(theKey, out fetchedValue);
+
+// fetchedValue is now "lollipop";
+```
+
+If this behaviour is not desired, `AssignsOutAndRefParameters` (or `…Lazily`) can be used to provide different behaviour.

--- a/docs/bootstrapper.md
+++ b/docs/bootstrapper.md
@@ -1,0 +1,69 @@
+# Bootstrapper
+
+Most of FakeItEasy's functionality is directly triggered by client
+code: [creating a fake](creating-fakes.md),
+[configuring a call](specifying-a-call-to-configure.md) and
+[making assertions about calls](assertion.md) are all explicitly
+invoked and are controllable by various input parameters.
+
+Some behavior is triggered implicitly. FakeItEasy initializes itself
+when its classes are first accessed. The Bootstrapper<sup>1</sup>
+allows users to customize the initialization process.
+
+## What does the Bootstrapper do?
+
+At present, the Bootstrapper provides only one service:
+
+* `GetAssemblyFileNamesToScanForExtensions` provides a list of
+  absolute paths to assemblies that should be
+  [scanned for extension points](scanning-for-extension-points.md).  
+  The default behavior is to return an empty list.<sup>2</sup>
+
+## How can the behavior be changed?
+
+Provide an alternative bootstrapper class and ensure that it is loaded
+in the current AppDomain before FakeItEasy is initialized (often
+this means just including it in your test assembly).
+
+The best way to provide an alternative implementation is to **extend
+FakeItEasy.DefaultBootstrapper**. This class defines the default
+FakeItEasy setup behavior, so using it as a base allows clients to
+change only those aspects of the initialization that need to be
+customized.
+
+### An example: returning a specific extra assembly scan for extensions
+
+Most often, FakeItEasy extension points will be defined in assemblies
+that are already loaded at the time that FakeItEasy is used. In some
+cases, extensions may reside in assemblies that are not (yet)
+loaded. Perhaps the extensions are distributed in a shared assembly
+that does not need to be referenced by any other code. The following
+bootstrapper can be used to force an additional assembly to be scanned
+for extension points.
+
+```csharp
+public class ScanAnExternalAssemblyBootstrapper : FakeItEasy.DefaultBootstrapper
+{
+    public override IEnumerable<string> GetAssemblyFilenamesToScanForExtensions()
+    {
+        return new [] { @"c:\full\path\to\another\assembly.dll" };
+    }
+}
+```
+
+## How does FakeItEasy find alternative bootstrappers?
+
+Just before the first Bootstrapper function needs to be accessed,
+FakeItEasy checks all the assemblies currently loaded in the
+AppDomain. Each assembly is examined for exported types that implement
+`FakeItEasy.IBootstrapper`. The first such type that is not
+`FakeItEasy.DefaultBootstrapper` is instantiated and used. If no such
+type is found, then `FakeItEasy.DefaultBootstrapper` is used.
+
+**Note that there is no warning provided if FakeItEasy finds more than
+one custom bootstrapper implementation. One will be chosen
+non-deterministically.**
+
+----
+1. The Bootstrapper was introduced in FakeItEasy 1.18.0. If you have need of its functionality and are using an older version of FakeItEasy, [upgrade now](https://nuget.org/packages/FakeItEasy/).
+2. Before FakeItEasy 1.19.0, the default startup behavior was to scan all assemblies in the current working directory.

--- a/docs/calling-base-methods.md
+++ b/docs/calling-base-methods.md
@@ -1,0 +1,24 @@
+# Calling base methods
+
+The `CallsBaseMethod` configuration method can be used to make a method execute the implementation of the faked class:
+
+```csharp
+A.CallTo(() => fakeShop.SellSmarties())
+ .CallsBaseMethod();
+```
+
+Configuring a method to call its base method only makes sense if the method is actually implemented, so this technique cannot be used on an abstract class method or on any method from a faked interface—a faked abstract method told to call its base method will throw a `NotImplementedException`.
+
+## Configuring all methods at once
+
+Perhaps you want to have all or nearly all of a fake's (fakeable) methods defer to the original implementation. Rather than using `CallsBaseMethod` a dozen times, the [fake creation option](creating-fakes.md#explicit-creation-options) `CallsBaseMethods` can do all the work at once:
+
+```csharp
+var fakeShop = A.Fake<CandyShop>(options => options.CallsBaseMethods());
+```
+
+And then [selectively override some of them](limited-call-specifications.md#changing-behavior-between-calls)
+
+```chsharp
+A.CallTo(() => fakeShop.SellRockets()).Throws<Exception>();
+```

--- a/docs/creating-fakes.md
+++ b/docs/creating-fakes.md
@@ -1,0 +1,68 @@
+# Creating Fakes
+
+##Natural fakes
+The common way to create a fake object is by using the `A.Fake` syntax, for example:
+
+```csharp
+var foo = A.Fake<IFoo>();
+```
+This will return a faked object that is an actual instance of the type specified (`IFoo` in this case).
+
+##Explicit Creation Options
+When creating fakes you can, through a fluent interface, specify
+options for how the fake should be created:
+
+* Specify arguments for the constructor of the faked type.
+* Specify additional interfaces that the fake should implement.
+* Assign additional custom attributes to the faked class.
+* Cause a fake to have [strict mocking semantics](strict-fakes.md).
+* Configure all of a fake's methods to [use their original implementation](calling-base-methods.md).
+* Create a fake that wraps another object.
+    * Specify a recorder for wrapping fakes.
+
+Examples:
+
+```csharp
+// Specifying arguments for constructor using expression. This is refactoring friendly!
+// The constructor seen here is never actually invoked. It is an expression and it's purpose
+// is purely to communicate the constructor arguments which will be extracted from it
+var foo = A.Fake<FooClass>(x => x.WithArgumentsForConstructor(() => new FooClass("foo", "bar")));
+
+// Specifying arguments for constructor using IEnumerable<object>.
+var foo = A.Fake<FooClass>(x => x.WithArgumentsForConstructor(new object[] { "foo", "bar" }));
+
+// Specifying additional interfaces to be implemented. Among other uses,
+// this can help when a fake skips members because they have been 
+// explicitly implemented on the class being faked.
+var foo = A.Fake<FooClass>(x => x.Implements(typeof(IFoo)));
+
+// Assigning custom attributes to the faked class.
+// Get a parameterless constructor for our attribute and create a builder 
+var constructor = typeof(FooAttribute).GetConstructor(new Type[0]);
+var builder = new CustomAttributeBuilder(constructor, new object[0]);
+var builders = new List<CustomAttributeBuilder>() { test };
+// foo and foo's type should both have "FooAttribute"
+var foo = A.Fake<IFoo>(x => x.WithAdditionalAttributes(builders));
+
+// Create wrapper - unconfigured calls will be forwarded to wrapped
+var wrapped = new FooClass("foo", "bar");
+var foo = A.Fake<IFoo>(x => x.Wrapping(wrapped));
+```
+
+##Unnatural fakes
+
+For those accustomed to [Moq](http://www.moqthis.com/) there is an
+alternative way of creating fakes through the `new Fake<T>`
+syntax. The fake provides a fluent interface for configuring the faked
+object:
+
+```csharp
+var fake = new Fake<IFoo>();
+fake.CallsTo(x => x.Bar("some argument")).Returns("some return value");
+
+var foo = fake.FakeObject;
+```
+
+For an alternative look at migrating from Moq to FakeItEasy, see
+Daniel Marbach's blog post that talks about
+[Migration from Moq to FakeItEasy with Resharper Search Patterns](http://www.planetgeek.ch/2013/07/18/migration-from-moq-to-fakeiteasy-with-resharper-search-patterns/).

--- a/docs/css/extra-highlight.css
+++ b/docs/css/extra-highlight.css
@@ -1,3 +1,14 @@
+code {
+    font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    border-radius: 3px;
+    border-width: 0px;
+    background-color: #f7f7f7;
+    color: inherit;
+    font-size: inherit;
+    padding-top: 0.1em;
+    padding-bottom: 0.1em;
+}
+
 /*
 Modified GitHub theme for highlight.js
 
@@ -10,14 +21,17 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   overflow-x: auto;
   padding: 0.5em;
   color: #333;
+  background-color: #f7f7f7;
+  border-width: 0px;
+  font-size: inherit;
   -webkit-text-size-adjust: none;
 }
 
 .hljs-comment,
 .diff .hljs-header,
 .hljs-javadoc {
-  color: #998;
-  font-style: italic;
+  color: #969896;
+  font-style: normal;
 }
 
 .hljs-keyword,
@@ -27,14 +41,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-subst,
 .hljs-request,
 .hljs-status {
-  color: #333;
-  font-weight: bold;
+  color: #a71d5d;
+  font-weight: normal;
 }
 
 .hljs-number,
 .hljs-hexcolor,
 .ruby .hljs-constant {
-  color: #008080;
+  color: #0086b3;
 }
 
 .hljs-string,
@@ -42,14 +56,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-phpdoc,
 .hljs-dartdoc,
 .tex .hljs-formula {
-  color: #d14;
+  color: #183691;
 }
 
 .hljs-title,
 .hljs-id,
 .scss .hljs-preprocessor {
-  color: #900;
-  font-weight: bold;
+  color: #795da3;
+  font-weight: normal;
 }
 
 .hljs-list .hljs-keyword,
@@ -62,7 +76,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .vhdl .hljs-literal,
 .tex .hljs-command {
   color: #458;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .hljs-tag,
@@ -105,7 +119,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-shebang,
 .hljs-cdata {
   color: #999;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .hljs-deletion {

--- a/docs/css/highlight.css
+++ b/docs/css/highlight.css
@@ -1,0 +1,125 @@
+/*
+Modified GitHub theme for highlight.js
+
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #333;
+  -webkit-text-size-adjust: none;
+}
+
+.hljs-comment,
+.diff .hljs-header,
+.hljs-javadoc {
+  color: #998;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.css .rule .hljs-keyword,
+.hljs-winutils,
+.nginx .hljs-title,
+.hljs-subst,
+.hljs-request,
+.hljs-status {
+  color: #333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-hexcolor,
+.ruby .hljs-constant {
+  color: #008080;
+}
+
+.hljs-string,
+.hljs-tag .hljs-value,
+.hljs-phpdoc,
+.hljs-dartdoc,
+.tex .hljs-formula {
+  color: #d14;
+}
+
+.hljs-title,
+.hljs-id,
+.scss .hljs-preprocessor {
+  color: #900;
+  font-weight: bold;
+}
+
+.hljs-list .hljs-keyword,
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-class .hljs-title,
+.hljs-type,
+.vhdl .hljs-literal,
+.tex .hljs-command {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-tag .hljs-title,
+.hljs-rule .hljs-property,
+.django .hljs-tag .hljs-keyword {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-attribute,
+.hljs-variable,
+.lisp .hljs-body,
+.hljs-name {
+  color: #008080;
+}
+
+.hljs-regexp {
+  color: #009926;
+}
+
+.hljs-symbol,
+.ruby .hljs-symbol .hljs-string,
+.lisp .hljs-keyword,
+.clojure .hljs-keyword,
+.scheme .hljs-keyword,
+.tex .hljs-special,
+.hljs-prompt {
+  color: #990073;
+}
+
+.hljs-built_in {
+  color: #0086b3;
+}
+
+.hljs-preprocessor,
+.hljs-pragma,
+.hljs-pi,
+.hljs-doctype,
+.hljs-shebang,
+.hljs-cdata {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.diff .hljs-change {
+  background: #0086b3;
+}
+
+.hljs-chunk {
+  color: #aaa;
+}

--- a/docs/custom-dummy-creation.md
+++ b/docs/custom-dummy-creation.md
@@ -1,0 +1,46 @@
+# Custom Dummy Creation
+
+FakeItEasy has built-in [Dummy](dummies.md) creation rules that
+provide usable non-null values to be used in tests. However, if the
+default dummy creation behavior isn't adequate, you can provide your
+own. Here's an example:
+
+```csharp
+class DummyBookDefinition : DummyDefinition<Book>
+{
+    protected override Book CreateDummy()
+    {
+        return new Book { Title = "Some Book", PublishedOn = new DateTime(2000, 1, 1) };
+    }
+}
+```
+
+### How it works
+
+FakeItEasy uses classes that implement the following interface to
+create Dummies:
+
+```csharp
+public interface IDummyDefinition
+{
+    Type ForType { get; }
+    object CreateDummy();
+}
+```
+
+When FakeItEasy tries to create a Dummy, it looks at all known
+`IDummyDefinition` implementations and if one of them has a `ForType`
+that matches the desired type, `CreateDummy` is used.
+
+Although it's possible to implement `IDummyDefinition` explicitly, the
+preferred approach is to extend `abstract class DummyDefinition<T>:
+IDummyDefinition`, where `T` is the type of dummy to produce, as in
+the example above. `DummyDefinition<T>` implements `ForType`
+(returning `T`), so all that's needed is to implement the abstract
+`CreateDummy` method, having it return the Dummy.
+
+### How does FakeItEasy find the Dummy Definitions?
+
+On initialization, FakeItEasy
+[looks for Discoverable Extension Points](scanning-for-extension-points.md),
+including Dummy Definitions.

--- a/docs/default-fake-behavior.md
+++ b/docs/default-fake-behavior.md
@@ -1,0 +1,75 @@
+# Default fake behavior
+
+Fake objects come with useful default behavior as soon as
+[they are created](creating-fakes.md). Knowing the default behavior
+can make the fakes easier to work with and can lead to more concise
+tests.
+
+## Non-overideable members cannot be faked
+
+Methods and properties can only be faked if they are declared on a
+faked interface, or are declared abstract or virtual on a faked
+class. If none of these conditions hold, then a member cannot be
+faked, just as it could not be overridden in a derived class.
+
+When such a member is invoked on the fake, the original behavior will
+be invoked.
+
+## Overrideable members are faked
+
+When a method or property is declared on a faked interface, or is
+declared as abstract or virtual on a faked class, and the member is
+invoked on the fake, no action will be taken by the fake. It is as if
+the body of the member were empty. If the member has a return type (or
+is a get property), the return value will depend on the type `T` of
+the member. The actual rules for generating the return values are
+quite complicated, but here are some sample behaviors:
+
+* if `T` is `string`, then `string.Empty` will be returned
+* if `T` is a `Task<TResult>`, then a `Task<TResult>` will be
+  returned. Its `Result` property will return a value generated
+  according its type. For example, a `Task<string>`'s Result property
+  would return `string.Empty`
+* if `T` is not fakeable, then `default(T)` will be returned
+* if T is fakeable, then a fake `T` will be returned. This behavior
+  is sometimes called _recursive fakes_
+
+## Examples
+
+Suppose we have the following interface definition
+
+```csharp
+public interface Interface
+{
+    bool BooleanFunction();
+    int IntProperty { get; set; }
+    string StringFunction();
+    FakeableClass FakeableClassFunction();
+    UnfakeableClass UnfakeableClassProperty { get; set; }
+    Struct StructFunction();
+}
+```
+
+Then the following test will pass
+
+```csharp
+public void Members_should_return_empty_string_default_or_fake_another_fake()
+{
+    var fakeLibrary = A.Fake<Interface>();
+
+    Assert.AreEqual(default(bool), fakeLibrary.BooleanFunction());
+
+    Assert.AreEqual(default(int), fakeLibrary.IntProperty);
+
+    Assert.AreEqual(typeof(string), fakeLibrary.StringFunction().GetType()); 
+    Assert.AreEqual(string.Empty, fakeLibrary.StringFunction());
+
+    Assert.IsInstanceOfType(fakeLibrary.FakeableClassFunction(), typeof(FakeableClass));
+    Assert.AreEqual("FakeableClassProxy",
+                    fakeLibrary.FakeableClassFunction().GetType().Name); // to show it's a fake
+
+    Assert.IsNull(fakeLibrary.UnfakeableClassProperty);
+
+    Assert.AreEqual(default(Struct), fakeLibrary.StructFunction());
+}
+```

--- a/docs/doing-nothing.md
+++ b/docs/doing-nothing.md
@@ -1,0 +1,13 @@
+# Doing Nothing
+
+Sometimes you want a call to be ignored. That can be configured like so:
+```csharp
+A.CallTo(() => aFake.SomeMethodThatShouldDoNothing())
+ .DoesNothing();
+```
+
+This is quite close to what a default Fake's unconfigured method will do, but there a few situations where you may need to make the `DoesNothing` call explicitly.
+
+If the [Fake is strict](strict-fakes.md), an unconfigured call will throw an exception, so `DoesNothing` can be used to allow an exception.
+
+Or, `DoesNothing` can be used to change the behaviour that an already-configured call is supposed to have. For example, if a call is [set to throw an exception](throwing-exceptions.md), that can be overridden. For more on this kind kind of thing, see how to use [call repetition limits to change Fakes' behavior](limited-call-specifications.md#changing-behavior-between-calls).

--- a/docs/dummies.md
+++ b/docs/dummies.md
@@ -1,0 +1,97 @@
+# Dummies
+
+A Dummy is an object that FakeItEasy can provide when an object of a
+certain type is required, but the actual behavior of the object is not
+important.
+
+## How to use them in your tests
+
+Consider this example. Say that you want to test the following class:
+
+```csharp
+public class Library
+{
+    public bool Checkout(Card patronCard, Book someBook);
+}
+```
+
+Maybe in one of your tests you want to invoke `Checkout` with an
+expired library card. The checkout should fail, regardless of the book
+being checked out&mdash;only the status of the card matters. Instead
+of writing
+
+```csharp
+library.Checkout(MakeExpiredCard(),
+                 new Book { Title = "The Ocean at the End of the Lane" } );
+```
+
+You can write:
+
+```csharp
+library.Checkout(MakeExpiredCard(), A.Dummy<Book>());
+```
+
+This signals that the actual value of the `Book` is really not
+important. The code is intention-revealing.
+
+## How FakeItEasy uses them
+
+When [creating Fakes](creating-fakes.md) or Dummies of class types,
+FakeItEasy needs to invoke the classes' constructors. If the
+constructors take arguments, FakeItEasy needs to generate appropriate
+argument values. It uses Dummies.
+
+## How are the Dummies made?
+
+When FakeItEasy needs to access a Dummy of type `T`, it tries a number
+of approaches in turn, until one succeeds:
+
+1. see if there's a user-supplied
+  [custom Dummy creation](custom-dummy-creation.md) mechanism for `T`
+
+1. if `T` is `Task`, the returned Dummy will be an actual `Task` that
+  completes immediately<sup>1</sup>
+
+1. if `T` is `Task<TResult>`
+    * if `TResult` can be made into a Dummy, then returned Dummy will be an actual
+      `Task<TResult>` that completes immediately<sup>1</sup> and whose
+      `Result` is a Dummy of type `TResult`
+    * if `TResult` cannot be made into a Dummy, an unconfigured Fake
+      `Task<TResult>` will be returned. If this causes problems,
+      [consider upgrading now](https://nuget.org/packages/FakeItEasy/)
+    
+1. if `T` is a `Lazy<TValue>`, then
+
+    * if `TValue` can be made into a Dummy and has a parameterless
+      constructor, the returned Dummy will be an actual `Lazy<TValue>`
+      whose `Value` is a Dummy of type `TValue`.
+
+    * if `TValue` can't be made into a Dummy, an unconfigured Fake
+      `Lazy<TResult>` will be returned. If this causes problems,
+      [consider upgrading now](https://nuget.org/packages/FakeItEasy/)
+
+    * if `TValue` doesn't have a parameterless constructor, then the
+      `Lazy` will not behave well. If this causes problems,
+      [consider upgrading now](https://nuget.org/packages/FakeItEasy/)
+      
+1. if `T` is [fakeable](what-can-be-faked.md), the Dummy will be a
+  Fake `T`
+
+1. if `T` is a value type, the Dummy will be a `T` created via
+  `Activator.CreateInstance`
+
+1. if nothing above matched, then `T` is a class. Loop over all its constructors in _descending order of argument list length_.  
+  For each constructor, attempt to get Dummies to satisfy the argument
+  list. If the Dummies can be found, use `Activator.CreateInstance` to
+  create the Dummy, supplying the Dummies as the argument list. If the
+  argument list can't be satisfied, then try the next constructor.
+
+1. if none of the previous strategies yield a viable Dummy, then
+  FakeItEasy can't make a Dummy of type `T`.
+
+----
+1. In FakeItEasy 1.12 or earlier, the `Task` returned from a
+  non-configured fake method would never be completed and (for
+  example) an `await` would never be satisfied. If you are using 1.12
+  or earlier, [upgrade now](https://nuget.org/packages/FakeItEasy/).
+

--- a/docs/external-resources.md
+++ b/docs/external-resources.md
@@ -1,0 +1,7 @@
+# External Resources
+
+* [FakeItEasy courses on Pluralsight](http://www.pluralsight.com/tag/fakeiteasy)
+* [The "fakeiteasy" tag on StackOverflow](http://stackoverflow.com/questions/tagged/fakeiteasy)
+* [Mocking HttpContext with FakeItEasy](http://blog.jonathanchannon.com/2013/04/30/mocking-httpcontext-with-fake-it-easy/)
+* [Migration from Moq to FakeItEasy with Resharper Search Patterns](http://www.planetgeek.ch/2013/07/18/migration-from-moq-to-fakeiteasy-with-resharper-search-patterns/)
+* [Running multithreaded unit tests with FakeItEasy](http://hmemcpy.com/2012/12/running-multithreaded-unit-tests-with-fakeiteasy/)

--- a/docs/faking-async-methods.md
+++ b/docs/faking-async-methods.md
@@ -1,0 +1,35 @@
+# Faking async methods
+
+The faking of `async` methods is fully supported in FakeItEasy.
+
+```csharp
+public class Foo
+{
+    public virtual async Task<string> Bar()
+    {
+        // await something...
+    }
+}
+```
+
+A call to a non-configured async method on a fake will return a
+[Dummy](dummies.md#how-are-the-dummies-made) `Task` or `Task<T>`, just
+as if it were any other method that returns a `Task` or
+`Task<T>`<sup>1</sup>. For example:
+
+```csharp
+var foo = A.Fake<Foo>();
+var bar = await foo.Bar(); // will return immediately and return string.Empty
+```
+
+Of course, you can still configure calls to `async` methods as you would normally:
+
+```csharp
+A.CallTo(() => foo.Bar()).Returns(Task.FromResult("bar"));
+```
+
+----
+1. In FakeItEasy 1.12 or earlier, the `Task` returned from a
+   non-configured fake method would never be completed and the `await`
+   would never be satisfied. If you are using 1.12 or earlier,
+   [upgrade now](https://nuget.org/packages/FakeItEasy/).

--- a/docs/formatting-argument-values.md
+++ b/docs/formatting-argument-values.md
@@ -1,0 +1,141 @@
+# Formatting Argument Values
+
+FakeItEasy tries to provide helpful error messages when an
+[Assertion](assertion.md) isn't met. For example, when an expected call to a fake
+method isn't made, or when an unexpected call _is_ made. Often these
+messages are adequate, but sometimes there's a need to improve upon
+them, which can be done by writing custom argument value formatters.
+
+## Writing a custom argument value formatter
+Just define a class that extends `FakeItEasy.ArgumentValueFormatter<T>`. Here's a sample that formats argument values of type `Book`:
+```csharp
+class BookArgumentValueFormatter : ArgumentValueFormatter<Book>
+{
+    protected override string GetStringValue(Book argumentValue)
+    {
+        return string.Format("'{0}' published on {1:yyyy-MM-dd}",
+            argumentValue.Title, argumentValue.PublishedOn);
+    }
+}
+```
+
+This would help FakeItEasy display this error message:
+<pre>
+Assertion failed for the following call:
+  SampleTests.ILibrary.Checkout(<Ignored>)
+Expected to find it never but found it #1 times among the calls:
+  1: SampleTests.ILibrary.Checkout(<b>book: 'The Ocean at the End of the Lane', published on 2013-06-18</b>)
+</pre>
+which could make tracking down any failures a little easier.
+
+Compare to the original behaviour:
+<pre>
+Assertion failed for the following call:
+  SampleTests.ILibrary.Checkout(<Ignored>)
+Expected to find it never but found it #1 times among the calls:
+  1: SampleTests.ILibrary.Checkout(<b>book: SampleTests.Book</b>)
+</pre>
+
+In the original form of the message, the Book argument is just
+formatted using `Book.ToString()` because FakeItEasy doesn't know any
+better.
+
+## How it works
+
+FakeItEasy uses classes that implement the following interface to format argument values:
+
+```csharp
+public interface IArgumentValueFormatter
+{
+    string GetArgumentValueAsString(object argumentValue);
+    Type ForType { get; }
+    int Priority { get; }
+}
+```
+
+`GetArgumentValueAsString` does the work, transforming an argument into its formatted representation.  
+`ForType` indicates what type of argument a formatter can format.  
+`Priority` is discussed below.
+
+Above, we wrote a formatter in the preferred way, by extending
+`abstract class ArgumentValueFormatter<T>:
+IArgumentValueFormatter`.   `ArgumentValueFormatter<T>` defines a
+`GetArgumentValueAsString` method that defers to `GetStringValue`, and
+its `ForType` method simply returns `T`. The default implementation of
+`Priority` returns `int.MinValue`, but this can be overridden.  It's
+possible to write a formatter from scratch, but there's no advantage
+to doing so over extending `ArgumentValueFormatter<T>`.
+
+It's possible to create formatters for any type, including concrete
+types, abstract types, and interfaces. Formatters defined for base
+types and interfaces will be used when formatting values whose types
+extend or implement the formatter's type.
+
+## FakeItEasy's default formatter behaviour
+
+Unless custom formatters are provided, FakeItEasy formats argument
+values like so:
+
+- the `null` value is formatted as `<null>`,
+- the empty `string` is formatted as `string.Empty`,
+- other `string` values are formatted as `"the string value"`, including the quotation marks, and
+- any other value is formatted as its `ToString()` result
+
+There is no way to change FakeItEasy's behaviour when formatting
+`null`, but the other behaviour can be overridden by user-defined
+formatters.
+
+## Resolving formatter collisions
+
+It's possible for a solution to contain multiple formatters that would
+apply to the same types of arguments. In fact, it's guaranteed to
+happen, since FakeItEasy itself defines a formatter that applies to
+`object`s and one that applies to `string`s. Any user-defined
+formatter will conflict with at least the built-in object formatter,
+and maybe others. When there is more than one candidate for formatting
+an argument, FakeItEasy picks the best one based on two factors:
+
+- the distance between the argument's type (hereafter _ArgType_) and the type each formatter knows about (hereafter _ForType_), and
+- the value of each formatter's `Priority` property
+
+### Lowest distance
+
+When an argument value needs to be formatted, FakeItEasy examines all
+known formatters whose ForType is in ArgType's inheritance tree, or
+whose ForType is an interface that ArgType implements. The _distance_
+between ForType and ArgType is calculated as follows:
+
+- 0 if ForType and ArgType are the same
+- 1 if ForType is an interface that ArgType implements<sup>1</sup>
+- 2 if `ForType == ArgType.BaseType`, 
+- 3 if `ForType == ArgType.BaseType.BaseType`, and so on, adding one for every step in the inheritance chain
+
+The formatter whose ForType has the smallest distance to ArgType is used to format the argument.
+
+### Highest priority
+
+Sometimes more than one formatter is found the same distance from
+ArgType. Maybe two formatters actually specify the same `ForType`
+property value, or there's a formatter defined for ArgType as well as
+for an interface that ArgType implements.
+
+When multiple formatters have the same distance from the argument,
+FakeItEasy will select the one with the highest `Priority` property
+value. If multiple formatters have the same distance _and_ the same
+priority, the behavior is undefined.
+
+The formatters that FakeItEasy includes have `Priority` equal to
+`int.MinValue`, as do all classes that extend
+`ArgumentValueFormatter<T>`, unless they explicitly override the
+property. So, for example, a user-provided alternate formatter for
+`string`s should override `Priority`, having it return a higher
+value. Otherwise, there's no guarantee which formatter will be used.
+
+###How does FakeItEasy find Argument Value Formatters?
+
+On initialization, FakeItEasy
+[looks for Discoverable Extension Points](scanning-for-extension-points.md),
+including Argument Value Formatters.
+
+----
+1. In FakeItEasy 1.13.1 and earlier, the distance `0` was returned if the ForType and ArgType were the same **or** if ForType was an interface that ArgType implements, so if there were two formatters, each matching one of those conditions, there was no way to tell which one would be used. This was fixed in [Issue 142](https://github.com/FakeItEasy/FakeItEasy/issues/142).

--- a/docs/how-to-fake-internal-types.md
+++ b/docs/how-to-fake-internal-types.md
@@ -1,0 +1,30 @@
+# How to fake internal (Friend in VB) types
+
+This guide will show you how to set up your project in order to be
+able to fake internal types in your tested system.
+
+#Details
+
+The assembly that generates the proxy instances must have access to
+your internal types, therefore a `InternalsVisibleTo` attribute must
+be added to your tested assembly. Note that it is the assembly under
+test, not your test-assembly that needs this attribute.
+
+##Unsigned assemblies
+
+If your assembly is not signed with a strong name it's as easy as
+adding the equivalent of the following to your AssemblyInfo.cs/vb
+file:
+
+```csharp
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+```
+
+##Signed assemblies
+
+For signed assemblies you have to specify the strong name of the
+proxy-generating assembly:
+
+```csharp
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+![FakeItEasy](http://fakeiteasy.github.io/img/fakeiteasy_logo_256.png)
+
+FakeItEasy is a .Net dynamic fake framework for creating all types of fake objects, mocks, stubs etc.
+
+* Easier semantics, all fake objects are just that - fakes - the use of the fakes determines whether they're mocks or stubs.
+* Context-aware fluent interface guides the developer.
+* Designed for ease of use.
+* Full compatibility with both C# and VB.Net.
+
+## It's faking amazing!
+
+* [Website](http://fakeiteasy.github.io/)
+* [Quickstart](quickstart.md)
+* [Chat](https://gitter.im/FakeItEasy/FakeItEasy)
+* [Package](https://nuget.org/packages/FakeItEasy "FakeItEasy on NuGet")
+
+----
+FakeItEasy logo designed by Vanja Pakaski.
+

--- a/docs/invoking-custom-code.md
+++ b/docs/invoking-custom-code.md
@@ -1,0 +1,38 @@
+# Invoking Custom Code
+
+Sometimes a faked method's desired behavior can't be satisfactorily
+defined just by
+[specifying return values](specifying-return-values.md),
+[throwing exceptions](throwing-exceptions.md),
+[assigning out and ref parameters](assigning-out-and-ref-parameters.md)
+or even [doing nothing](doing-nothing.md). Maybe you need to simulate
+some kind of side effect, either for the benefit of the System Under
+Test or to make writing a test easier (or possible). Let's see what
+that's like.
+
+```csharp
+A.CallTo(() => fakeShop.SellSmarties())
+ .Invokes(() => OrderMoreSmarties()) // simulate Smarties stock falling too low
+ .Returns(20);
+```
+
+Now when the System Under Test calls `SellSmarties`, the Fake will call `OrderMoreSmarties`.
+
+If the method being configured has a return value, you should use `Return` to specify the return value, or it will return `null` (or a default value for a value type). This is true even if the return type of the method is such that an unconfigured method would not return `null` (for example, if the method returns a string or `Task`).
+
+There are also more advanced variants that can invoke actions based on arguments supplied to the faked method. These act similarly to how you specify return values that are calculated at call time. For example
+```csharp
+// Pass up to 4 original call argument values into the method that creates the exception.
+// Since FakeItEasy 1.15.0, this works even if NumberOfSweetsSoldOn takes a ref DateTime 
+// or an out DateTime.
+A.CallTo(()=>fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
+ .Invokes((DateTime when) => System.Console.Out.WriteLine("showing sweet sales for " + when)
+ .Returns(17);
+
+// Pass an IFakeObjectCall into the creation method for more advanced scenarios.
+A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
+ .Invokes(callObject => System.Console.Out.WriteLine(callObject.FakedObject +
+                                                     " is closed on " +
+                                                     callObject.Arguments[0]))
+ .Returns(0);
+```

--- a/docs/limited-call-specifications.md
+++ b/docs/limited-call-specifications.md
@@ -1,0 +1,38 @@
+# Limited Call Specifications
+
+When [specifying return values](specifying-return-values.md) or
+configuring [exceptions to be thrown](throwing-exceptions.md) and so
+on, it's possible to define the number of times the action can
+occur. By default, omitting the number of repetitions is the same as
+saying "forever", so after specifying
+`A.CallTo(() =>fakeShop.Address).Returns("123 Fake Street")`,
+`fakeShop.Address` will return the same value _every time it's
+called. Forever._
+
+This can be changed, though:
+```csharp
+A.CallTo(() => fakeShop.Address).Returns("123 Fake Street").Once();
+A.CallTo(() => fakeShop.Address).Returns("123 Fake Street").Twice();
+A.CallTo(() => fakeShop.Address).Returns("123 Fake Street").NumberOfTimes(17);
+```
+
+This could be useful if you want to allow a limited number of calls on
+a [strict fake](strict-fakes.md), but there's a more useful
+application.
+
+##Changing behavior between calls
+
+Call specifications act kind of like a stack - they're pushed on the
+Fake and then popped off once the number of repetitions defined for a
+call have been exhausted. Thus, it's possible to have a call to a Fake
+act one way, and then another. In order to test the System Under
+Test's retry logic, a Fake service could be configured to fail once
+and then function properly thereafter:
+
+```csharp
+// set up an action that can run forever, unless superseded
+A.CallTo(() => fakeService.DoSomething()).Returns("SUCCESS");
+
+// set up a one-time exception which will be used for the first call
+A.CallTo(() => fakeService.DoSomething()).Throws<Exception>().Once;
+```

--- a/docs/ordered-assertions.md
+++ b/docs/ordered-assertions.md
@@ -1,0 +1,118 @@
+# Ordered Assertions
+
+The concept of ordered assertions is somewhat complex and nothing that
+should be used frequently but there are times when it's really needed.
+
+In FakeItEasy you can assert that calls happened in a specific order
+on _more than one_ fake object.
+
+Note that this feature is not available in the 1.0.x versions.
+
+#Details
+
+One area where ordered asserts are useful is when you need to test
+that a call to a fake has happened between two other calls creating a
+scope. This could be useful when dealing with transactions or units of
+work.
+
+```csharp
+public interface IUnitOfWorkFactory
+{
+    IDisposable BeginWork();
+}
+
+public interface IDoSomethingPrettyUseful
+{
+    void JustDoIt();
+}
+
+public class Worker
+{
+    private IUnitOfWorkFactory unitOfWorkFactory;
+    private IDoSomethingPrettyUseful usefulCollaborator;
+        
+    public Worker(IUnitOfWorkFactory unitOfWorkFactory, IDoSomethingPrettyUseful usefulCollaborator)
+    {
+        this.unitOfWorkFactory = unitOfWorkFactory;
+        this.usefulCollaborator = usefulCollaborator;
+    }
+
+    public void JustDoIt()
+    {
+        using (this.unitOfWorkFactory.BeginWork())
+        {
+            this.usefulCollaborator.JustDoIt();
+        }
+    }
+}
+```
+
+In the following example we'll assert that the call to
+`usefulCollaborator.JustDoIt()` happened between the calls to
+`BeginWork` and the `Dispose` method of the returned unit of work.
+
+```csharp
+[Test]
+public void Should_start_work_within_unit_of_work()
+{
+    // Arrange
+    var unitOfWork = A.Fake<IDisposable>();
+            
+    var unitOfWorkFactory = A.Fake<IUnitOfWorkFactory>();
+    A.CallTo(() => unitOfWorkFactory.BeginWork()).Returns(unitOfWork);
+
+    var usefulCollaborator = A.Fake<IDoSomethingPrettyUseful>();
+
+    var worker = new Worker(unitOfWorkFactory, usefulCollaborator);
+
+    using (var scope = Fake.CreateScope())
+    {
+        // Act
+        worker.JustDoIt();
+
+        // Assert
+        using (scope.OrderedAssertions())
+        {
+            A.CallTo(() => unitOfWorkFactory.BeginWork()).MustHaveHappened();
+            A.CallTo(() => usefulCollaborator.JustDoIt()).MustHaveHappened();
+            A.CallTo(() => unitOfWork.Dispose()).MustHaveHappened();
+        }
+    }
+}
+```
+
+In the test we need to create a "fake scope" that wraps the call to
+the tested class and the assertions. A fake scope is used to catch all
+the calls to any fake object within that scope (among other things).
+
+Then to do the assertions we call the `OrderedAssertions` method on
+the scope, any assertion within this using statement will now need to
+have happened in the same order as the assertions are specified or the
+test will fail.
+
+With the current implementation of `Worker`, the test will pass. But
+let's change the order of the calls in `JustDoIt`:
+
+```csharp
+public void JustDoIt()
+{ 
+    using (this.unitOfWorkFactory.BeginWork())
+    { 
+        
+    }
+    this.usefulCollaborator.JustDoIt();
+}
+```
+
+The test will now fail with the following exception message:
+
+<pre>
+ Assertion failed for the following calls:
+    'OrderedAssertsDemo.IUnitOfWorkFactory.BeginWork()' repeated once
+    'OrderedAssertsDemo.IDoSomethingPrettyUseful.JustDoIt()' repeated once
+    'System.IDisposable.Dispose()' repeated once
+  The calls where found but not in the correct order among the calls:
+    1.  'OrderedAssertsDemo.IUnitOfWorkFactory.BeginWork()'
+    2.  'System.IDisposable.Dispose()'
+    3.  'OrderedAssertsDemo.IDoSomethingPrettyUseful.JustDoIt()'
+</pre>

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,0 +1,16 @@
+# Platform support
+
+FakeItEasy supports the following platforms:
+
+* .NET Framework 4.0 onwards
+* .NET Framework 3.5
+* Silverlight 5.0 in FakeItEasy
+  [1.16.0](https://www.nuget.org/packages/FakeItEasy/1.16.0)–[1.25.3](https://www.nuget.org/packages/FakeItEasy/1.25.3)
+* Silverlight 4.0 in FakeItEasy
+  ???–[1.25.3](https://www.nuget.org/packages/FakeItEasy/1.25.3)
+* Silverlight 3.0 in FakeItEasy
+  ???–[1.7.4626.65](https://www.nuget.org/packages/FakeItEasy/1.7.4626.65)
+* Windows 8 (experimental) in FakeItEasy
+  [1.16.0](https://www.nuget.org/packages/FakeItEasy/1.16.0)–[1.25.3](https://www.nuget.org/packages/FakeItEasy/1.25.3)
+* Windows Phone Silverlight 8 (experimental) in FakeItEasy
+  [1.16.0](https://www.nuget.org/packages/FakeItEasy/1.16.0)–[1.25.3](https://www.nuget.org/packages/FakeItEasy/1.25.3)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,42 @@
+# Quickstart
+
+Getting started with FakeItEasy is very simple:
+
+* Open the Package Manager Console:  
+Tools → Library Package Manager → Package Manager Console
+* Execute `Install-Package FakeItEasy`
+* Start faking dependencies in your tests. Here's a sample test class with fakes:
+
+```csharp
+namespace FakeItEasyQuickstart
+{
+    using FakeItEasy;
+    using NUnit; // any test framework will do
+
+    public class SweetToothTests
+    {
+        [Test]
+        public void BuyTastiestCandy_should_buy_top_selling_candy_from_shop
+        {
+            // make some fakes for the test
+            var lollipop = A.Fake<ICandy>();
+            var shop = A.Fake<ICandyShop>();
+
+            // set up a call to return a value
+            A.CallTo(() => shop.GetTopSellingCandy()).Returns(lollipop);
+
+            // use the fake as an actual instance of the faked type
+            var developer = new SweetTooth();
+            developer.BuyTastiestCandy(shop);
+
+            // asserting uses the exact same syntax as when configuring calls—
+            // no need to learn another syntax
+            A.CallTo(() => shop.BuyCandy(lollipop)).MustHaveHappened();
+        }
+    }
+}
+```
+
+* Most FakeItEasy functionality is reached from a common entry point: the `A` class.
+* In this example the `lollipop` instance is used as a stub and the `shop` instance is used as a mock but there's no need to know the difference, just fake it! Easy!
+* Fluent, easy-to-use syntax guides you as you configure fakes.

--- a/docs/raising-events.md
+++ b/docs/raising-events.md
@@ -1,0 +1,56 @@
+# Raising Events
+
+Let's say - for argument's sake - that we have an interface that has
+an event defined:
+
+```csharp
+public interface IRobot
+{ 
+    event EventHandler FellInLove;
+}
+```
+
+Now in a test where we have a faked instance of this interface we can
+raise that event whenever we want, specifying sender and event
+args. We could also omit the sender and the fake will be passed as
+sender to the event handler. There's also a convenience method for
+raising with empty event args.
+
+```csharp
+var robot = A.Fake<IRobot>();
+            
+robot.FellInLove += (s, e) =>
+    {
+        Console.WriteLine("Yay!");
+    };
+         
+// Raise the event!
+robot.FellInLove += Raise.With(EventArgs.Empty);
+
+// Use the overload for empty event args
+robot.FellInLove += Raise.WithEmpty();
+
+// Specify sender and event args explicitly:
+robot.FellInLove += Raise.With(sender: robot, e: EventArgs.Empty);
+```
+
+Events of type `EventHandler<TEventArgs>` may be raised in exactly the same way. 
+
+If an event is defined using a custom delegate, such as `delegate void
+CustomEventHandler(object sender, FileSystemEventArgs eventArgs)`, it
+needs to be raised using `Now`:
+
+```csharp
+robot.FoundANewFile += Raise.With(robot, new FileSystemEventArgs(…)).Now;
+```
+
+Just as when we're trying to
+[ov erride a method's behavior](what-can-be-faked.md#what-members-can-be-overriden),
+_for FakeItEasy to raise an event, the event must be virtual (if
+defined on a class) or defined on an interface_.
+
+## VB.Net
+
+```
+AddHandler robot.FellInLove, AddressOf Raise.With(EventArgs.Empty)
+```

--- a/docs/read-write-property-behavior.md
+++ b/docs/read-write-property-behavior.md
@@ -1,0 +1,24 @@
+# Read/Write Property Behavior
+
+Although you can explicitly
+[specify the return value for a called property getter](specifying-return-values.md),
+there's an easier, more intuitive way to work with read/write
+properties.  By default, any
+[fakeable](what-can-be-faked.md#what-members-can-be-overridden) property
+that has both a `set` and `get` accessor behaves like you might
+expect. Setting a value and then getting the value returns the value
+that was set.
+
+```csharp
+var fakeShop = A.Fake<ICandyShop>();
+
+fakeShop.Address = "123 Fake Street";
+
+System.Console.Out.Write(fakeShop.Address); 
+// prints "123 Fake Street"
+```
+
+This behaviour can be used to 
+
+* supply values for the system under test to use (via the getter) or to
+* verify that the system under test performed the `set` action on the Fake

--- a/docs/scanning-for-extension-points.md
+++ b/docs/scanning-for-extension-points.md
@@ -1,0 +1,40 @@
+# Scanning for Extension Points
+
+On initialization, essentially as soon as a FakeItEasy type is
+accessed, FakeItEasy uses reflection to look for internal and
+user-supplied extension points. In most cases, there is no _need_ for
+users to define any extensions, but they may be used to enhance the
+power and usability of FakeItEasy.
+
+There are currently three kinds of extension points defined:
+
+* [Custom Dummy Creation](custom-dummy-creation.md) rules,
+* Fake Configurators
+* [Argument Value Formatters](formatting-argument-values.md)
+
+Please see their individual documentation pages to learn how each of these is used.
+
+## The scanning process
+
+On startup, FakeItEasy searches:
+* its own assembly,
+* assemblies already loaded in the current AppDomain and
+* additional assemblies identified by the [Bootstrapper](bootstrapper.md)'s
+  `GetAssemblyFileNamesToScanForExtensions` method<sup>1</sup>
+  
+for classes that implement the various extensions points.
+Any such classes found are added to a catalogue and used at need.
+
+**Note: this does not apply to the Silverlight version of the DLL,
+  which does not load externally-supplied extension points. Under
+  Silverlight, only extensions defined in the FakeItEasy assembly are
+  used.**
+
+----
+1. In FakeItEasy 1.17.0 or earlier, there was no
+  [Bootstrapper](bootstrapper.md), and all DLLs in the current working
+  directory were considered as sources for extension points. This lead
+  to some problems, notably slow startup. If you use an old version of
+  FakeItEasy and have these problems,
+  [upgrade now](https://nuget.org/packages/FakeItEasy/).
+  

--- a/docs/slow-startup-time.md
+++ b/docs/slow-startup-time.md
@@ -1,0 +1,31 @@
+# Slow startup time
+
+##The Problem
+
+Users with test solutions that include many (or very large) assemblies
+sometimes report slow test runs with FakeItEasy. Often this manifests
+as a very long time taken for the initial test to complete.
+
+##The Cause
+
+This behaviour is usually caused by the way FakeItEasy looks for
+user-defined extension points. Some older versions load and scan all
+DLLs in the working directory that aren't already in the AppDomain. If
+there are many such DLLs, this can take several seconds. The time is
+only spent on the first call to FakeItEasy, but it can be quite
+annoying.
+
+##Remedy
+
+1. If you're **using a FakeItEasy older than 1.19.0**, upgrade
+  now. Releases 1.13.0 and 1.19.0 included improvements to the
+  scanning procedure that greatly reduced the startup time. If you
+  upgrade to the latest FakeItEasy from a pre-1.19.0 release causes
+  FakeItEasy to stop loading some extensible behaviour defined in an
+  external assembly, you can configure the
+  [Bootstrapper](bootstrapper.md) to get it back.
+2. If you're already using the newest FakeItEasy and startup times
+  seem unreasonably long, [create an issue][newissue], providing as
+  much detail as possible so we can try to help.
+  
+[newissue]:https://github.com/FakeItEasy/FakeItEasy/issues/new

--- a/docs/snippets-for-fakeiteasy-in-sidewaffle.md
+++ b/docs/snippets-for-fakeiteasy-in-sidewaffle.md
@@ -1,0 +1,53 @@
+# Snippets for FakeItEasy in SideWaffle
+
+The [SideWaffle](http://sidewaffle.com/) extension adds a bunch of useful Snippets, Project- and Item Templates to Visual Studio, which you download through "Extensions and Updates..." under Tools in Visual Studio.
+
+It includes eight code snippets for FakeItEasy. Use them by writing **snippet shortcut + Tab**, for example **afake + Tab**.
+
+##Fake
+Shortcut: afake
+```csharp
+var fake = A.Fake<ITypeToFake>();
+```
+
+##Fake - Strict
+Shortcut: afakestrict
+```csharp
+var fake = A.Fake<ITypeToFake>(x => x.Strict());
+```
+
+##Call To
+Shortcut: acall
+```csharp
+A.CallTo(() => fake.Method()).Returns("something");
+```
+
+##Call To - Must Have Happened One Or More Times
+Shortcut: acallmust
+```csharp
+A.CallTo(() => fake.Method()).MustHaveHappened();
+```
+
+##Call To - Must Have Happened Exactly Once
+Shortcut: acallmust1
+```csharp
+A.CallTo(() => fake.Method()).MustHaveHappened(Repeated.Exactly.Once);  
+```
+
+##Call To - Must Have Happened Exactly Twice
+Shortcut: acallmust2
+```csharp
+A.CallTo(() => fake.Method()).MustHaveHappened(Repeated.Exactly.Twice);
+```
+
+##Call To - Must Have Happened Exactly Times
+Shortcut: acallmustx
+```csharp
+A.CallTo(() => fake.Method()).MustHaveHappened(Repeated.Exactly.Times(3));
+```
+
+##Call To - Must Not Have Happened
+Shortcut: acallmustnot
+```csharp
+A.CallTo(() => fake.Method()).MustNotHaveHappened();
+```

--- a/docs/specifying-a-call-to-configure.md
+++ b/docs/specifying-a-call-to-configure.md
@@ -1,0 +1,83 @@
+# Specifying a Call to Configure
+
+One of the first steps in configuring a fake object's behaviour is to
+specify which call to configure. Like most FakeItEasy actions, this is
+done using a method on the `A` class: `A.CallTo`.
+
+## Specifying a method call or property `get` using an Expression
+
+```csharp
+A.CallTo(() => fakeShop.GetTopSellingCandy())
+A.CallTo(() => fakeShop.Address)
+```
+
+The expressions in the above example are not evaluated by FakeItEasy:
+no call to `GetTopSellingCandy` or `Address` is made. The expressions
+are just used to identify which call to configure.
+
+`A.CallTo` returns an object that can be used to specify how the fake
+should behave when the call is made. For example:
+
+```csharp
+A.CallTo(() => fakeShop.GetTopSellingCandy())
+                       .Returns(lollipop);
+```
+
+Many types of actions can be specified, including
+[returning various values](specifying-return-values.md),
+[throwing exceptions](throwing-exceptions.md), and more.
+
+## Specifying a call to any method or property
+
+Instead of supplying an expression to identify a specific method, pass
+the fake to `A.CallTo` to refer to any method on the fake:
+
+```csharp
+A.CallTo(fakeShop).Throws(new Exception());
+
+// Or limit the calls by return type
+A.CallTo(fakeShop).WithReturnType<string>().Returns("sugar tastes good");
+
+// Or create a sophisticated test with a predicate that acts on an IFakeObjectCall
+A.CallTo(fakeShop).Where(call => call.Arguments.Count > 4)
+                  .Throws(new Exception("too many arguments is bad");
+```
+
+`A.CallTo(object)` can also be used to specify property `set`s and
+`protected` members:
+
+```csharp
+A.CallTo(fakeShop).Where(call => call.Method.Name == "ProtectedCalculateSalesForToday")
+                  .WithReturnType<double>()
+                  .Returns(4741.71);
+
+// refers to the Address property's setter
+A.CallTo(fakeShop).Where(call => call.Method.Name == "set_Address")
+                  .Throws(new Exception("we can't move");
+```
+
+[Issue 175](https://github.com/FakeItEasy/FakeItEasy/issues/175) has
+been raised to develop a better mechanism for specifying property
+`set`s.
+
+## Specifying a call by example
+```csharp
+NextCall.To(fakeShop).WithAnyArguments()
+                     .Throws(new Exception("we're closed");
+fakeShop.SellThisCandy(null); // recorded, and configuration above is applied
+
+...
+
+fakeShop.SellThisCandy(lollipop); // will throw now
+```
+
+## VB.Net
+Special syntax is provided to specify `Func`s and `Sub`s in VB, using their respective keywords:
+
+```
+A.CallTo(Sub() fakeShop.SellSomething())
+                       .DoesNothing()
+
+A.CallTo(Func() fakeShop.GetTopSellingCandy())
+                        .Returns(lollipop)
+```

--- a/docs/specifying-return-values.md
+++ b/docs/specifying-return-values.md
@@ -1,0 +1,73 @@
+# Specifying Return Values
+
+One of the most common tasks on a
+[newly-created Fake](creating-fakes.md) is to specify the return value
+for some method or property that might be called on it. This is often
+done by using the `Returns` method on the result of an `A.CallTo`:
+
+```csharp
+A.CallTo(() => fakeShop.GetTopSellingCandy()).Returns(lollipop);
+```
+
+Now, whenever the parameterless method `GetTopSellingCandy` is called
+on the `fakeShop` Fake, it will return the `lollipop` object.
+
+A `get` property on a Fake can be configured similarly:
+```csharp
+A.CallTo(() => fakeShop.Address).Returns("123 Fake Street");
+```
+
+##Return Values Calculated at Call Time
+
+Sometimes a desired return value won't be known at the time the call
+is configured. `ReturnsNextFromSequence` and `ReturnsLazily` can help
+with that. `ReturnsNextFromSequence` is the simpler of the two:
+
+```csharp
+A.CallTo(() => fakeShop.SellSweetFromShelf()
+                       .ReturnsNextFromSequence(lollipop, smarties, wineGums));
+```
+
+will first return `lollipop`, then `smarties`, then `wineGums`. The
+next call will not take an item from the sequence, but will rely on
+other configured (or default) behaviour.
+
+On to the very powerful `ReturnsLazily`:
+
+```csharp
+// Returns the number of times the method has been called
+int sweetsSold = 0;
+A.CallTo(() => fakeShop.NumberOfSweetsSoldToday().ReturnsLazily(() => ++sweetsSold);
+```
+
+If a return value depends on input to the method, those values can be
+incorporated in the calculation. Convenient overloads exist for
+methods of up to four parameters.
+
+```csharp
+A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>.Ignored) 
+                       .ReturnsLazily((DateTime theDate) => 
+                                          theDate.DayOfWeek == DayOfWeek.Sunday ? 0 : 200);
+```
+
+The type of the `Func` sent to `ReturnsLazily` isn't checked at
+compile time, but any type mismatch should trigger a helpful error
+message.  Starting with FakeItEasy 1.15.0, the convenience methods may
+be used with methods that take `out` and `ref` parameters. This means
+that the previous example would work even if `NumberOfSweetsSoldOn`
+took an `out DateTime` or a `ref DateTime`.
+
+If more advanced decision-making is required, or the method has more
+than 4 parameters, the convenience methods won't work. Use the variant
+that takes an `IFakeObjectCall` instead:
+
+```charp
+A.CallTo(objectCall => fakeShop.SomeCall(…)
+                               .ReturnsLazily(objectCall => calculateReturnFrom(objectCall));
+```
+
+The `IFakeObjectCall` object provides access to
+
+* information about the `Method` being called, as a `MethodInfo`,
+* the `Arguments`, accessed by position or name, and
+* the original `FakedObject`

--- a/docs/strict-fakes.md
+++ b/docs/strict-fakes.md
@@ -1,0 +1,25 @@
+# Strict fakes
+
+[By default](default-fake-behavior.md), FakeItEasy's fakes support
+what is sometimes called "loose mocking". This means that calls to any
+of the fake's members are allowed, even if they haven't been
+configured.
+
+However, FakeItEasy also supports strict fakes, in which all calls to
+unconfigured members are rejected, throwing an
+`ExpectationException`. Strict fakes are created by supplying a
+[creation option](creating-fakes.md#explicit-creation-options):
+
+```csharp
+var foo = A.Fake<IFoo>(x => x.Strict());
+```
+
+After you have configured your fake in this fashion you can configure
+any "allowed" calls as usual, for example:
+
+```csharp
+A.CallTo(() => foo.Bar()).Returns("bar");
+```
+
+Strict fakes are useful when it is important to ensure that no calls
+are made to your fake other than the ones you are expecting.

--- a/docs/throwing-exceptions.md
+++ b/docs/throwing-exceptions.md
@@ -1,0 +1,42 @@
+# Throwing Exceptions
+
+When it's deployed, you may not want code to throw exceptions, but
+often it's necessary to test what happens when libraries your code
+interacts with throw them. You can configure a Fake to throw an
+exception like this:
+
+```csharp
+A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(DateTime.MaxValue))
+ .Throws(new InvalidDateException("the date is in the future");
+```
+
+If the exception type has a parameterless constructor, you can use it
+like
+
+```csharp
+A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(DateTime.MaxValue))
+ .Throws<InvalidDateException>();
+```
+
+There are also more advanced methods that can throw exceptions based
+on values calculated at runtime. These act similarly to how you
+[specify return values that are calculated at call time](specifying-return-values.md#return-values-calculated-at-call-time). For
+example
+
+```csharp
+// Generate the exception at call time.
+A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
+ .Throws(() => new InvalidDateException(DateTime.UtcNow + " is in the future");
+
+// Pass up to 4 original call argument values into the method that creates the exception.
+// Since FakeItEasy 1.15.0, this works even if NumberOfSweetsSoldOn takes a ref DateTime 
+// an out DateTime.
+A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
+ .Throws((DateTime when)=>new InvalidDateException(when + " is in the future");
+
+// Pass an IFakeObjectCall into the creation method for more advanced scenarios.
+A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
+ .Throws(callObject => new InvalidDateException(callObject.FakedObject +
+                                                " is closed on " +
+                                                callObject.Arguments[0]));
+```

--- a/docs/upgrading-from-older-versions.md
+++ b/docs/upgrading-from-older-versions.md
@@ -1,0 +1,9 @@
+# Upgrading from older versions
+
+Here is a regular expression that can help upgrade code written for older versions of FakeItEasy. Specifically, it will replace `Configure.Fake` calls with `A.CallTo` calls:
+
+Find:
+`Configure[\.:b\n]*Fake\({[:Al:Nu:Pu]*}\)[\.:b\n]*CallsTo\([:Al] =\> [:Al]\.`
+
+Replace:
+`A.CallTo(() => \1.`

--- a/docs/what-can-be-faked.md
+++ b/docs/what-can-be-faked.md
@@ -1,0 +1,37 @@
+# What can be faked
+
+## What types can be faked?
+
+FakeItEasy uses
+[Castle DynamicProxy](http://www.castleproject.org/projects/dynamicproxy/)
+to create fakes. Thus, it can fake just about anything that could
+normally be overridden, extended, or implemented.  This means that the
+following entities can be faked:
+
+* interfaces
+* classes that
+    * are not sealed,
+    * are not static, and
+    * have at least one public or protected constructor whose arguments FakeItEasy can construct or obtain
+
+
+Note that special steps will need to be taken to
+[fake internal interfaces and classes](how-to-fake-internal-types.md).
+
+### Where do the constructor arguments come from?
+  
+* they can be supplied via `WithArgumentsForConstructor` as shown in
+  [creating fakes](creating-fakes.md), or
+* FakeItEasy will use [dummies](dummies.md) as arguments
+
+## What members can be overridden?
+
+Once a fake has been constructed, its methods and properties can be
+overridden if they are:
+
+* virtual,
+* abstract, or
+* an interface method when an interface is being faked
+
+Note that this means that static members, including extension methods,
+**cannot** be overridden.

--- a/docs/why-was-fakeiteasy-created.md
+++ b/docs/why-was-fakeiteasy-created.md
@@ -1,0 +1,63 @@
+# Why was FakeItEasy created?
+
+#Introduction
+
+There was a good question on Stack Overflow that asks what
+distinguishes FakeItEasy from other frameworks. creator of FakeItEasy,
+Patrik H&auml;gne, answered the question there but we reproduce the
+answer here. Note that the text has been preserved, and particular
+constructs referenced (such as `DummyDefinitions`) have changed or
+been renamed in newer versions of FakeItEasy.
+
+The question on Stack Overflow:
+"[Are fakes better than Mocks?](http://stackoverflow.com/questions/4001101/are-fakes-better-than-mocks)"
+
+#Patrik H&auml;gne's answer
+
+To be clear, I created FakeItEasy so I'll definitely not say whether
+one framework is better than the other, what I can do is point out
+some differences and motivate why I created FakeItEasy. Functionally
+there are no major differences between Moq and FakeItEasy.
+
+FakeItEasy has no "Verifiable" or "Expectations" it has assertions
+however, these are always explicitly stated at the very end of a test,
+I believe this makes tests easier to read and understand. It also
+helps beginners to avoid multiple asserts (where they would set
+expectations on many calls or mock objects).
+
+I used Rhino Mocks before and I quite liked it, especially after the
+AAA-syntax was introduced I did like the fluent API of Moq better
+though. What I didn't like with Moq was the "mock object" where you
+have to use mock.Object everywhere, I like the Rhino-approach with
+"natural" mocks better. Every instance looks and feels like a normal
+instance of the faked type. I wanted the best of both worlds and also
+I wanted to see what I could do with the syntax when I had absolutely
+free hands. Personally I (obviously) think I created something that is
+a good mix with the best from both world, but that's quite easy when
+you're standing on the shoulders of giants.
+
+As has been mentioned here one of the main differences is in the
+terminology, FakeItEasy was first created to introduce TDD and mocking
+to beginners and having to worry about the differences between mocks
+and stubs up front is not very useful.
+
+I've put a lot of focus into the exception messages, it should be very
+easy to tell what went wrong in a test just looking at an exception
+message.
+
+FakeItEasy has some extensibility features that the other frameworks
+don't have but these aren't very well documented yet.
+
+FakeItEasy is (hopefully) a little stronger in mocking classes that
+has constructor arguments since it has a mechanism for resolving
+dummy-values to use. You can even specify your own dummy value
+definitions by implementing a DummyDefinition(Of T) class within your
+test project, this will automatically be picked up by FakeItEasy.
+
+The syntax is an obvious difference, which one is better is largely a
+matter of taste.
+
+I'm sure there are lots of other differences that I forget about now
+(and to be fair I've never used Moq in production myself so my
+knowledge of it is limited), I do think these are the most important
+differences though.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,44 @@
+site_name: FakeItEasy 
+site_dir: artifacts/docs
+theme: readthedocs
+repo_url: https://github.com/FakeItEasy/FakeItEasy
+
+
+pages:
+- FakeItEasy: index.md
+- Quickstart: quickstart.md
+- Creating Fakes: 
+  - Creating Fakes: creating-fakes.md
+  - What can be faked: what-can-be-faked.md
+  - Default fake behavior: default-fake-behavior.md
+  - How to fake internal (Friend in VB) types: how-to-fake-internal-types.md
+- Specifying Fakes’ Behavior:
+  - Specifying a Call to Configure: specifying-a-call-to-configure.md
+  - Specifying Return Values: specifying-return-values.md
+  - Throwing Exceptions: throwing-exceptions.md
+  - Doing Nothing: doing-nothing.md
+  - Read/Write Property Behavior: read-write-property-behavior.md
+  - Assigning out and ref parameters: assigning-out-and-ref-parameters.md
+  - Invoking Custom Code: invoking-custom-code.md
+  - Calling base methods: calling-base-methods.md
+  - Limited Call Specifications: limited-call-specifications.md
+- Argument constraints: argument-constraints.md
+- Assertion:
+  - Assertion: assertion.md
+  - Ordered assertions: ordered-assertions.md
+- Faking async methods: faking-async-methods.md
+- Raising events: raising-events.md
+- Strict fakes: strict-fakes.md
+- Dummies:
+  - Dummies: dummies.md
+  - Custom Dummy Creation: custom-dummy-creation.md
+- Formatting Argument Values: formatting-argument-values.md
+- Scanning for Extension Points: scanning-for-extension-points.md
+- Bootstrapper: bootstrapper.md
+- Snippets for FakeItEasy in SideWaffle: snippets-for-fakeiteasy-in-sidewaffle.md
+- Platform support: platform-support.md
+- Troubleshooting:
+  - Slow startup time: slow-startup-time.md
+- Why was FakeItEasy created?: why-was-fakeiteasy-created.md
+- Upgrading from older versions: upgrading-from-older-versions.md
+- External Resources: external-resources.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: FakeItEasy
 site_dir: artifacts/docs
 theme: readthedocs
 repo_url: https://github.com/FakeItEasy/FakeItEasy
-
+extra_css: [css/highlight.css]
 
 pages:
 - FakeItEasy: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: FakeItEasy
 site_dir: artifacts/docs
 theme: readthedocs
 repo_url: https://github.com/FakeItEasy/FakeItEasy
-extra_css: [css/highlight.css]
+extra_css: [css/extra-highlight.css]
 
 pages:
 - FakeItEasy: index.md


### PR DESCRIPTION
Connects to #626.

Docs can be previewed at http://bfakeiteasy.readthedocs.org/en/read-the-docs-1.25.3/

Imported the documentation from the wiki, in a MkDocs-style layout.
Adjusted the markdown to conform to MkDocs/ReadTheDocs requirements,
removed references to features in 2.0, and
corrected some minor errors.