### PR TITLE
Suppress harmless diagnostics for test projects

### DIFF
--- a/tests/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
+++ b/tests/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
@@ -9,20 +9,15 @@ namespace FakeItEasy.Specs
     using Xunit;
 
     [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "WithOut", Justification = "That's two words, not one")]
-    [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "1#", Justification = "Required for testing.")]
-    [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "Required for testing.")]
     public delegate void VoidDelegateWithOutAndRefParameters(
         int byValueParameter, ref int byRefParameter, out int outParameter);
 
     [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "WithOut", Justification = "That's two words, not one")]
-    [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "1#", Justification = "Required for testing.")]
-    [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "Required for testing.")]
     public delegate int NonVoidDelegateWithOutAndRefParameters(
         int byValueParameter, ref int byRefParameter, out int outParameter);
 
     public interface IHaveARef
     {
-        [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "0#", Justification = "Required for testing.")]
         void MightReturnAKnownValue(ref string andThisIsWhoReallyDidIt);
     }
 

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -33,13 +33,11 @@ namespace FakeItEasy.Specs
 
         public interface IHaveARefParameter
         {
-            [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "0#", Justification = "Required for testing.")]
             bool CheckYourReferences(ref string refString);
         }
 
         public interface IHaveAnOutParameter
         {
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Required for testing.")]
             bool Validate([Out] string value);
         }
 

--- a/tests/FakeItEasy.Specs/GlobalSuppressions.cs
+++ b/tests/FakeItEasy.Specs/GlobalSuppressions.cs
@@ -6,22 +6,6 @@
     Target = "FakeItEasy.Specs.when_faking_a_disposable_class.#.ctor()",
     Justification = "Required for testing.")]
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(
-    "Microsoft.Design",
-    "CA1045:DoNotPassTypesByReference",
-    MessageId = "0#",
-    Scope = "member",
-    Target = "FakeItEasy.Specs.when_matching_a_call_with_a_ref_parameter+IHaveInterestingParameters.#CheckYourReferences(System.String&)",
-    Justification = "Required for testing.")]
-
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(
-    "Microsoft.Design",
-    "CA1021:AvoidOutParameters",
-    MessageId = "0#",
-    Scope = "member",
-    Target = "FakeItEasy.Specs.when_matching_a_call_with_a_parameter_having_an_out_attribute+IHaveInterestingParameters.#Validate(System.String)",
-    Justification = "Required for testing.")]
-
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/tests/FakeItEasy.Specs/SelfInitializedFakesSpecs.cs
+++ b/tests/FakeItEasy.Specs/SelfInitializedFakesSpecs.cs
@@ -2,7 +2,6 @@ namespace FakeItEasy.Specs
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
     using FakeItEasy.SelfInitializedFakes;
@@ -17,10 +16,6 @@ namespace FakeItEasy.Specs
 
         string GetTitle(string internationalStandardBookNumber);
 
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Required for test scenario")]
-        [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "1#", Justification = "Required for test scenario")]
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "ref", Justification = "There are no other consumers, so the name is safe.")]
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "out", Justification = "There are no other consumers, so the name is safe.")]
         bool TryToSetSomeOutAndRefParameters(out int @out, ref int @ref);
     }
 

--- a/tests/FakeItEasy.Specs/WrappingFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/WrappingFakeSpecs.cs
@@ -1,7 +1,6 @@
 ﻿namespace FakeItEasy.Specs
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using Xbehave;
@@ -15,10 +14,6 @@
 
             void VoidMethod(string parameter);
 
-            [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "ref", Justification = "There are no other consumers, so the name is safe.")]
-            [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "out", Justification = "There are no other consumers, so the name is safe.")]
-            [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "0#", Justification = "Required for test scenario")]
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "1#", Justification = "Required for test scenario")]
             void OutAndRefMethod(ref int @ref, out int @out);
         }
 

--- a/tests/FakeItEasy.Tests.ruleset
+++ b/tests/FakeItEasy.Tests.ruleset
@@ -8,8 +8,11 @@
     <Rule Id="CA1016" Action="None" />
     <Rule Id="CA1017" Action="None" />
     <Rule Id="CA1020" Action="None" />
+    <Rule Id="CA1021" Action="None" />
     <Rule Id="CA1025" Action="None" />
     <Rule Id="CA1034" Action="None" />
+    <Rule Id="CA1045" Action="None" />
+    <Rule Id="CA1062" Action="None" />
     <Rule Id="CA1303" Action="None" />
     <Rule Id="CA1305" Action="None" />
     <Rule Id="CA1402" Action="None" />
@@ -17,6 +20,7 @@
     <Rule Id="CA1506" Action="None" />
     <Rule Id="CA1707" Action="None" />
     <Rule Id="CA1709" Action="None" />
+    <Rule Id="CA1716" Action="None" />
     <Rule Id="CA1822" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2210" Action="None" />

--- a/tests/FakeItEasy.Tests/Core/WrappedObjectRuleTests.cs
+++ b/tests/FakeItEasy.Tests/Core/WrappedObjectRuleTests.cs
@@ -1,7 +1,6 @@
 namespace FakeItEasy.Tests.Core
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using FakeItEasy.Core;
     using FluentAssertions;
     using Xunit;
