### PR TITLE
Call WhenArgumentsMatch on parent configuration

### DIFF
--- a/src/FakeItEasy/Configuration/RuleBuilder.cs
+++ b/src/FakeItEasy/Configuration/RuleBuilder.cs
@@ -158,9 +158,7 @@ namespace FakeItEasy.Configuration
 
             public IReturnValueConfiguration<TMember> WhenArgumentsMatch(Func<ArgumentCollection, bool> argumentsPredicate)
             {
-                Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
-
-                this.ParentConfiguration.RuleBeingBuilt.UsePredicateToValidateArguments(argumentsPredicate);
+                this.ParentConfiguration.WhenArgumentsMatch(argumentsPredicate);
                 return this;
             }
 


### PR DESCRIPTION
instead of reimplementing it separately

Similar to the [change](https://github.com/FakeItEasy/FakeItEasy/pull/840/files#diff-6d9562889008c1f9bfad045e9078aba0R150) made in #840, but I moved this one to a separate PR since it wasn't related to the original PR.