### PR TITLE
Fix AssignsOutAndRefParameters for faked delegates

### DIFF
--- a/tests/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
+++ b/tests/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
@@ -6,6 +6,10 @@ namespace FakeItEasy.Specs
     using FluentAssertions;
     using Xbehave;
 
+    public delegate void VoidDelegateWithOutAndRefParameters(int x, ref int y, out int z);
+
+    public delegate int NonVoidDelegateWithOutAndRefParameters(int x, ref int y, out int z);
+
     public interface IHaveAnOut
     {
         [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Required for testing.")]
@@ -118,6 +122,54 @@ namespace FakeItEasy.Specs
 
             "it should throw an invalid operation exception"
                 .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
+        }
+
+        [Scenario]
+        public static void AssignOutAndRefParameterForVoidDelegate(
+            VoidDelegateWithOutAndRefParameters subject,
+            int refValue,
+            int outValue)
+        {
+            "Given a faked delegate with void return type and ref and out parameters"
+                .x(() => subject = A.Fake<VoidDelegateWithOutAndRefParameters>());
+
+            "When the faked delegate is configured to assign the out and ref parameters"
+                .x(() => A.CallTo(() => subject(1, ref refValue, out outValue)).AssignsOutAndRefParameters(42, 99));
+
+            "And I call the faked delegate"
+                .x(() => subject(1, ref refValue, out outValue));
+
+            "Then the ref parameter is set to the specified value"
+                .x(() => refValue.Should().Be(42));
+
+            "And the out parameter is set to the specified value"
+                .x(() => outValue.Should().Be(99));
+        }
+
+        [Scenario]
+        public static void AssignOutAndRefParameterForNonVoidDelegate(
+            NonVoidDelegateWithOutAndRefParameters subject,
+            int refValue,
+            int outValue,
+            int result)
+        {
+            "Given a faked delegate with a non-void return type and ref and out parameters"
+                .x(() => subject = A.Fake<NonVoidDelegateWithOutAndRefParameters>());
+
+            "When the faked delegate is configured to assign the out and ref parameters"
+                .x(() => A.CallTo(() => subject(1, ref refValue, out outValue)).Returns(123).AssignsOutAndRefParameters(42, 99));
+
+            "And I call the faked delegate"
+                .x(() => result = subject(1, ref refValue, out outValue));
+
+            "Then it returns the specified value"
+                .x(() => result.Should().Be(123));
+
+            "And the ref parameter is set to the specified value"
+                .x(() => refValue.Should().Be(42));
+
+            "And the out parameter is set to the specified value"
+                .x(() => outValue.Should().Be(99));
         }
     }
 }

--- a/tests/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
+++ b/tests/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
@@ -2,125 +2,126 @@ namespace FakeItEasy.Specs
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using Xbehave;
 
-    public delegate void VoidDelegateWithOutAndRefParameters(int x, ref int y, out int z);
+    [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "WithOut", Justification = "That's two words, not one")]
+    [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "1#", Justification = "Required for testing.")]
+    [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "Required for testing.")]
+    public delegate void VoidDelegateWithOutAndRefParameters(int byValueParameter, ref int byRefParameter, out int outParameter);
 
-    public delegate int NonVoidDelegateWithOutAndRefParameters(int x, ref int y, out int z);
+    [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "WithOut", Justification = "That's two words, not one")]
+    [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "1#", Justification = "Required for testing.")]
+    [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "Required for testing.")]
+    public delegate int NonVoidDelegateWithOutAndRefParameters(int byValueParameter, ref int byRefParameter, out int outParameter);
 
