### PR TITLE
Avoid some calls to DynamicMethod.CreateDelegate

### DIFF
--- a/src/FakeItEasy/Expressions/ParsedCallExpression.cs
+++ b/src/FakeItEasy/Expressions/ParsedCallExpression.cs
@@ -16,7 +16,7 @@ namespace FakeItEasy.Expressions
         {
             this.CalledMethod = calledMethod;
             this.ArgumentsExpressions = argumentsExpressions;
-            this.callTarget = new Lazy<object>(() => callTargetExpression?.Evaluate());
+            this.callTarget = new Lazy<object>(() => FastEvaluate(callTargetExpression));
         }
 
         public ParsedCallExpression(
@@ -34,5 +34,43 @@ namespace FakeItEasy.Expressions
         public IEnumerable<ParsedArgumentExpression> ArgumentsExpressions { get; }
 
         public object CallTarget => this.callTarget.Value;
+
+        // Expression evaluation optimized for a very common case,
+        // locating the call target described by a local lambda closure
+        // such as
+        //   A.CallTo(() => fakeObj.doSomething(args))
+        //
+        // In this example, fakeObj is a field on the anonymous
+        // type that the compiler creates to represent the closure,
+        // so the expression will be a MemberExpression where the
+        // Member is a FieldInfo.
+        // That FieldInfo can be used to find the value of fakeObj
+        // from the anonymous object, which is represented in the
+        // expression tree by the ConstantExpression.
+        private static object FastEvaluate(Expression expression)
+        {
+            if (expression == null)
+            {
+                return null;
+            }
+
+            switch (expression.NodeType)
+            {
+                case ExpressionType.Constant:
+                    return ((ConstantExpression)expression).Value;
+
+                case ExpressionType.MemberAccess:
+                    var memberExpression = (MemberExpression)expression;
+                    var fieldInfo = memberExpression.Member as FieldInfo;
+                    if (fieldInfo != null)
+                    {
+                        return fieldInfo.GetValue(FastEvaluate(memberExpression.Expression));
+                    }
+
+                    break;
+            }
+
+            return expression.Evaluate();
+        }
     }
 }


### PR DESCRIPTION
Fixes #850. Supersedes #851.
Cleans up some style warnings and expands on the comments in the optimized code, mostly because I'd misinterpreted what was going on, and if I can do it once, I'll do it again.