### PR TITLE
Improve documentation code styling

### DIFF
--- a/docs/css/extra-highlight.css
+++ b/docs/css/extra-highlight.css
@@ -1,3 +1,14 @@
+code {
+    font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    border-radius: 3px;
+    border-width: 0px;
+    background-color: #f7f7f7;
+    color: inherit;
+    font-size: inherit;
+    padding-top: 0.1em;
+    padding-bottom: 0.1em;
+}
+
 /*
 Modified GitHub theme for highlight.js
 
@@ -10,14 +21,17 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   overflow-x: auto;
   padding: 0.5em;
   color: #333;
+  background-color: #f7f7f7;
+  border-width: 0px;
+  font-size: inherit;
   -webkit-text-size-adjust: none;
 }
 
 .hljs-comment,
 .diff .hljs-header,
 .hljs-javadoc {
-  color: #998;
-  font-style: italic;
+  color: #969896;
+  font-style: normal;
 }
 
 .hljs-keyword,
@@ -27,14 +41,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-subst,
 .hljs-request,
 .hljs-status {
-  color: #333;
-  font-weight: bold;
+  color: #a71d5d;
+  font-weight: normal;
 }
 
 .hljs-number,
 .hljs-hexcolor,
 .ruby .hljs-constant {
-  color: #008080;
+  color: #0086b3;
 }
 
 .hljs-string,
@@ -42,14 +56,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-phpdoc,
 .hljs-dartdoc,
 .tex .hljs-formula {
-  color: #d14;
+  color: #183691;
 }
 
 .hljs-title,
 .hljs-id,
 .scss .hljs-preprocessor {
-  color: #900;
-  font-weight: bold;
+  color: #795da3;
+  font-weight: normal;
 }
 
 .hljs-list .hljs-keyword,
@@ -62,7 +76,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .vhdl .hljs-literal,
 .tex .hljs-command {
   color: #458;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .hljs-tag,
@@ -105,7 +119,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-shebang,
 .hljs-cdata {
   color: #999;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .hljs-deletion {

--- a/docs/css/highlight.css
+++ b/docs/css/highlight.css
@@ -1,0 +1,125 @@
+/*
+Modified GitHub theme for highlight.js
+
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #333;
+  -webkit-text-size-adjust: none;
+}
+
+.hljs-comment,
+.diff .hljs-header,
+.hljs-javadoc {
+  color: #998;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.css .rule .hljs-keyword,
+.hljs-winutils,
+.nginx .hljs-title,
+.hljs-subst,
+.hljs-request,
+.hljs-status {
+  color: #333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-hexcolor,
+.ruby .hljs-constant {
+  color: #008080;
+}
+
+.hljs-string,
+.hljs-tag .hljs-value,
+.hljs-phpdoc,
+.hljs-dartdoc,
+.tex .hljs-formula {
+  color: #d14;
+}
+
+.hljs-title,
+.hljs-id,
+.scss .hljs-preprocessor {
+  color: #900;
+  font-weight: bold;
+}
+
+.hljs-list .hljs-keyword,
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-class .hljs-title,
+.hljs-type,
+.vhdl .hljs-literal,
+.tex .hljs-command {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-tag .hljs-title,
+.hljs-rule .hljs-property,
+.django .hljs-tag .hljs-keyword {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-attribute,
+.hljs-variable,
+.lisp .hljs-body,
+.hljs-name {
+  color: #008080;
+}
+
+.hljs-regexp {
+  color: #009926;
+}
+
+.hljs-symbol,
+.ruby .hljs-symbol .hljs-string,
+.lisp .hljs-keyword,
+.clojure .hljs-keyword,
+.scheme .hljs-keyword,
+.tex .hljs-special,
+.hljs-prompt {
+  color: #990073;
+}
+
+.hljs-built_in {
+  color: #0086b3;
+}
+
+.hljs-preprocessor,
+.hljs-pragma,
+.hljs-pi,
+.hljs-doctype,
+.hljs-shebang,
+.hljs-cdata {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.diff .hljs-change {
+  background: #0086b3;
+}
+
+.hljs-chunk {
+  color: #aaa;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: FakeItEasy
 site_dir: artifacts/docs
 theme: readthedocs
 repo_url: https://github.com/FakeItEasy/FakeItEasy
-
+extra_css: [css/highlight.css]
 
 pages:
 - FakeItEasy: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: FakeItEasy
 site_dir: artifacts/docs
 theme: readthedocs
 repo_url: https://github.com/FakeItEasy/FakeItEasy
-extra_css: [css/highlight.css]
+extra_css: [css/extra-highlight.css]
 
 pages:
 - FakeItEasy: index.md


### PR DESCRIPTION
This PR contributes to #626, and updates code styling by cherry-picking the last two commits from #634, which were applied to the 1.25.3 docs.
Preview at http://bfakeiteasy.readthedocs.org/en/read-the-docs-2.0/