### PR TITLE
Remove IFakeAndDummyManager.TryResolveDummyValue

### DIFF
--- a/src/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
+++ b/src/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
@@ -45,12 +45,6 @@ namespace FakeItEasy.Creation
             return this.session.TryResolveDummyValue(typeOfDummy, out result);
         }
 
-        public bool TryCreateFake(Type typeOfFake, IProxyOptions options, out object result)
-        {
-            result = this.fakeCreator.CreateFake(typeOfFake, options, this.session, throwOnFailure: false);
-            return result != null;
-        }
-
         private static IFakeOptions CreateFakeOptions(Type typeOfFake, ProxyOptions proxyOptions)
         {
             var optionsConstructor = typeof(FakeOptions<>)

--- a/src/FakeItEasy/Creation/IFakeAndDummyManager.cs
+++ b/src/FakeItEasy/Creation/IFakeAndDummyManager.cs
@@ -32,14 +32,5 @@ namespace FakeItEasy.Creation
         /// <param name="result">Outputs the result dummy when creation is successful.</param>
         /// <returns>A value indicating whether the creation was successful.</returns>
         bool TryCreateDummy(Type typeOfDummy, out object result);
-
-        /// <summary>
-        /// Tries to create a fake object of the specified type.
-        /// </summary>
-        /// <param name="typeOfFake">The type of fake to create.</param>
-        /// <param name="options">Options for building the proxy that will act as the fake.</param>
-        /// <param name="result">The created fake object when creation is successful.</param>
-        /// <returns>A value indicating whether the creation was successful.</returns>
-        bool TryCreateFake(Type typeOfFake, IProxyOptions options, out object result);
     }
 }


### PR DESCRIPTION
It's not used. Probably was missed from removal when we changed unconfigured fakes to always return Dummies. But that's just a guess.