### PR TITLE
add 32-bit platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,12 @@ GEM
 
 PLATFORMS
   x64-mingw32
+  x86-mingw32
 
 DEPENDENCIES
   albacore (= 0.3.6)
   rake
   zip
+
+BUNDLED WITH
+   1.12.4


### PR DESCRIPTION
On the recommendation of http://rubyinstaller.org/downloads/ I took the conservative option and installed 32-bit Ruby on my new (64-bit) workstation:

> The 64-bit versions of Ruby are relatively new on the Windows area and not all the packages have been updated to be compatible with it. To use this version you will require some knowledge about compilers and solving dependency issues, which might be too complicated if you just want to play with the language.

(With Ruby, I don't want to do anything other than run Rake.)

Every time I run Bundler now it insists on adding these lines to Gemfile.lock so I'm bowing to the pressure and sending a PR for it. I don't think it will do any harm.