### PR TITLE
Call out use of prefixes for property method names

### DIFF
--- a/docs/specifying-a-call-to-configure.md
+++ b/docs/specifying-a-call-to-configure.md
@@ -68,9 +68,14 @@ A.CallTo(fakeShop).Where(call => call.Method.Name == "ProtectedCalculateSalesFor
                   .WithReturnType<double>()
                   .Returns(4741.71);
 
-// refers to the Address property's setter
+// Use the conventional .NET prefix "get_" to refer to a property's getter:
+A.CallTo(fakeShop).Where(call => call.Method.Name == "get_Address")
+                  .WithReturnType<string>()
+                  .Returns("123 Fake Street");
+
+// Use the conventional .NET prefix "set_" to refer to a property's setter:
 A.CallTo(fakeShop).Where(call => call.Method.Name == "set_Address")
-                  .Throws(new Exception("we can't move");
+                  .Throws(new Exception("we can't move"));
 ```
 
 ## VB.Net


### PR DESCRIPTION
Fixes #752 