### PR TITLE
Allow callmatching to happen from external interpection

### DIFF
--- a/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
@@ -25,7 +25,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "The compiler would not be able to figure out the type.")]
         public static IEnumerable<ICompletedFakeObjectCall> Matching<TFake>(this IEnumerable<ICompletedFakeObjectCall> calls, Expression<Action<TFake>> callSpecification)
         {
-            return Matching(calls, callSpecification);
+            return InternalMatching(calls, callSpecification);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "The compiler would not be able to figure out the type.")]
         public static IEnumerable<ICompletedFakeObjectCall> Matching<TFake, TResult>(this IEnumerable<ICompletedFakeObjectCall> calls, Expression<Func<TFake, TResult>> callSpecification)
         {
-            return Matching(calls, callSpecification);
+            return InternalMatching(calls, callSpecification);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace FakeItEasy
         /// <param name="calls">The calls to filter.</param>
         /// <param name="callSpecification">The call to match on.</param>
         /// <returns>A collection of the calls that matches the call specification.</returns>
-        private static IEnumerable<ICompletedFakeObjectCall> Matching(this IEnumerable<ICompletedFakeObjectCall> calls, LambdaExpression callSpecification)
+        private static IEnumerable<ICompletedFakeObjectCall> InternalMatching(this IEnumerable<ICompletedFakeObjectCall> calls, LambdaExpression callSpecification)
         {
             var factory = ServiceLocator.Current.Resolve<IExpressionCallMatcherFactory>();
             var callExpressionParser = ServiceLocator.Current.Resolve<ICallExpressionParser>();

--- a/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
@@ -34,5 +34,27 @@ namespace FakeItEasy
                 where matcher.Matches(call)
                 select call;
         }
+
+        /// <summary>
+        /// Filters to contain only the calls that matches the call specification, for specifications with return value.
+        /// </summary>
+        /// <typeparam name="TFake">The type of fake the call is made on.</typeparam>
+        /// <typeparam name="TResult">The type of return value the call returns.</typeparam>
+        /// <param name="calls">The calls to filter.</param>
+        /// <param name="callSpecification">The call to match on.</param>
+        /// <returns>A collection of the calls that matches the call specification.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design when using the Expression-, Action- and Func-types.")]
+        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "The compiler would not be able to figure out the type.")]
+        public static IEnumerable<ICompletedFakeObjectCall> Matching<TFake, TResult>(this IEnumerable<ICompletedFakeObjectCall> calls, Expression<Func<TFake, TResult>> callSpecification)
+        {
+            var factory = ServiceLocator.Current.Resolve<IExpressionCallMatcherFactory>();
+            var callExpressionParser = ServiceLocator.Current.Resolve<ICallExpressionParser>();
+            var matcher = factory.CreateCallMatcher(callExpressionParser.Parse(callSpecification));
+
+            return
+                from call in calls
+                where matcher.Matches(call)
+                select call;
+        }
     }
 }

--- a/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
@@ -25,14 +25,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "The compiler would not be able to figure out the type.")]
         public static IEnumerable<ICompletedFakeObjectCall> Matching<TFake>(this IEnumerable<ICompletedFakeObjectCall> calls, Expression<Action<TFake>> callSpecification)
         {
-            var factory = ServiceLocator.Current.Resolve<IExpressionCallMatcherFactory>();
-            var callExpressionParser = ServiceLocator.Current.Resolve<ICallExpressionParser>();
-            var matcher = factory.CreateCallMatcher(callExpressionParser.Parse(callSpecification));
-
-            return
-                from call in calls
-                where matcher.Matches(call)
-                select call;
+            return Matching(calls, callSpecification);
         }
 
         /// <summary>
@@ -47,6 +40,17 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "The compiler would not be able to figure out the type.")]
         public static IEnumerable<ICompletedFakeObjectCall> Matching<TFake, TResult>(this IEnumerable<ICompletedFakeObjectCall> calls, Expression<Func<TFake, TResult>> callSpecification)
         {
+            return Matching(calls, callSpecification);
+        }
+
+        /// <summary>
+        /// Filters to contain only the calls that matches the call specification.
+        /// </summary>
+        /// <param name="calls">The calls to filter.</param>
+        /// <param name="callSpecification">The call to match on.</param>
+        /// <returns>A collection of the calls that matches the call specification.</returns>
+        private static IEnumerable<ICompletedFakeObjectCall> Matching(this IEnumerable<ICompletedFakeObjectCall> calls, LambdaExpression callSpecification)
+        {
             var factory = ServiceLocator.Current.Resolve<IExpressionCallMatcherFactory>();
             var callExpressionParser = ServiceLocator.Current.Resolve<ICallExpressionParser>();
             var matcher = factory.CreateCallMatcher(callExpressionParser.Parse(callSpecification));
@@ -55,6 +59,6 @@ namespace FakeItEasy
                 from call in calls
                 where matcher.Matches(call)
                 select call;
-        }
+        }      
     }
 }

