### PR TITLE
add build suffix to pre-release packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ version: '{build}'
 
 environment:
     PATH: 'C:\Ruby200\bin;%PATH%'
+    BUILD: $(APPVEYOR_BUILD_NUMBER)
 
 install:
     - cmd: bundle install
@@ -17,6 +18,6 @@ test: off
 
 artifacts:
     - path: .\artifacts\logs\*.*
-    - path: .\artifacts\output\*-netstd.nupkg
+    - path: .\artifacts\output\*-netstd*.nupkg
     - path: .\artifacts\output
     - path: .\artifacts\tests\*.*

--- a/rakefile.netstd.rb
+++ b/rakefile.netstd.rb
@@ -15,6 +15,8 @@ version         = IO.read(assembly_info)[/AssemblyInformationalVersion\("([^"]+)
 #version_suffix  = ENV["VERSION_SUFFIX"]
 #version_suffix  = version_suffix.to_s.empty? ? "-adhoc" : version_suffix
 version_suffix  = "-netstd" #temporary while we have two build scripts
+build           = (ENV["BUILD"] || "").rjust(6, "0");
+build_suffix    = version_suffix.to_s.empty? ? "" : "-build" + build;
 repo_url        = "https://github.com/FakeItEasy/FakeItEasy"
 nuspec          = "src/FakeItEasy.netstd/FakeItEasy.nuspec"
 analyzer_nuspec = "src/FakeItEasy.Analyzer/FakeItEasy.Analyzer.nuspec"
@@ -269,13 +271,13 @@ directory output
 desc "create the nuget package"
 exec :pack => [:build, output] do |cmd|
   cmd.command = nuget_command
-  cmd.parameters "pack #{nuspec} -Version #{version}#{version_suffix} -OutputDirectory #{output}"
+  cmd.parameters "pack #{nuspec} -Version #{version}#{version_suffix}#{build_suffix} -OutputDirectory #{output}"
 end
 
 desc "create the analyzer nuget package"
 exec :pack => [:build, output] do |cmd|
   cmd.command = nuget_command
-  cmd.parameters "pack #{analyzer_nuspec} -Version #{version}#{version_suffix} -OutputDirectory #{output}"
+  cmd.parameters "pack #{analyzer_nuspec} -Version #{version}#{version_suffix}#{build_suffix} -OutputDirectory #{output}"
 end
 
 def create_release(client, repo, milestone, release_version, release_body, release_issue_body, release_issue_labels)

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -13,6 +13,8 @@ solution        = "FakeItEasy.sln"
 assembly_info   = "src/CommonAssemblyInfo.cs"
 version         = IO.read(assembly_info)[/AssemblyInformationalVersion\("([^"]+)"\)/, 1]
 version_suffix  = ENV["VERSION_SUFFIX"]
+build           = (ENV["BUILD"] || "").rjust(6, "0");
+build_suffix    = version_suffix.to_s.empty? ? "" : "-build" + build;
 repo_url        = "https://github.com/FakeItEasy/FakeItEasy"
 nuspec          = "src/FakeItEasy/FakeItEasy.nuspec"
 analyzer_nuspec = "src/FakeItEasy.Analyzer/FakeItEasy.Analyzer.nuspec"
@@ -253,13 +255,13 @@ directory output
 desc "create the nuget package"
 exec :pack => [:build, output] do |cmd|
   cmd.command = nuget_command
-  cmd.parameters "pack #{nuspec} -Version #{version}#{version_suffix} -OutputDirectory #{output}"
+  cmd.parameters "pack #{nuspec} -Version #{version}#{version_suffix}#{build_suffix} -OutputDirectory #{output}"
 end
 
 desc "create the analyzer nuget package"
 exec :pack => [:build, output] do |cmd|
   cmd.command = nuget_command
-  cmd.parameters "pack #{analyzer_nuspec} -Version #{version}#{version_suffix} -OutputDirectory #{output}"
+  cmd.parameters "pack #{analyzer_nuspec} -Version #{version}#{version_suffix}#{build_suffix} -OutputDirectory #{output}"
 end
 
 def create_release(client, repo, milestone, release_version, release_body, release_issue_body, release_issue_labels)


### PR DESCRIPTION
I think it's important that we increment our package number each time a new package is created in our AppVeyor NuGet feed. This PR appends the build number to it. Otherwise, each time a PR is merged, the -netstd packages are replaced in the NuGet feed, and anyone restoring them will be silently upgraded.

This will also affect pre-release packages of the regular (non -netstd) packages, but appending a build number to these is also common practice, e.g. https://www.nuget.org/packages/xunit/2.2.0-beta2-build3300.