### PR TITLE
Change analyzer diagnostic id to FakeItEasy001

### DIFF
--- a/src/FakeItEasy.Analyzer/UnusedCallSpecificationAnalyzer.cs
+++ b/src/FakeItEasy.Analyzer/UnusedCallSpecificationAnalyzer.cs
@@ -10,7 +10,7 @@ namespace FakeItEasy.Analyzer
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class UnusedCallSpecificationAnalyzer : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = "UnusedCallSpecification";
+        public const string DiagnosticId = "FakeItEasy001";
         internal const string Category = "Usage";
 
         internal static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.UnusedCallSpecificationTitle), Resources.ResourceManager, typeof(Resources));

--- a/src/FakeItEasy.Analyzer/UnusedCallSpecificationAnalyzer.cs
+++ b/src/FakeItEasy.Analyzer/UnusedCallSpecificationAnalyzer.cs
@@ -17,7 +17,7 @@ namespace FakeItEasy.Analyzer
         internal static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.UnusedCallSpecificationMessageFormat), Resources.ResourceManager, typeof(Resources));
         internal static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.UnusedCallSpecificationDescription), Resources.ResourceManager, typeof(Resources));
 
-        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/tests/FakeItEasy.Analyzer.Tests/UnusedCallSpecificationAnalyzerTests.cs
+++ b/tests/FakeItEasy.Analyzer.Tests/UnusedCallSpecificationAnalyzerTests.cs
@@ -100,7 +100,7 @@ namespace TheNamespace
                     Id = UnusedCallSpecificationAnalyzer.DiagnosticId,
                     Message =
                         "Unused call specification for 'foo.Bar()'; did you forget to configure or assert the call?",
-                    Severity = DiagnosticSeverity.Warning,
+                    Severity = DiagnosticSeverity.Error,
                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 13) }
                 });
         }


### PR DESCRIPTION
I couldn't find any guidelines about what we should use for diagnostic ids, but we should probably use numbered ids with a common prefix; that's what everyone else seems to be doing.

Also, should we change the default severity of the diagnostic to `Error` rather than `Warning` ? Ignoring the result of `CallTo` will almost certainly not be intentional. And it can always be overriden in the .ruleset file if necessary.

Connects to #490