### PR TITLE
[WIP] add dotnet targets to rakefile

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -10,11 +10,13 @@ gitlink_command = "packages/gitlink.2.3.0/lib/net45/GitLink.exe"
 xunit_command   = "packages/xunit.runner.console.2.0.0/tools/xunit.console.exe"
 
 solution        = "FakeItEasy.sln"
+dotnet_solution = "FakeItEasy-NetCore.sln"
 assembly_info   = "src/CommonAssemblyInfo.cs"
 version         = IO.read(assembly_info)[/AssemblyInformationalVersion\("([^"]+)"\)/, 1]
 version_suffix  = ENV["VERSION_SUFFIX"]
 repo_url        = "https://github.com/FakeItEasy/FakeItEasy"
 nuspec          = "src/FakeItEasy/FakeItEasy.nuspec"
+dotnet_nuspec   = "src/FakeItEasy.dotnet/FakeItEasy.nuspec"
 analyzer_nuspec = "src/FakeItEasy.Analyzer/FakeItEasy.Analyzer.nuspec"
 logs            = "artifacts/logs"
 output          = "artifacts/output"
@@ -26,6 +28,10 @@ gitlinks        = ["FakeItEasy", "FakeItEasy.Analyzer"]
 unit_tests = [
   "tests/FakeItEasy.Tests/bin/Release/FakeItEasy.Tests.dll",
   "tests/FakeItEasy.Analyzer.Tests/bin/Release/FakeItEasy.Analyzer.Tests.dll"
+]
+
+dotnet_unit_test_directories = [
+  "tests/FakeItEasy.Tests.dotnet"
 ]
 
 integration_tests = [
@@ -95,6 +101,9 @@ end
 desc "Execute default tasks"
 task :default => [ :vars, :gitlink, :unit, :integ, :spec, :pack ]
 
+desc "Execute default tasks for .NET Core solution"
+task :dotnet => [ :default, :unit_dotnet, :pack_dotnet]
+
 desc "Print all variables"
 task :vars do
   print_vars(local_variables.sort.map { |name| [name.to_s, (eval name.to_s)] })
@@ -111,6 +120,11 @@ directory logs
 desc "Clean solution"
 task :clean => [logs] do
   run_msbuild solution, "Clean", msbuild_command
+end
+
+desc "Clean .NET Core solution"
+task :clean_dotnet => [logs] do
+  run_msbuild dotnet_solution, "Clean", msbuild_command
 end
 
 desc "Update version number and create pull request, milestone, release, and release checklist issue"
@@ -222,6 +236,10 @@ task :build => [:clean, :restore, logs] do
   run_msbuild solution, "Build", msbuild_command, packages
 end
 
+task :build_dotnet => [:clean_dotnet, :restore, logs] do
+  run_msbuild dotnet_solution, "Build", msbuild_command, packages
+end
+
 desc "GitLink PDB's"
 exec :gitlink => [:build] do |cmd|
   cmd.command = gitlink_command
@@ -233,6 +251,11 @@ directory tests
 desc "Execute unit tests"
 task :unit => [:build, tests] do
     run_tests(unit_tests, xunit_command, tests)
+end
+
+desc "Execute .NET Core unit tests"
+task :unit_dotnet => [:build_dotnet, tests] do
+    run_dotnet_tests(dotnet_unit_test_directories, tests)
 end
 
 desc "Execute integration tests"
@@ -256,6 +279,12 @@ desc "create the nuget package"
 exec :pack => [:build, output] do |cmd|
   cmd.command = nuget_command
   cmd.parameters "pack #{nuspec} -Version #{version}#{version_suffix} -OutputDirectory #{output}"
+end
+
+desc "create the nuget package for .NET Core"
+exec :pack_dotnet => [:build_dotnet, output] do |cmd|
+  cmd.command = nuget_command
+  cmd.parameters "pack #{dotnet_nuspec} -Version #{version}-dotnet#{version_suffix} -OutputDirectory #{output}"
 end
 
 desc "create the analyzer nuget package"
@@ -341,6 +370,18 @@ def run_tests(test_assemblies, command, result_dir)
     xunit.assembly = test_assembly
     xunit.options '-noshadow', '-nologo', '-notrait', '"explicit=yes"', '-xml', result_file
     xunit.execute
+  end
+end
+
+def run_dotnet_tests(test_directories, result_dir)
+  test_directories.each do |test_directory|
+    result_file = File.expand_path(File.join(result_dir, File.basename(test_directory)) + '.TestResults.xml')
+
+    cmd = Exec.new
+    cmd.command = 'dotnet'
+    cmd.working_directory = test_directory
+    cmd.parameters "test -c Release --no-build -xml #{result_file} -nologo -notrait \"explicit=yes\""
+    cmd.execute
   end
 end
 

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -101,7 +101,7 @@ end
 desc "Execute default tasks"
 task :default => [ :vars, :gitlink, :unit, :integ, :spec, :pack ]
 
-desc "Execute default tasks for .NET Core solution"
+desc "Execute default tasks plus .NET Core tasks"
 task :dotnet => [ :default, :unit_dotnet, :pack_dotnet]
 
 desc "Print all variables"


### PR DESCRIPTION
Add a target (of the form *_dotnet) for each existing target that we have a .NET Standard analogue for.
Also add a "dotnet" target to run all .NET 4.0-related targets as well as the .NET Standard targets.

One downside is that we end up building the .NET 4.0 projects twice.

Connects to #531