### PR TITLE
[WIP]make FakeManager internal

### DIFF
--- a/src/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Core
     using System.Linq;
 
     /// <content>Auto fake property rule.</content>
-    public partial class FakeManager
+    internal partial class FakeManager
     {
         [Serializable]
         private class AutoFakePropertyRule

--- a/src/FakeItEasy/Core/FakeManager.EventRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.EventRule.cs
@@ -7,7 +7,7 @@ namespace FakeItEasy.Core
     using System.Reflection;
 
     /// <content>Event rule.</content>
-    public partial class FakeManager
+    internal partial class FakeManager
     {
         [Serializable]
         [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Would provide no benefit since there is no place from where to call the Dispose-method.")]

--- a/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Core
     using FakeItEasy.Creation;
 
     /// <content>Object member rule.</content>
-    public partial class FakeManager
+    internal partial class FakeManager
     {
         [Serializable]
         private class ObjectMemberRule

--- a/src/FakeItEasy/Core/FakeManager.PropertyBehaviorRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.PropertyBehaviorRule.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Core
     using System.Reflection;
 
     /// <content>Property behavior rule.</content>
-    public partial class FakeManager
+    internal partial class FakeManager
     {
         private class PropertyBehaviorRule
             : IFakeObjectCallRule

--- a/src/FakeItEasy/Core/FakeManager.PropertySetterRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.PropertySetterRule.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Core
     using System.Linq;
 
     /// <content>Property setter rule.</content>
-    public partial class FakeManager
+    internal partial class FakeManager
     {
         [Serializable]
         private class PropertySetterRule

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -14,7 +14,7 @@ namespace FakeItEasy.Core
     /// by using the AddRule-method.
     /// </summary>
     [Serializable]
-    public partial class FakeManager : IFakeCallProcessor
+    internal partial class FakeManager : IFakeCallProcessor
     {
         private readonly LinkedList<CallRuleMetadata> allUserRulesField;
         private readonly CallRuleMetadata[] postUserRules;

--- a/src/FakeItEasy/Fake.cs
+++ b/src/FakeItEasy/Fake.cs
@@ -23,7 +23,7 @@ namespace FakeItEasy
         /// <returns>The fake object manager.</returns>
         [DebuggerStepThrough]
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "object", Justification = "The term fake object does not refer to the type System.Object.")]
-        public static FakeManager GetFakeManager(object fakedObject)
+        internal static FakeManager GetFakeManager(object fakedObject)
         {
             return Facade.GetFakeManager(fakedObject);
         }

--- a/tests/FakeItEasy.Specs/CreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationSpecs.cs
@@ -71,7 +71,7 @@ namespace FakeItEasy.Specs
                 .x(() => fakes.Should().ContainItemsAssignableTo<ICollectionItem>());
 
             "And all items should be fakes"
-                .x(() => fakes.Should().OnlyContain(item => Fake.GetFakeManager(item) != null));
+                .x(() => fakes.Should().OnlyContain(item => item.GetType().Assembly.FullName.StartsWith("DynamicProxyGenAssembly2")));
         }
 
         public class ClassWhoseConstructorThrows

--- a/tests/FakeItEasy.Tests/CustomArgumentConstraints.cs
+++ b/tests/FakeItEasy.Tests/CustomArgumentConstraints.cs
@@ -8,7 +8,7 @@ namespace FakeItEasy.Tests
     using FakeItEasy.Creation;
     using FakeItEasy.Expressions;
 
-    public static class CustomArgumentConstraints
+    internal static class CustomArgumentConstraints
     {
         public static T IsThisSequence<T>(this IArgumentConstraintManager<T> scope, T collection) where T : IEnumerable
         {


### PR DESCRIPTION
*Currently for discussion only.*

So here's a thing. Again, whilst poking around wrt #651, I noticed that `FakeManager`, apart from one dubious call in the specs, can be internal.

Call the :cop:s! Am I committing heresy here? It is designed to be public?