### PR TITLE
Specify sln file for gitlink to use

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -224,7 +224,7 @@ end
 desc "GitLink PDB's"
 exec :gitlink => [:build] do |cmd|
   cmd.command = gitlink_command
-  cmd.parameters ". -u #{repo_url} -include " + gitlinks.join(",")
+  cmd.parameters ". -f #{solution} -u #{repo_url} -include " + gitlinks.join(",")
 end
 
 directory tests


### PR DESCRIPTION
Protects us against duplicate projects in case we ever add a second .sln.

See @jeremymeng's [AppVeyor build](https://ci.appveyor.com/project/jeremymeng/fakeiteasy/build/2.3.0-coreclr-alpha30#L476) for what I'm talking about. Or just build coreclr locally.