### PR TITLE
Optimize away some calls to DynamicMethod.CreateDelegate() 

### DIFF
--- a/src/FakeItEasy/ExpressionExtensions.cs
+++ b/src/FakeItEasy/ExpressionExtensions.cs
@@ -1,6 +1,8 @@
 namespace FakeItEasy
 {
+    using System.Linq;
     using System.Linq.Expressions;
+    using System.Reflection;
 
     /// <summary>
     /// Provides extension methods for <see cref="Expression"/>.
@@ -8,12 +10,98 @@ namespace FakeItEasy
     internal static class ExpressionExtensions
     {
         /// <summary>
-        /// Evaluates an expression by compiling it into a delegate and invoking the delegate.
+        /// Evaluates an expression, potentially by compiling it into a delegate and invoking the delegate, but faster if possible.
         /// </summary>
+        /// <notes>
+        /// This method evaluates an expression, but tries to do it in a light-weight way that doesn't compile it into a delegate.
+        /// This is often going to be used in the context of finding out 'what object/value is a some (sub-)expression referring to?'
+        /// 
+        /// Key observation is that walking the expression tree and evaluating directly can be much faster for simple expressions like:
+        /// 
+        /// - constant expressions (null, 1, "easy", etc.)
+        /// 
+        /// - local variables referenced from lambda expressions, such as 'fake' in the A.CallTo line:
+        /// 
+        ///     {
+        ///         var fake = A.Fake&lt;Something&gt;();
+        ///         A.CallTo(() => fake.DoStuff());
+        ///     }
+        ///     
+        /// - Expressions that are simple member accesses (field gets, property gets) on an object or class, such as
+        ///     String.Empty
+        ///     A&lt;SomethingA&gt;.Ignored
+        ///     A&lt;SomethingA&gt;._
+        ///     myObj.someProperty
+        ///     
+        /// - Trivial method calls with no arguments (A.ToString(), B.GetType(), Factory.Create())
+        ///     
+        /// </notes>
         /// <param name="expression">The expression to be evaluated.</param>
         /// <returns>The value returned from the delegate compiled from the expression.</returns>
         public static object Evaluate(this Expression expression)
         {
+            return EvaluateOptimized(expression);
+        }
+        
+        private static object EvaluateOptimized(this Expression expression)
+        {
+            if (expression == null)
+            {
+                return null;
+            }
+
+            switch (expression.NodeType)
+            {
+                case ExpressionType.Constant:
+                    return ((ConstantExpression)expression).Value;
+
+                case ExpressionType.MemberAccess:
+                    var memberExpression = (MemberExpression)expression;
+
+                    var fieldInfo = memberExpression.Member as FieldInfo;
+                    if (fieldInfo != null)
+                    {
+                        return fieldInfo.GetValue(EvaluateOptimized(memberExpression.Expression));
+                    }
+
+                    var propertyInfo = memberExpression.Member as PropertyInfo;
+                    if (propertyInfo != null)
+                    {
+                        // index = null: this is always fine since it's a MemberAccess expression, not an IndexExpression
+                        return propertyInfo.GetValue(EvaluateOptimized(memberExpression.Expression), null);
+                    }
+
+                    break;
+
+                case ExpressionType.Call:
+                    var callExpression = (MethodCallExpression)expression;
+
+                    // for now, handling only very trivial call expressions with no arguments, like 'GetBlarg()'
+                    // because anything else might get complicated quickly (method overloads etc.)
+                    if (!callExpression.Arguments.Any())
+                    {
+                        var targetObject = EvaluateOptimized(callExpression.Object);
+                        return callExpression.Method.Invoke(targetObject, null);
+                    }
+
+                    break;
+
+                case ExpressionType.Convert:
+                    var unaryExpression = (UnaryExpression)expression;
+
+                    // for now, handling only 'boxing/casting to object' expressions like '3' used as an argument to a function which takes an object[] array parameter.
+                    if (unaryExpression.Type == typeof(object))
+                    {
+                        // in principle, we would first evaluate it without the boxing, and then box/cast to object... 
+                        // ...but EvaluateOptimized already boxes before returning, so no explicit cast needed.
+                        object obj = EvaluateOptimized(unaryExpression.Operand); // declaring an explicitly typed variable to ensure we're really boxing
+                        return obj;
+                    }
+
+                    break;
+            }
+
+            // when we didn't know how to evaluate the tree, fall back to compiling into a delegate and invoking the expression
             var lambda = Expression.Lambda(expression).Compile();
             return lambda.DynamicInvoke();
         }


### PR DESCRIPTION
...from by 'AssertThatMemberCanBeIntercepted' during trivial A.CallTo() specifications, like

```
var fake = A.Fake<X>();
A.CallTo(() => fake.DoStuff();
```

Fixes #850 