-    public interface IHaveAnOut
+    public interface IHaveARef
     {
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Required for testing.")]
-        void MightReturnAKnownValue(out string andThisIsWhoReallyDidIt);
+        [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "0#", Justification = "Required for testing.")]
+        void MightReturnAKnownValue(ref string andThisIsWhoReallyDidIt);
     }
 
     public static class AssignsOutAndRefParametersSpecs
     {
+        const string Condition = "someone_else";
+        const string KnownOutput = "you";
+
         [Scenario]
         public static void AssignOutAndRefParametersLazilyUsingFunc(
-            IHaveAnOut subject,
+            IHaveARef subject,
             string outValue)
         {
-            var condition = "someone_else";
-            var knownOutput = "you";
+            "Given a fake with a method that has a ref parameter"
+                .x(() => subject = A.Fake<IHaveARef>());
 
-            "establish"
-                .x(() => subject = A.Fake<IHaveAnOut>());
-
-            "when configuring a fake to assign out and ref parameters lazily using func"
-                .x(() => A.CallTo(() => subject.MightReturnAKnownValue(out outValue))
+            "When the fake is configured to assign out and ref parameters lazily using func"
+                .x(() => A.CallTo(() => subject.MightReturnAKnownValue(ref outValue))
                     .WithAnyArguments()
                     .AssignsOutAndRefParametersLazily((string value) => new object[]
                     {
-                        value == condition ? knownOutput : "me"
+                        value == Condition ? KnownOutput : "me"
                     }));
 
-            "it should assign the conditional value to the out field"
+            "And the configured method is called with matching arguments"
                 .x(() =>
-                    {
-                        string value = condition;
-                        subject.MightReturnAKnownValue(out value);
-                        value.Should().BeEquivalentTo(knownOutput);
-                    });
+                {
+                    outValue = Condition;
+                    subject.MightReturnAKnownValue(ref outValue);
+                });
+
+            "Then it assigns the conditional value to the ref field"
+                .x(() => outValue.Should().BeEquivalentTo(KnownOutput));
         }
 
         [Scenario]
         public static void AssignOutAndRefParametersLazilyUsingCall(
-            IHaveAnOut subject,
+            IHaveARef subject,
             string outValue)
         {
-            var condition = "someone_else";
-            var knownOutput = "you";
+            "Given a fake with a method that has a ref parameter"
+                .x(() => subject = A.Fake<IHaveARef>());
 
-            "establish"
-                .x(() => subject = A.Fake<IHaveAnOut>());
-
-            "when configuring a fake to assign out and ref parameters lazily using call"
-                .x(() => A.CallTo(() => subject.MightReturnAKnownValue(out outValue))
+            "When the fake is configured to assign out and ref parameters lazily using call"
+                .x(() => A.CallTo(() => subject.MightReturnAKnownValue(ref outValue))
                     .WithAnyArguments()
                     .AssignsOutAndRefParametersLazily((call) => new object[]
                     {
-                        call.Arguments.Get<string>(0) == condition ? knownOutput : "me"
+                        call.Arguments.Get<string>(0) == Condition ? KnownOutput : "me"
                     }));
 
-            "it should assign the conditional value to the out field"
+            "And the configured method is called with matching arguments"
                 .x(() =>
-                    {
-                        string value = condition;
-                        subject.MightReturnAKnownValue(out value);
-                        value.Should().BeEquivalentTo(knownOutput);
-                    });
+                {
+                    outValue = Condition;
+                    subject.MightReturnAKnownValue(ref outValue);
+                });
+
+            "Then it assigns the conditional value to the ref field"
+                .x(() => outValue.Should().BeEquivalentTo(KnownOutput));
         }
 
         [Scenario]
         public static void AssignOutAndRefParameters(
-            IHaveAnOut subject,
+            IHaveARef subject,
             string outValue)
         {
-            var condition = "someone_else";
-            var knownOutput = "you";
+            "Given a fake with a method that has a ref parameter"
+                .x(() => subject = A.Fake<IHaveARef>());
 
-            "establish"
-                .x(() => subject = A.Fake<IHaveAnOut>());
-
-            "when configuring a fake to assign out and ref parameters"
-                .x(() => A.CallTo(() => subject.MightReturnAKnownValue(out outValue))
+            "When the fake is configured to assign out and ref parameters unconditionally"
+                .x(() => A.CallTo(() => subject.MightReturnAKnownValue(ref outValue))
                              .WithAnyArguments()
-                             .AssignsOutAndRefParameters(knownOutput));
+                             .AssignsOutAndRefParameters(KnownOutput));
 
-            "it should assign the conditional value to the out field"
-                .x(() =>
-                    {
-                        string value = condition;
-                        subject.MightReturnAKnownValue(out value);
-                        value.Should().BeEquivalentTo(knownOutput);
-                    });
+            "And the configured method is called"
+                .x(() => subject.MightReturnAKnownValue(ref outValue));
+
+            "Then it assigns the configured value to the ref field"
+                .x(() => outValue.Should().BeEquivalentTo(KnownOutput));
         }
 
         [Scenario]
         public static void MultipleAssignOutAndRefParameters(
-            IHaveAnOut subject,
+            IHaveARef subject,
             string outValue,
+            IVoidConfiguration callSpec,
             Exception exception)
         {
-            "establish"
-                .x(() => subject = A.Fake<IHaveAnOut>());
+            "Given a fake with a method that has a ref parameter"
+                .x(() => subject = A.Fake<IHaveARef>());
 
-            "when configuring a fake to assign out and ref parameters multiple times"
-                .x(() =>
-                {
-                    var callSpec =
-                        A.CallTo(() => subject.MightReturnAKnownValue(out outValue))
-                            .WithAnyArguments();
+            "And a call specification on that fake"
+                .x(() => callSpec = A.CallTo(() => subject.MightReturnAKnownValue(ref outValue)).WithAnyArguments());
 
-                    callSpec.AssignsOutAndRefParameters(new object[] { "test1" });
+            "And the call specification is configured to assign out and ref parameters"
+                .x(() => callSpec.AssignsOutAndRefParameters("test1"));
 
-                    exception = Record.Exception(() => callSpec.AssignsOutAndRefParameters(new object[] { "test2" }));
-                });
+            "When the fake is configured to assign out and ref parameters again"
+                .x(() => exception = Record.Exception(() => callSpec.AssignsOutAndRefParameters("test2")));
 
-            "it should throw an invalid operation exception"
+            "Then it throws an invalid operation exception"
                 .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
         }
 

--- a/tests/FakeItEasy.Tests/Creation/DelegateProxies/DelegateProxyGeneratorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/DelegateProxies/DelegateProxyGeneratorTests.cs
@@ -17,7 +17,13 @@ namespace FakeItEasy.Tests.Creation.DelegateProxies
         private DelegateProxyGenerator generator;
 #pragma warning restore 649
 
-        private delegate void DelegateWithOutputValue(out string result);
+        private delegate void VoidDelegateWithOutputValue(out string result);
+
+        private delegate string NonVoidDelegateWithOutputValue(out int result);
+
+        private delegate void VoidDelegateWithRefValue(ref string result);
+
+        private delegate string NonVoidDelegateWithRefValue(ref int result);
 
         [SetUp]
         public void Setup()
@@ -150,18 +156,78 @@ namespace FakeItEasy.Tests.Creation.DelegateProxies
             proxy.Invoke();
         }
 