--- a/src/FakeItEasy/Configuration/ArgumentCollection.cs
+++ b/src/FakeItEasy/Configuration/ArgumentCollection.cs
@@ -25,6 +25,17 @@ namespace FakeItEasy.Configuration
         ///   Initializes a new instance of the <see cref = "ArgumentCollection" /> class.
         /// </summary>
         /// <param name = "arguments">The arguments.</param>
+        /// <param name = "method">The method.</param>
+        [DebuggerStepThrough]
+        public ArgumentCollection(object[] arguments, MethodInfo method)
+            : this(arguments, GetArgumentNames(method))
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref = "ArgumentCollection" /> class.
+        /// </summary>
+        /// <param name = "arguments">The arguments.</param>
         /// <param name = "argumentNames">The argument names.</param>
         [DebuggerStepThrough]
         internal ArgumentCollection(object[] arguments, IEnumerable<string> argumentNames)
@@ -39,17 +50,6 @@ namespace FakeItEasy.Configuration
 
             this.arguments = arguments;
             this.ArgumentNames = argumentNames.ToArray();
-        }
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref = "ArgumentCollection" /> class.
-        /// </summary>
-        /// <param name = "arguments">The arguments.</param>
-        /// <param name = "method">The method.</param>
-        [DebuggerStepThrough]
-        internal ArgumentCollection(object[] arguments, MethodInfo method)
-            : this(arguments, GetArgumentNames(method))
-        {
         }
 
         /// <summary>

--- a/tests/FakeItEasy.Specs/FakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeSpecs.cs
@@ -15,6 +15,12 @@
             void AnotherMethod();
 
             void AnotherMethod(string text);
+
+            string AMethodReturns();
+
+            string AnotherMethodReturns();
+
+            string AnotherMethodReturns(string text);
         }
 
         [Scenario]
@@ -94,6 +100,59 @@
 
             "Then it finds the matching call"
                 .x(() => matchedCalls.Select(c => c.Method.Name).Should().Equal("AnotherMethod"));
+        }
+
+        [Scenario]
+        public static void MatchingCallsWithReturnValueWithNoMatches(
+          IFoo fake,
+          IEnumerable<ICompletedFakeObjectCall> completedCalls,
+          IEnumerable<ICompletedFakeObjectCall> matchedCalls)
+        {
+            "Given a Fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And I make several calls to the Fake"
+                .x(() =>
+                {
+                    fake.AMethodReturns();
+                    fake.AnotherMethodReturns("houseboat");
+                });
+
+            "And I use the static Fake class to get the calls made on the Fake"
+                .x(() => completedCalls = Fake.GetCalls(fake));
+
+            "When I use Matching to find calls to a method with no matches"
+                .x(() => matchedCalls = completedCalls.Matching<IFoo>(c => c.AnotherMethodReturns("hovercraft")));
+
+            "Then it finds no calls"
+                .x(() => matchedCalls.Should().BeEmpty());
+        }
+
+        [Scenario]
+        public static void MatchingCallsWithReturnValueWithMatches(
+            IFoo fake,
+            IEnumerable<ICompletedFakeObjectCall> completedCalls,
+            IEnumerable<ICompletedFakeObjectCall> matchedCalls)
+        {
+            "Given a Fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And I make several calls to the Fake"
+                .x(() =>
+                {
+                    fake.AMethodReturns();
+                    fake.AnotherMethodReturns();
+                    fake.AnotherMethodReturns("houseboat");
+                });
+
+            "And I use the static Fake class to get the calls made on the Fake"
+                .x(() => completedCalls = Fake.GetCalls(fake));
+
+            "When I use Matching to find calls to a method with a match"
+                .x(() => matchedCalls = completedCalls.Matching<IFoo>(c => c.AnotherMethodReturns("houseboat")));
+
+            "Then it finds the matching call"
+                .x(() => matchedCalls.Select(c => c.Method.Name).Should().Equal("AnotherMethodReturns"));
         }
     }
 }


### PR DESCRIPTION
Open ArgumentCollection constructor for external usage ,and added CompletedFakeObjectCallExtensions.Matches method for callspecifications with return values.

See issue #805

Not used to doing pull requests, so if I missed something, please let me know.