### PR TITLE
remove nuget downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![Are you mocking me?](http://fakeiteasy.github.io/img/fakeiteasy_logo_256.png)
 
 [![NuGet version](https://img.shields.io/nuget/v/FakeItEasy.svg?style=flat-square)](https://www.nuget.org/packages/FakeItEasy)
-[![NuGet downloads](https://img.shields.io/nuget/dt/FakeItEasy.svg?style=flat-square)](https://www.nuget.org/packages/FakeItEasy)
 [![Pull requests](http://issuestats.com/github/FakeItEasy/FakeItEasy/badge/pr?style=flat-square)](http://issuestats.com/github/FakeItEasy/FakeItEasy)
 [![Issues](http://issuestats.com/github/FakeItEasy/FakeItEasy/badge/issue?style=flat-square)](http://issuestats.com/github/FakeItEasy/FakeItEasy)
 [![TeamCity CodeBetter](https://img.shields.io/teamcity/codebetter/bt929.svg?style=flat-square)](http://teamcity.codebetter.com/viewType.html?buildTypeId=bt929)


### PR DESCRIPTION
shields.io no longer supports it.

We could switch to https://buildstats.info/ but then we'd have to abandon the square badge style and go with rounded corners for all:

[![NuGet Badge](https://buildstats.info/nuget/FakeItEasy)](https://www.nuget.org/packages/FakeItEasy/)