-        [Test, Ignore]
-        public void Should_return_proxy_where_out_parameter_can_be_set()
+        [Test]
+        public void Should_return_proxy_where_out_parameter_can_be_set_void()
         {
             // Arrange
-            var proxy = this.GenerateProxy<DelegateWithOutputValue>(x => { x.SetArgumentValue(0, "Foo"); });
+            var proxy = this.GenerateProxy<VoidDelegateWithOutputValue>(x => { x.SetArgumentValue(0, "Foo"); });
 
             // Act
-            string output = null;
+            string output;
             proxy.Invoke(out output);
 
             // Assert
             output.Should().Be("Foo");
+        }
+
+        [Test]
+        public void Should_return_proxy_where_out_parameter_can_be_set_non_void()
+        {
+            // Arrange
+            var proxy = this.GenerateProxy<NonVoidDelegateWithOutputValue>(
+                x =>
+                {
+                    x.SetArgumentValue(0, 42);
+                    x.SetReturnValue("Foo");
+                });
+
+            // Act
+            int output;
+            string result = proxy.Invoke(out output);
+
+            // Assert
+            result.Should().Be("Foo");
+            output.Should().Be(42);
+        }
+
+        [Test]
+        public void Should_return_proxy_where_ref_parameter_can_be_set_void()
+        {
+            // Arrange
+            var proxy = this.GenerateProxy<VoidDelegateWithRefValue>(
+                x =>
+                {
+                    var arg = x.GetArgument<string>(0);
+                    x.SetArgumentValue(0, arg + arg);
+                });
+
+            // Act
+            string output = "Foo";
+            proxy.Invoke(ref output);
+
+            // Assert
+            output.Should().Be("FooFoo");
+        }
+
+        [Test]
+        public void Should_return_proxy_where_ref_parameter_can_be_set_non_void()
+        {
+            // Arrange
+            var proxy = this.GenerateProxy<NonVoidDelegateWithRefValue>(
+                x =>
+                {
+                    var arg = x.GetArgument<int>(0);
+                    x.SetArgumentValue(0, arg + arg);
+                    x.SetReturnValue("Foo");
+                });
+
+            // Act
+            int output = 21;
+            string result = proxy.Invoke(ref output);
+
+            // Assert
+            result.Should().Be("Foo");
+            output.Should().Be(42);
         }
 
         [Test]


### PR DESCRIPTION
Fixes #677

WIP because I still need to add specs

I took into account the other remarks from https://github.com/thomaslevesque/FakeItEasy/commit/5570756fa1dbefc872804ad7a80bf3ad87aa9f5d