### PR TITLE
refactor: move System.Diagnostics.CodeAnalysis to using statement

### DIFF
--- a/src/FakeItEasy.Analyzer/DiagnosticDefinitions.cs
+++ b/src/FakeItEasy.Analyzer/DiagnosticDefinitions.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy.Analyzer
 {
     using System;
     using System.Collections.Immutable;
+    using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
     using Microsoft.CodeAnalysis;
 
@@ -9,7 +10,7 @@ namespace FakeItEasy.Analyzer
     {
         public static DiagnosticDescriptor UnusedCallSpecification { get; } = CreateDiagnosticDescriptor(nameof(UnusedCallSpecification), "FakeItEasy0001", "FakeItEasy.Usage", DiagnosticSeverity.Error, true);
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1305:SpecifyIFormatProvider", MessageId = "System.String.Format(System.String,System.Object[])", Justification = "Irrelevant in this case")]
+        [SuppressMessage("Microsoft.Globalization", "CA1305:SpecifyIFormatProvider", MessageId = "System.String.Format(System.String,System.Object[])", Justification = "Irrelevant in this case")]
         public static ImmutableDictionary<string, DiagnosticDescriptor> GetDiagnosticsMap(params string[] diagnosticNames)
         {
             if (diagnosticNames == null)

--- a/src/FakeItEasy/Core/ArgumentConstraintTrap.cs
+++ b/src/FakeItEasy/Core/ArgumentConstraintTrap.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy.Core
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     internal class ArgumentConstraintTrap
         : IArgumentConstraintTrapper
@@ -9,7 +10,7 @@ namespace FakeItEasy.Core
         [ThreadStatic]
         private static List<IArgumentConstraint> trappedConstraints;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
         public static void ReportTrappedConstraint(IArgumentConstraint constraint)
         {
             if (trappedConstraints == null)

--- a/tests/FakeItEasy.Analyzer.Tests/Helpers/CodeFixVerifier.cs
+++ b/tests/FakeItEasy.Analyzer.Tests/Helpers/CodeFixVerifier.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading;
     using FluentAssertions;
@@ -22,7 +23,7 @@
         /// Returns the code fix being tested (C#) - to be implemented in non-abstract class.
         /// </summary>
         /// <returns>The CodeFixProvider to be used for CSharp code.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "It's not appropriate here")]
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "It's not appropriate here")]
         protected virtual CodeFixProvider GetCSharpCodeFixProvider()
         {
             return null;
@@ -32,7 +33,7 @@
         /// Returns the code fix being tested (VB) - to be implemented in non-abstract class.
         /// </summary>
         /// <returns>The CodeFixProvider to be used for VisualBasic code.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "It's not appropriate here")]
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "It's not appropriate here")]
         protected virtual CodeFixProvider GetBasicCodeFixProvider()
         {
             return null;
@@ -45,7 +46,7 @@
         /// <param name="newSource">A class in the form of a string after the code fix was applied to it.</param>
         /// <param name="codeFixIndex">Index determining which code fix to apply if there are multiple.</param>
         /// <param name="allowNewCompilerDiagnostics">A boolean controlling whether or not the test will fail if the code fix introduces other warnings after being applied.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Justification = "It's not intended to be a public API, so it doesn't matter")]
+        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Justification = "It's not intended to be a public API, so it doesn't matter")]
         protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
         {
             this.VerifyFix(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzer(), this.GetCSharpCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
@@ -58,7 +59,7 @@
         /// <param name="newSource">A class in the form of a string after the code fix was applied to it.</param>
         /// <param name="codeFixIndex">Index determining which code fix to apply if there are multiple.</param>
         /// <param name="allowNewCompilerDiagnostics">A boolean controlling whether or not the test will fail if the code fix introduces other warnings after being applied.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Justification = "It's not intended to be a public API, so it doesn't matter")]
+        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Justification = "It's not intended to be a public API, so it doesn't matter")]
         protected void VerifyBasicFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
         {
             this.VerifyFix(LanguageNames.VisualBasic, this.GetBasicDiagnosticAnalyzer(), this.GetBasicCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);

--- a/tests/FakeItEasy.Analyzer.Tests/Helpers/DiagnosticResult.cs
+++ b/tests/FakeItEasy.Analyzer.Tests/Helpers/DiagnosticResult.cs
@@ -1,12 +1,13 @@
 ﻿namespace FakeItEasy.Analyzer.Tests.Helpers
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using Microsoft.CodeAnalysis;
 
     /// <summary>
     /// Location where the diagnostic appears, as determined by path, line number, and column number.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "Not necessary")]
+    [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "Not necessary")]
     internal struct DiagnosticResultLocation
     {
         public DiagnosticResultLocation(string path, int line, int column)
@@ -36,12 +37,12 @@
     /// <summary>
     /// Struct that stores information about a Diagnostic appearing in a source.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "Not necessary")]
+    [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "Not necessary")]
     internal struct DiagnosticResult
     {
         private DiagnosticResultLocation[] locations;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "It's not intended to be a public API, so it doesn't matter")]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "It's not intended to be a public API, so it doesn't matter")]
         public DiagnosticResultLocation[] Locations
         {
             get

--- a/tests/FakeItEasy.Analyzer.Tests/Helpers/DiagnosticVerifier.cs
+++ b/tests/FakeItEasy.Analyzer.Tests/Helpers/DiagnosticVerifier.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Text;
     using FluentAssertions;
@@ -29,7 +30,7 @@
         /// Get the CSharp analyzer being tested - to be implemented in non-abstract class.
         /// </summary>
         /// <returns>The diagnostic analyzer being tested.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "It's not appropriate here")]
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "It's not appropriate here")]
         protected virtual DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return null;
