### PR TITLE
Restore project/account AppVeyor NuGet feeds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ build_script:
 
 nuget:
     disable_publish_on_pr: true
+    account_feed: true
+    project_feed: true
 
 test: off
 


### PR DESCRIPTION
I think in #858, the addition of the `nuget` section to `appveyor.yml` may have stopped the automatic publishing of the NuGet project and account feeds:

![image](https://cloud.githubusercontent.com/assets/3275797/18547363/0c4a0058-7b11-11e6-9116-c63ec8b899a1.png)

I'm hoping this will restore them, but have no idea how to test other than to make the change and see what happens.
Sorry about this.