### PR TITLE
add nuget.exe to solutions

### DIFF
--- a/FakeItEasy-NetCore.sln
+++ b/FakeItEasy-NetCore.sln
@@ -32,6 +32,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{4B581366-50F5-42E9-87A5-BA7DC4F6E330}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\nuget.exe = .nuget\nuget.exe
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
 EndProject

--- a/FakeItEasy.sln
+++ b/FakeItEasy.sln
@@ -31,6 +31,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{4B581366-50F5-42E9-87A5-BA7DC4F6E330}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\nuget.exe = .nuget\nuget.exe
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Believe it or not, this isn't completely useless.

When you "open" the exe from the solution explorer, you get this:

![image](https://cloud.githubusercontent.com/assets/677704/17355571/d0250d06-5951-11e6-9b0a-a94494c92a82.png)

If you then double-click the leaf under `Version`, you get:

![image](https://cloud.githubusercontent.com/assets/677704/17355586/df631ede-5951-11e6-8763-f99b9cc76b33.png)

I.e. you can check which version of nuget.exe we are running from inside VS!