### PR TITLE
Clean up properties

### DIFF
--- a/src/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/src/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -53,7 +53,7 @@ namespace FakeItEasy.Configuration
         /// Gets a collection of actions that should be invoked when the configured
         /// call is made.
         /// </summary>
-        public virtual ICollection<Action<IFakeObjectCall>> Actions { get; private set; }
+        public virtual ICollection<Action<IFakeObjectCall>> Actions { get; }
 
         /// <summary>
         /// Gets or sets a function that provides values to apply to output and reference variables.
@@ -214,9 +214,9 @@ namespace FakeItEasy.Configuration
                 this.DescriptionWriter = descriptionWriter;
             }
 
-            public Func<IFakeObjectCall, bool> Predicate { get; private set; }
+            public Func<IFakeObjectCall, bool> Predicate { get; }
 
-            public Action<IOutputWriter> DescriptionWriter { get; private set; }
+            public Action<IOutputWriter> DescriptionWriter { get; }
         }
     }
 }

--- a/src/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/src/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -88,7 +88,7 @@ namespace FakeItEasy.Core
                 this.distanceFromKnownType = distanceFromKnownType;
             }
 
-            public IArgumentValueFormatter Formatter { get; private set; }
+            public IArgumentValueFormatter Formatter { get; }
 
             public int CompareTo(RangedFormatter other)
             {

--- a/src/FakeItEasy/Core/DelegateRaiser.cs
+++ b/src/FakeItEasy/Core/DelegateRaiser.cs
@@ -32,9 +32,9 @@ namespace FakeItEasy.Core
             argumentProviderMap.AddArgumentProvider(this.EventHandler as Delegate, this);
         }
 
-        private TEventHandler EventHandler { get; set; }
+        private TEventHandler EventHandler { get; }
 
-        private object[] EventArguments { get; set; }
+        private object[] EventArguments { get; }
 
         /// <summary>
         /// Converts the <c>DelegateRaiser</c> to a <c>TEventHandler</c>.

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -76,7 +76,7 @@ namespace FakeItEasy.Core
         /// <summary>
         /// Gets the faked type.
         /// </summary>
-        public virtual Type FakeObjectType { get; private set; }
+        public virtual Type FakeObjectType { get; }
 
         /// <summary>
         /// Gets the interceptions that are currently registered with the fake object.

--- a/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
+++ b/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
@@ -22,7 +22,7 @@ namespace FakeItEasy.Core
             this.WrappedObject = wrappedObject;
         }
 
-        private object WrappedObject { get; set; }
+        private object WrappedObject { get; }
 
         public override IFakeOptions<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
         {

--- a/src/FakeItEasy/Core/MethodInfoManager.cs
+++ b/src/FakeItEasy/Core/MethodInfoManager.cs
@@ -169,9 +169,9 @@ namespace FakeItEasy.Core
                 MethodInfo = methodInfo;
             }
 
-            public MethodInfo MethodInfo { get; private set; }
+            public MethodInfo MethodInfo { get; }
 
