### PR TITLE
fixed several syntax issues in documentation

### DIFF
--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -19,7 +19,7 @@ Then the arguments to Bar can be constrained used to limit call matching:
 ```csharp
 var foo = A.Fake<IFoo>();
 
-A.CallTo(() => foo.Bar("hello", 17).MustHaveHappened();
+A.CallTo(() => foo.Bar("hello", 17)).MustHaveHappened();
 ```
 
 Then FakeItEasy will look _only_ for calls made with the arguments
@@ -138,7 +138,7 @@ the fake's configuration.
 
 
 ```csharp
-A.CallTo(() => foo.Bar(null, 7).WithAnyArguments().MustHaveHappened();
+A.CallTo(() => foo.Bar(null, 7)).WithAnyArguments().MustHaveHappened();
 ```
 
 The example above will match any call to `foo.Bar`, regardless of the arguments. The

--- a/docs/assigning-out-and-ref-parameters.md
+++ b/docs/assigning-out-and-ref-parameters.md
@@ -17,7 +17,7 @@ call being faked - the other arguments to the method should be
 omitted.
 
 While assigning out and ref parameters, the `Returns` method (or
-[some variant](specifying-return-values.md) should be used to specify
+[some variant](specifying-return-values.md)) should be used to specify
 the return value for the method - `AssignsOutAndRefParameters` does
 not do this on its own.
 

--- a/docs/implicit-creation-options.md
+++ b/docs/implicit-creation-options.md
@@ -14,7 +14,7 @@ public class RobotRunsAmokEventFakeOptionsBuilder : FakeOptionsBuilder<RobotRuns
         options.ConfigureFake(fake =>
         {
             A.CallTo(() => fake.CalculateTimestamp())
-                .Returns(new DateTime(1997, 8, 29, 2, 14, 03););
+                .Returns(new DateTime(1997, 8, 29, 2, 14, 03));
             robotRunsAmokEvent.ID = Guid.NewGuid();
         });
     }

--- a/docs/invoking-custom-code.md
+++ b/docs/invoking-custom-code.md
@@ -32,7 +32,7 @@ specify return values that are calculated at call time. For example
 ```csharp
 // Pass up to 4 original call argument values into the method that creates the exception.
 A.CallTo(()=>fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
- .Invokes((DateTime when) => System.Console.Out.WriteLine("showing sweet sales for " + when)
+ .Invokes((DateTime when) => System.Console.Out.WriteLine("showing sweet sales for " + when))
  .Returns(17);
 
 // Pass an IFakeObjectCall into the creation method for more advanced scenarios.

--- a/docs/specifying-a-call-to-configure.md
+++ b/docs/specifying-a-call-to-configure.md
@@ -36,7 +36,7 @@ Use `A.CallToSet` to configure the `set` behavior of read/write properties:
 
 ```csharp
 A.CallToSet(() => fakeShop.Address).To("123 Fake Street").CallsBaseMethod();
-A.CallToSet(() => fakeShop.Address).To(() => A<string>.That.StartsWith("123").DoesNothing();
+A.CallToSet(() => fakeShop.Address).To(() => A<string>.That.StartsWith("123")).DoesNothing();
 A.CallToSet(() => fakeShop.Address).DoesNothing(); // ignores the value that's set
 ```
 

--- a/docs/specifying-return-values.md
+++ b/docs/specifying-return-values.md
@@ -24,8 +24,8 @@ is configured. `ReturnsNextFromSequence` and `ReturnsLazily` can help
 with that. `ReturnsNextFromSequence` is the simpler of the two:
 
 ```csharp
-A.CallTo(() => fakeShop.SellSweetFromShelf()
-                       .ReturnsNextFromSequence(lollipop, smarties, wineGums));
+A.CallTo(() => fakeShop.SellSweetFromShelf())
+                       .ReturnsNextFromSequence(lollipop, smarties, wineGums);
 ```
 
 will first return `lollipop`, then `smarties`, then `wineGums`. The
@@ -37,7 +37,7 @@ On to the very powerful `ReturnsLazily`:
 ```csharp
 // Returns the number of times the method has been called
 int sweetsSold = 0;
-A.CallTo(() => fakeShop.NumberOfSweetsSoldToday().ReturnsLazily(() => ++sweetsSold);
+A.CallTo(() => fakeShop.NumberOfSweetsSoldToday()).ReturnsLazily(() => ++sweetsSold);
 ```
 
 If a return value depends on input to the method, those values can be
@@ -45,7 +45,7 @@ incorporated in the calculation. Convenient overloads exist for
 methods of up to four parameters.
 
 ```csharp
-A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>.Ignored) 
+A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>.Ignored)) 
                        .ReturnsLazily((DateTime theDate) => 
                                           theDate.DayOfWeek == DayOfWeek.Sunday ? 0 : 200);
 ```
@@ -63,7 +63,7 @@ than 4 parameters, the convenience methods won't work. Use the variant
 that takes an `IFakeObjectCall` instead:
 
 ```charp
-A.CallTo(objectCall => fakeShop.SomeCall(…)
+A.CallTo(() => fakeShop.SomeCall(…)
                                .ReturnsLazily(objectCall => calculateReturnFrom(objectCall));
 ```
 

--- a/docs/specifying-return-values.md
+++ b/docs/specifying-return-values.md
@@ -64,7 +64,7 @@ that takes an `IFakeObjectCall` instead:
 
 ```charp
 A.CallTo(() => fakeShop.SomeCall(…)
-                               .ReturnsLazily(objectCall => calculateReturnFrom(objectCall));
+                       .ReturnsLazily(objectCall => calculateReturnFrom(objectCall));
 ```
 
 The `IFakeObjectCall` object provides access to

--- a/docs/throwing-exceptions.md
+++ b/docs/throwing-exceptions.md
@@ -7,7 +7,7 @@ exception like this:
 
 ```csharp
 A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(DateTime.MaxValue))
- .Throws(new InvalidDateException("the date is in the future");
+ .Throws(new InvalidDateException("the date is in the future"));
 ```
 
 If the exception type has a parameterless constructor, you can use it
@@ -26,11 +26,11 @@ example
 ```csharp
 // Generate the exception at call time.
 A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
- .Throws(() => new InvalidDateException(DateTime.UtcNow + " is in the future");
+ .Throws(() => new InvalidDateException(DateTime.UtcNow + " is in the future"));
 
 // Pass up to 4 original call argument values into the method that creates the exception.
 A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
- .Throws((DateTime when)=>new InvalidDateException(when + " is in the future");
+ .Throws((DateTime when)=>new InvalidDateException(when + " is in the future"));
 
 // Pass an IFakeObjectCall into the creation method for more advanced scenarios.
 A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))


### PR DESCRIPTION
I was looking through the docs and spotted several things that looked strange
that's a minor thing but would help the docs to look consistent