### PR TITLE
[WIP] Add WithNonVoidReturnType function

### DIFF
--- a/src/FakeItEasy/Configuration/AnyCallCallRule.cs
+++ b/src/FakeItEasy/Configuration/AnyCallCallRule.cs
@@ -15,6 +15,8 @@ namespace FakeItEasy.Configuration
 
         public Type ApplicableToMembersWithReturnType { get; set; }
 
+        public bool ApplicableToAllNonVoidReturnTypes { get; set; }
+
         public override string DescriptionOfValidCall
         {
             get
@@ -37,7 +39,9 @@ namespace FakeItEasy.Configuration
         {
             return
                 this.argumentsPredicate(fakeObjectCall.Arguments) &&
-                    (this.ApplicableToMembersWithReturnType == null || this.ApplicableToMembersWithReturnType.Equals(fakeObjectCall.Method.ReturnType));
+                    (this.ApplicableToMembersWithReturnType == null 
+                    || this.ApplicableToMembersWithReturnType.Equals(fakeObjectCall.Method.ReturnType)
+                    || this.ApplicableToAllNonVoidReturnTypes);
         }
     }
 }

--- a/src/FakeItEasy/Configuration/AnyCallConfiguration.cs
+++ b/src/FakeItEasy/Configuration/AnyCallConfiguration.cs
@@ -29,6 +29,12 @@ namespace FakeItEasy.Configuration
             return this.configurationFactory.CreateConfiguration<TMember>(this.manager, this.configuredRule);
         }
 
+        public IAnyCallConfigurationWithReturnTypeSpecified<object> WithNonVoidReturnType()
+        {
+            this.configuredRule.ApplicableToAllNonVoidReturnTypes = true;
+            return this.configurationFactory.CreateConfiguration<object>(this.manager, this.configuredRule);
+        }
+
         public IAfterCallSpecifiedConfiguration DoesNothing()
         {
             return this.VoidConfiguration.DoesNothing();

--- a/src/FakeItEasy/Configuration/IAnyCallConfiguration.cs
+++ b/src/FakeItEasy/Configuration/IAnyCallConfiguration.cs
@@ -15,5 +15,7 @@ namespace FakeItEasy.Configuration
         /// <returns>A configuration object.</returns>
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Used to provide a strongly typed fluent API.")]
         IAnyCallConfigurationWithReturnTypeSpecified<TMember> WithReturnType<TMember>();
+
+        IAnyCallConfigurationWithReturnTypeSpecified<object> WithNonVoidReturnType();
     }
 }

--- a/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
+++ b/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
@@ -81,7 +81,7 @@ namespace FakeItEasy.Expressions
             var trappedConstraints = this.argumentConstraintTrapper.TrapConstraints(() =>
             {
                 expressionValue = InvokeExpression(expression);
-            });
+            }) ?? new IArgumentConstraint[0];
 
             return TryCreateConstraintFromTrappedConstraints(trappedConstraints.ToArray()) ?? CreateEqualityConstraint(expressionValue);
         }

--- a/tests/FakeItEasy.Tests/Configuration/AnyCallConfigurationTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/AnyCallConfigurationTests.cs
@@ -48,6 +48,19 @@ namespace FakeItEasy.Tests.Configuration
             Assert.That(this.callRule.ApplicableToMembersWithReturnType, Is.EqualTo(typeof(string)));
         }
 
+
+        [Test]
+        public void WithNonVoidReturnType_should_set_the_flag_to_apply_to_all_return_types()
+        {
+            // Arrange
+
+            // Act
+            this.configuration.WithNonVoidReturnType();
+
+            // Assert
+            Assert.That(this.callRule.ApplicableToAllNonVoidReturnTypes, Is.EqualTo(true));
+        }
+
         [Test]
         public void DoesNothing_delegates_to_configuration_produced_by_factory()
         {

--- a/tests/FakeItEasy.Tests/Expressions/ExpressionArgumentConstraintFactoryTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ExpressionArgumentConstraintFactoryTests.cs
@@ -44,6 +44,20 @@ namespace FakeItEasy.Tests.Expressions
             result.Should().BeSameAs(constraint);
         }
 
+
+        [Test]
+        public void Should_return_null_from_trapper_when_set_to_return_null()
+        {
+            // Arrange
+            A.CallTo(this.trapper).WithNonVoidReturnType().Returns(null);
+
+            // Act
+            var result = this.factory.GetArgumentConstraint(BuilderForParsedArgumentExpression.BuildWithDefaults());
+
+            // Assert
+            result.Should().BeNull();
+        }
+
         [Test]
         public void Should_return_equality_constraint_when_trapper_does_not_produce_any_constraint()
         {


### PR DESCRIPTION
DO NOT MERGE.

I started working on the https://github.com/FakeItEasy/FakeItEasy/issues/648 issue, just to see if I can manage to get it done, and I got to weird exception here.

First of all, I don't know if I am taking the right approach, so feel free to tell me where should I look at.

Secondly, I added a unit test to see how my code works so far (Should_return_null_from_trapper_when_set_to_return_null in ExpressionArgumentConstraintFactoryTests.cs), and it blows up saying this:

`Expected object to be <null>, but found <NULL>.`

which I cannot wrap my head around...

Can I ask one of the FakeItEasy gurus to help me out with this? :smile:

<!-- connects to #648 -->