-            public Type Type { get; private set; }
+            public Type Type { get; }
 
             public override int GetHashCode()
             {

--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleInvocationCallAdapter.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleInvocationCallAdapter.cs
@@ -42,12 +42,12 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
         /// <summary>
         /// Gets the method that's called.
         /// </summary>
-        public MethodInfo Method { get; private set; }
+        public MethodInfo Method { get; }
 
         /// <summary>
         /// Gets the arguments used in the call.
         /// </summary>
-        public ArgumentCollection Arguments { get; private set; }
+        public ArgumentCollection Arguments { get; }
 
         /// <summary>
         /// Gets the faked object the call is performed on.

--- a/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
@@ -199,9 +199,9 @@ namespace FakeItEasy.Creation.DelegateProxies
 
             public object ReturnValue { get; private set; }
 
-            public MethodInfo Method { get; private set; }
+            public MethodInfo Method { get; }
 
-            public ArgumentCollection Arguments { get; private set; }
+            public ArgumentCollection Arguments { get; }
 
             public object FakedObject
             {

--- a/src/FakeItEasy/Creation/DummyValueCreationSession.cs
+++ b/src/FakeItEasy/Creation/DummyValueCreationSession.cs
@@ -26,12 +26,12 @@ namespace FakeItEasy.Creation
             this.strategyCache = new Dictionary<Type, ResolveStrategy>();
             this.strategies = new ResolveStrategy[]
                 {
-                    new ResolveFromDummyFactoryStrategy { DummyFactory = dummyFactory },
-                    new ResolveByCreatingTaskStrategy { Session = this },
-                    new ResolveByCreatingLazyStrategy { Session = this },
-                    new ResolveByCreatingFakeStrategy { FakeCreator = fakeObjectCreator, Session = this },
+                    new ResolveFromDummyFactoryStrategy(dummyFactory),
+                    new ResolveByCreatingTaskStrategy(this),
+                    new ResolveByCreatingLazyStrategy(this),
+                    new ResolveByCreatingFakeStrategy(fakeObjectCreator, this),
                     new ResolveByActivatingValueTypeStrategy(),
-                    new ResolveByInstantiatingClassUsingDummyValuesAsConstructorArgumentsStrategy { Session = this }
+                    new ResolveByInstantiatingClassUsingDummyValuesAsConstructorArgumentsStrategy(this)
                 };
         }
 
@@ -109,9 +109,15 @@ namespace FakeItEasy.Creation
 
         private class ResolveByCreatingFakeStrategy : ResolveStrategy
         {
-            public IFakeObjectCreator FakeCreator { get; set; }
+            public ResolveByCreatingFakeStrategy(IFakeObjectCreator fakeCreator, DummyValueCreationSession session)
+            {
+                this.FakeCreator = fakeCreator;
+                this.Session = session;
+            }
 
-            public DummyValueCreationSession Session { get; set; }
+            private IFakeObjectCreator FakeCreator { get; }
+
+            private DummyValueCreationSession Session { get; }
 
             public override bool TryCreateDummyValue(Type typeOfDummy, out object result)
             {
@@ -123,7 +129,12 @@ namespace FakeItEasy.Creation
         {
             private static readonly MethodInfo GenericFromResultMethodDefinition = CreateGenericFromResultMethodDefinition();
 
-            public DummyValueCreationSession Session { get; set; }
+            public ResolveByCreatingTaskStrategy(DummyValueCreationSession session)
+            {
+                this.Session = session;
+            }
+
+            private DummyValueCreationSession Session { get; }
 
             public override bool TryCreateDummyValue(Type typeOfDummy, out object result)
             {
@@ -162,7 +173,12 @@ namespace FakeItEasy.Creation
 
         private class ResolveByCreatingLazyStrategy : ResolveStrategy
         {
-            public DummyValueCreationSession Session { get; set; }
+            public ResolveByCreatingLazyStrategy(DummyValueCreationSession session)
+            {
+                this.Session = session;
+            }
+
+            private DummyValueCreationSession Session { get; }
 
             public override bool TryCreateDummyValue(Type typeOfDummy, out object result)
             {
@@ -203,7 +219,12 @@ namespace FakeItEasy.Creation
 
         private class ResolveByInstantiatingClassUsingDummyValuesAsConstructorArgumentsStrategy : ResolveStrategy
         {
-            public DummyValueCreationSession Session { get; set; }
+            public ResolveByInstantiatingClassUsingDummyValuesAsConstructorArgumentsStrategy(DummyValueCreationSession session)
+            {
+                this.Session = session;
+            }
+
+            private DummyValueCreationSession Session { get; }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Appropriate in try method.")]
             public override bool TryCreateDummyValue(Type typeOfDummy, out object result)
@@ -262,7 +283,12 @@ namespace FakeItEasy.Creation
 
         private class ResolveFromDummyFactoryStrategy : ResolveStrategy
         {
-            public DynamicDummyFactory DummyFactory { get; set; }
+            public ResolveFromDummyFactoryStrategy(DynamicDummyFactory dummyFactory)
+            {
+                this.DummyFactory = dummyFactory;
+            }
+
+            private DynamicDummyFactory DummyFactory { get; }
 
             public override bool TryCreateDummyValue(Type typeOfDummy, out object result)
             {

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
@@ -10,7 +10,7 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
             this.ExpectedValue = expectedValue;
         }
 
-        public object ExpectedValue { get; private set; }
+        public object ExpectedValue { get; }
 
         public string ConstraintDescription
         {

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/OutArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/OutArgumentConstraint.cs
@@ -16,10 +16,7 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
         /// there's no use in accepting or rejecting calls based on the
         /// incoming parameter value.
         /// </summary>
-        public object Value
-        {
-            get; private set;
-        }
+        public object Value { get; }
 
         public void WriteDescription(IOutputWriter writer)
         {

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/RefArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/RefArgumentConstraint.cs
@@ -24,7 +24,7 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
         /// Gets the value that was used when specifying the constraint.
         /// Used for implicit assignment of ref parameter values.
         /// </summary>
-        public object Value { get; private set; }
+        public object Value { get; }
 
         public void WriteDescription(IOutputWriter writer)
         {

--- a/src/FakeItEasy/Expressions/ParsedArgumentExpression.cs
+++ b/src/FakeItEasy/Expressions/ParsedArgumentExpression.cs
@@ -11,7 +11,7 @@ namespace FakeItEasy.Expressions
             this.ArgumentInformation = argumentInformation;
         }
 
-        public Expression Expression { get; private set; }
+        public Expression Expression { get; }
 
         public object Value
         {

--- a/src/FakeItEasy/Fake.of.T.cs
+++ b/src/FakeItEasy/Fake.of.T.cs
@@ -42,7 +42,7 @@ namespace FakeItEasy
         /// <summary>
         /// Gets the faked object.
         /// </summary>
-        public T FakedObject { get; private set; }
+        public T FakedObject { get; }
 
         /// <summary>
         /// Gets all calls made to the faked object.

--- a/src/FakeItEasy/SelfInitializedFakes/RecordingManager.cs
+++ b/src/FakeItEasy/SelfInitializedFakes/RecordingManager.cs
@@ -48,7 +48,7 @@ namespace FakeItEasy.SelfInitializedFakes
         /// Gets a value indicating whether the recorder is currently recording.
         /// </summary>
         /// <value></value>
-        public bool IsRecording { get; private set; }
+        public bool IsRecording { get; }
 
         /// <summary>
         /// Applies the call if the call has been recorded.

--- a/tests/FakeItEasy.Specs/UnconfiguredFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/UnconfiguredFakeSpecs.cs
@@ -155,11 +155,11 @@ namespace FakeItEasy.Specs
 
             public virtual string StringProperty { get; set; }
 
-            public string StringPropertyValueDuringConstructorCall { get; private set; }
+            public string StringPropertyValueDuringConstructorCall { get; }
 
             public virtual int ValueTypeProperty { get; set; }
 
-            public int ValueTypePropertyValueDuringConstructorCall { get; private set; }
+            public int ValueTypePropertyValueDuringConstructorCall { get; }
 
             public virtual IFoo FakeableProperty { get; set; }
         }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
@@ -473,7 +473,7 @@ namespace FakeItEasy.Core
     }
     public class FakeManager : FakeItEasy.Core.IFakeCallProcessor
     {
-        public System.Type FakeObjectType { get; }
+        public virtual System.Type FakeObjectType { get; }
         public virtual object Object { get; }
         public virtual System.Collections.Generic.IEnumerable<FakeItEasy.Core.IFakeObjectCallRule> Rules { get; }
         public void AddInterceptionListener(FakeItEasy.Core.IInterceptionListener listener) { }

--- a/tests/FakeItEasy.Tests/Core/DefaultSutInitializerTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DefaultSutInitializerTests.cs
@@ -117,11 +117,11 @@ namespace FakeItEasy.Tests.Core
                 this.Dependency = dependency;
             }
 
-            public IFoo FooDependency { get; private set; }
+            public IFoo FooDependency { get; }
 
-            public IFoo FooDependency2 { get; private set; }
+            public IFoo FooDependency2 { get; }
 
-            public object Dependency { get; private set; }
+            public object Dependency { get; }
         }
     }
 }


### PR DESCRIPTION
Taking advantage of a little C# 6 to remove private setters from auto-props. While I was here, I noticed some getters that were effectively private. There are more, but on public classes. :disappointed: 