@@ -39,7 +40,7 @@
         /// Get the Visual Basic analyzer being tested - to be implemented in non-abstract class.
         /// </summary>
         /// <returns>The diagnostic analyzer being tested.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "It's not appropriate here")]
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "It's not appropriate here")]
         protected virtual DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
             return null;

--- a/tests/FakeItEasy.Analyzer.Tests/UnusedCallSpecificationAnalyzerTests.cs
+++ b/tests/FakeItEasy.Analyzer.Tests/UnusedCallSpecificationAnalyzerTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace FakeItEasy.Analyzer.Tests
 {
+    using System.Diagnostics.CodeAnalysis;
     using FakeItEasy.Analyzer.Tests.Helpers;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
@@ -75,7 +76,7 @@ namespace TheNamespace
 
         [Test]
         [SetUICulture("en-US")] // so that the message is in the expected language regardless of the OS language
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
         public void Diagnostic_Should_Be_Triggered_When_Call_Specification_Is_Not_Used()
         {
             var test = @"using FakeItEasy;
@@ -108,7 +109,7 @@ namespace TheNamespace
 
         [Test]
         [SetUICulture("en-US")] // so that the message is in the expected language regardless of the OS language
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
         public void Diagnostic_Should_Have_The_Correct_Call_Description_For_Call_To_With_No_Expression()
         {
             var test = @"using FakeItEasy;
@@ -140,8 +141,8 @@ namespace TheNamespace
 
         [Test]
         [SetUICulture("en-US")] // so that the message is in the expected language regardless of the OS language
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "WithAnyArguments", Justification = "It's an identifier")]
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "WithAnyArguments", Justification = "It's an identifier")]
         public void Diagnostic_Should_Have_The_Correct_Call_Description_If_Triggered_On_WithAnyArguments()
         {
             var test = @"using FakeItEasy;
@@ -173,8 +174,8 @@ namespace TheNamespace
 
         [Test]
         [SetUICulture("en-US")] // so that the message is in the expected language regardless of the OS language
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "WithReturnType", Justification = "It's an identifier")]
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CallTo", Justification = "It's an identifier")]
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "WithReturnType", Justification = "It's an identifier")]
         public void Diagnostic_Should_Have_The_Correct_Call_Description_If_Triggered_On_Where()
         {
             var test = @"using FakeItEasy;

--- a/tests/FakeItEasy.Specs/TaskSpecs.cs
+++ b/tests/FakeItEasy.Specs/TaskSpecs.cs
@@ -1,5 +1,6 @@
 ﻿namespace FakeItEasy.Specs
 {
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
     using FluentAssertions;
     using Xbehave;
@@ -12,10 +13,10 @@
 
             Task<int> QueryAsync();
 
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate in this case")]
+            [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate in this case")]
             Task<Foo> GetFooAsync();
 
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate in this case")]
+            [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate in this case")]
             Task<Bar> GetBarAsync();
         }
 


### PR DESCRIPTION
There were only a few places in the codebase where we having the namespace in-line, compared to many where we use a `using`, so I aligned everything to use a `using`.