@@ -10,13 +9,11 @@ namespace FakeItEasy.Tests.Core
     {
         public interface ITypeWithReferenceArguments
         {
-            [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "0#", Justification = "Required for testing.")]
             void MethodWithReferenceArgument(ref int argument);
         }
 
         public interface ITypeWithOutputArguments
         {
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Required for testing.")]
             void MethodWithOutputArgument(out int argument);
         }
 

--- a/tests/FakeItEasy.Tests/IFoo.cs
+++ b/tests/FakeItEasy.Tests/IFoo.cs
@@ -32,8 +32,6 @@ namespace FakeItEasy.Tests
 
         object Biz();
 
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", Justification = "Required for testing.")]
-        [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", Justification = "Required for testing.")]
         int MethodWithOutputAndReference(out int argument1, ref int argument2);
     }
 }

--- a/tests/FakeItEasy.Tests/IOutputAndRef.cs
+++ b/tests/FakeItEasy.Tests/IOutputAndRef.cs
@@ -1,15 +1,9 @@
 namespace FakeItEasy.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
     public interface IOutputAndRef
     {
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "Required for testing.")]
-        [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "3#", Justification = "Required for testing.")]
         int Foo(int numberIn, string textIn, out int numberOut, ref string textReference);
 
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "Required for testing.")]
-        [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", MessageId = "3#", Justification = "Required for testing.")]
         int Bar(int numberIn, string textIn, out int numberOut, ref string textReference);
     }
 }

--- a/tests/FakeItEasy.Tests/OutAndRefParametersConfigurationExtensionsTests.cs
+++ b/tests/FakeItEasy.Tests/OutAndRefParametersConfigurationExtensionsTests.cs
@@ -2,7 +2,6 @@ namespace FakeItEasy.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Linq.Expressions;
     using FakeItEasy.Configuration;
@@ -15,28 +14,20 @@ namespace FakeItEasy.Tests
     {
         public interface IInterface
         {
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Required for testing.")]
             void RequestOfOne(out int numberOut);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Required for testing.")]
             void RequestOfOne(out string textOut);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "1#", Justification = "Required for testing.")]
             void RequestOfTwo(int number1, out int numberOut);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "1#", Justification = "Required for testing.")]
             void RequestOfTwo(string text1, out string textOut);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "Required for testing.")]
             void RequestOfThree(int number1, int number2, out int numberOut);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "Required for testing.")]
             void RequestOfThree(string text1, string text2, out string textOut);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "3#", Justification = "Required for testing.")]
             void RequestOfFour(int number1, int number2, int number3, out int numberOut);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "3#", Justification = "Required for testing.")]
             void RequestOfFour(string text1, string text2, string text3, out string textOut);
         }
 

--- a/tests/FakeItEasy.Tests/ReturnValueConfigurationExtensionsTests.cs
+++ b/tests/FakeItEasy.Tests/ReturnValueConfigurationExtensionsTests.cs
@@ -1,7 +1,6 @@
 namespace FakeItEasy.Tests
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
@@ -23,10 +22,8 @@ namespace FakeItEasy.Tests
 
             string RequestOfOne(string text);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", Justification = "Required for testing.")]
             string RequestOfOneWithOutput(out string text);
 
-            [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", Justification = "Required for testing.")]
             string RequestOfOneWithReference(ref string text);
 
             int RequestOfTwo(int number1, int number2);
@@ -35,8 +32,6 @@ namespace FakeItEasy.Tests
 
             string RequestOfTwo(string text1, string text2);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", Justification = "Required for testing.")]
-            [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", Justification = "Required for testing.")]
             string RequestOfTwoWithOutputAndReference(out string text1, ref string text2);
 
             int RequestOfThree(int number1, int number2, int number3);
@@ -45,8 +40,6 @@ namespace FakeItEasy.Tests
 
             string RequestOfThree(string text1, string text2, string text3);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", Justification = "Required for testing.")]
-            [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", Justification = "Required for testing.")]
             string RequestOfThreeWithOutputAndReference(out string text1, ref string text2, string text3);
 
             int RequestOfFour(int number1, int number2, int number3, int number4);
@@ -55,8 +48,6 @@ namespace FakeItEasy.Tests
 
             string RequestOfFour(string text1, string text2, string text3, string text4);
 
-            [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", Justification = "Required for testing.")]
-            [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference", Justification = "Required for testing.")]
             string RequestOfFourWithOutputAndReference(string text1, string text2, ref string text3, out string text4);
         }
 


### PR DESCRIPTION
FakeItEasy must work with a variety of client code that doesn't conform to
some coding "best practices". As such, our test need to include types that
likewise violate these rules. Including suppression statements for the
more common of the rules is tiresome and clutters the code, so move some
out into the global ruleset:

- CA1021: AvoidOutParameters
- CA1045: DoNotPassTypesByReference
- CA1062: ValidateArgumentsOfPublicMethods
- CA1716: IdentifiersShouldNotMatchKeywords