### PR TITLE
Integration tests for .NET Standard build

### DIFF
--- a/FakeItEasy.netstd.sln
+++ b/FakeItEasy.netstd.sln
@@ -143,6 +143,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FakeItEasy.Tests.Approval.n
 		{CF137AE3-7C4F-41BD-A4AD-762BBED2255E} = {CF137AE3-7C4F-41BD-A4AD-762BBED2255E}
 	EndProjectSection
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FakeItEasy.IntegrationTests.netstd", "tests\FakeItEasy.IntegrationTests.netstd\FakeItEasy.IntegrationTests.netstd.xproj", "{CFCEF7CF-B06E-47C5-B1E4-59A41262DA8D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{CF137AE3-7C4F-41BD-A4AD-762BBED2255E} = {CF137AE3-7C4F-41BD-A4AD-762BBED2255E}
+	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FakeItEasy.IntegrationTests.External.netstd", "tests\FakeItEasy.IntegrationTests.External.netstd\FakeItEasy.IntegrationTests.External.netstd.xproj", "{BB92D188-5666-46DC-935A-81F0C5173D20}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -205,6 +212,14 @@ Global
 		{BC38E29E-2915-4E3E-BC12-69226747E269}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC38E29E-2915-4E3E-BC12-69226747E269}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BC38E29E-2915-4E3E-BC12-69226747E269}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFCEF7CF-B06E-47C5-B1E4-59A41262DA8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFCEF7CF-B06E-47C5-B1E4-59A41262DA8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFCEF7CF-B06E-47C5-B1E4-59A41262DA8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFCEF7CF-B06E-47C5-B1E4-59A41262DA8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB92D188-5666-46DC-935A-81F0C5173D20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB92D188-5666-46DC-935A-81F0C5173D20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB92D188-5666-46DC-935A-81F0C5173D20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB92D188-5666-46DC-935A-81F0C5173D20}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -230,6 +245,8 @@ Global
 		{AA7CF6E8-C3F2-43CC-A765-5B05AADED390} = {DC5EAE30-96E3-4D38-B3C5-33E587C9FB76}
 		{E7190229-2F49-4FFF-ABA6-715D48C83BA1} = {3192F732-5E1C-4B3A-9CB9-AF729A513941}
 		{BC38E29E-2915-4E3E-BC12-69226747E269} = {9D4A41F1-D444-4244-AAAC-F610D9977B2F}
+		{CFCEF7CF-B06E-47C5-B1E4-59A41262DA8D} = {5D41D463-D53B-4ADC-90AD-44AA03D6340D}
+		{BB92D188-5666-46DC-935A-81F0C5173D20} = {5D41D463-D53B-4ADC-90AD-44AA03D6340D}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		version = 0.1

--- a/rakefile.netstd.rb
+++ b/rakefile.netstd.rb
@@ -41,6 +41,10 @@ integration_tests = [
   "tests/FakeItEasy.IntegrationTests.VB/bin/Release/FakeItEasy.IntegrationTests.VB.dll"
 ]
 
+netstd_integration_test_directories = [
+  "tests/FakeItEasy.IntegrationTests.netstd"
+]
+
 specs = [
   "tests/FakeItEasy.Specs/bin/Release/FakeItEasy.Specs.dll"
 ]
@@ -116,7 +120,7 @@ task :restore do
 
   # performing restore on the solution doesn't restore
   # all the xprojs' dependencies, so do them separately
-  netstd_unit_test_directories.each do | test_directory |
+  (netstd_unit_test_directories + netstd_integration_test_directories).each do | test_directory |
     restore_dependencies_for_project test_directory
   end
 end
@@ -254,6 +258,7 @@ end
 desc "Execute integration tests"
 task :integ => [:build, tests] do
     run_tests(integration_tests, xunit_command, tests)
+    run_netstd_tests(netstd_integration_test_directories, tests)
 end
 
 desc "Execute specifications"

--- a/src/FakeItEasy/Core/AssemblyExtensions.cs
+++ b/src/FakeItEasy/Core/AssemblyExtensions.cs
@@ -14,16 +14,7 @@ namespace FakeItEasy.Core
         {
             Guard.AgainstNull(assembly, nameof(assembly));
 
-#if FEATURE_REFLECTION_GETASSEMBLIES
             return assembly.GetReferencedAssemblies().Any(r => r.FullName == TypeCatalogue.FakeItEasyAssembly.FullName);
-#else
-            var fakeItEasyLibraryName = TypeCatalogue.FakeItEasyAssembly.GetName().Name;
-            var context = Microsoft.Extensions.DependencyModel.DependencyContext.Default;
-
-            var runtimeLib = context.RuntimeLibraries
-                .SingleOrDefault(library => string.Equals(library.Name, assembly.Name(), System.StringComparison.Ordinal));
-            return runtimeLib != null && runtimeLib.Dependencies.Any(dependency => string.Equals(dependency.Name, fakeItEasyLibraryName, System.StringComparison.Ordinal));
-#endif
         }
 
         /// <summary>

--- a/src/FakeItEasy/Core/TypeCatalogue.cs
+++ b/src/FakeItEasy/Core/TypeCatalogue.cs
@@ -107,13 +107,13 @@ namespace FakeItEasy.Core
         {
             foreach (var file in files)
             {
-                Assembly reflectedAssembly = null;
+                Assembly assembly = null;
                 try
                 {
 #if FEATURE_REFLECTION_GETASSEMBLIES
-                    reflectedAssembly = Assembly.ReflectionOnlyLoadFrom(file);
+                    assembly = Assembly.ReflectionOnlyLoadFrom(file);
 #else
-                    reflectedAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(file);
+                    assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(file);
 #endif
                 }
                 catch (Exception ex)
@@ -122,24 +122,25 @@ namespace FakeItEasy.Core
                     continue;
                 }
 
-                if (!reflectedAssembly.ReferencesFakeItEasy())
+                if (!assembly.ReferencesFakeItEasy())
                 {
                     continue;
                 }
 
-                // A reflection-only loaded assembly can't be scanned for types, so fully load it before saving it.
-                Assembly loadedAssembly = null;
+#if FEATURE_REFLECTION_GETASSEMBLIES
+                // A reflection-only loaded assembly can't be scanned for types, so fully load it before returning it.
                 try
                 {
-                    loadedAssembly = Assembly.Load(reflectedAssembly.GetName());
+                    assembly = Assembly.Load(assembly.GetName());
                 }
                 catch (Exception ex)
                 {
                     WarnFailedToLoadAssembly(file, ex);
                     continue;
                 }
+#endif
 
-                yield return loadedAssembly;
+                yield return assembly;
             }
         }
 

--- a/tests/FakeItEasy.IntegrationTests.External.netstd/FakeItEasy.IntegrationTests.External.netstd.xproj
+++ b/tests/FakeItEasy.IntegrationTests.External.netstd/FakeItEasy.IntegrationTests.External.netstd.xproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>bb92d188-5666-46dc-935a-81f0c5173d20</ProjectGuid>
+    <RootNamespace>FakeItEasy.IntegrationTests.External</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tests/FakeItEasy.IntegrationTests.External.netstd/project.json
+++ b/tests/FakeItEasy.IntegrationTests.External.netstd/project.json
@@ -1,0 +1,26 @@
+﻿{
+  "name": "FakeItEasy.IntegrationTests.External",
+  "version": "1.0.0-*",
+  "description": "FakeItEasy.IntegrationTests.External.netstd Class Library",
+
+  "buildOptions": {
+    "compile": {
+      "include": [
+        "../FakeItEasy.IntegrationTests.External/**/*.cs"
+      ]
+    }
+  },
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "FakeItEasy": {
+      "target": "project",
+      "version": "99.99.99-wrapped"
+    }
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+    }
+  }
+}

--- a/tests/FakeItEasy.IntegrationTests.netstd/FakeItEasy.IntegrationTests.netstd.xproj
+++ b/tests/FakeItEasy.IntegrationTests.netstd/FakeItEasy.IntegrationTests.netstd.xproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>cfcef7cf-b06e-47c5-b1e4-59a41262da8d</ProjectGuid>
+    <RootNamespace>FakeItEasy.IntegrationTests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tests/FakeItEasy.IntegrationTests.netstd/project.json
+++ b/tests/FakeItEasy.IntegrationTests.netstd/project.json
@@ -1,0 +1,58 @@
+﻿{
+  "name": "FakeItEasy.IntegrationTests",
+  "version": "1.0.0-*",
+  "description": "FakeItEasy.IntegrationTests.netstd Class Library",
+
+  "buildOptions": {
+    "keyFile": "../../FakeItEasy.snk",
+    "compile": {
+      "include": [
+        "../FakeItEasy.IntegrationTests/**/*.cs"
+      ]
+    },
+    "define": [ "NETCORE" ]
+  },
+
+  "dependencies": {
+    "xunit.abstractions": "2.0.1-rc2",
+    "xunit.extensibility.core": "2.2.0-beta2-build3300",
+    "xunit.extensibility.execution": "2.2.0-beta2-build3300"
+  },
+
+  "testRunner": "xunit",
+  "frameworks": {
+    "netcoreapp1.0": {
+      "buildOptions": {
+        "define": [ "NETCORE", "FEATURE_NETCORE_REFLECTION" ]
+      },
+      "dependencies": {
+        "Castle.Core": "4.0.0-beta002",
+        "FakeItEasy": {
+          "target": "project",
+          "version": "99.99.99-wrapped"
+        },
+        "FakeItEasy.Tests.netstd": {
+          "target": "project",
+          "version": "1.0.0"
+        },
+        "FluentAssertions": "4.6.3",
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "System.Console": "4.0.0",
+        "System.Diagnostics.TraceSource": "4.0.0",
+        "System.Linq.Expressions": "4.1.0",
+        "System.Reflection": "4.1.0",
+        "System.Reflection.Emit.ILGeneration": "4.0.1",
+        "System.Reflection.Extensions": "4.0.1",
+        "System.Reflection.TypeExtensions": "4.1.0",
+        "System.Runtime.Serialization.Primitives": "4.1.1",
+        "System.Threading.Tasks.Parallel": "4.0.1",
+        "Microsoft.CSharp": "4.0.1",
+        "dotnet-test-xunit": "2.2.0-preview2-build1029"
+      },
+      "imports": [ "dnxcore50", "portable-net451+win81" ]
+    }
+  }
+}

--- a/tests/FakeItEasy.IntegrationTests/FakeItEasy.IntegrationTests.csproj
+++ b/tests/FakeItEasy.IntegrationTests/FakeItEasy.IntegrationTests.csproj
@@ -121,10 +121,6 @@
     </CodeAnalysisDictionary>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /D /Y $(SolutionDir)\tests\FakeItEasy.IntegrationTests.External\$(OutDir)FakeItEasy.IntegrationTests.External.dll $(TargetDir)
-</PostBuildEvent>
-  </PropertyGroup>
   <Import Project="..\..\packages\StyleCop.MSBuild.4.7.54.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.54.0\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/tests/FakeItEasy.IntegrationTests/FakingClassesTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/FakingClassesTests.cs
@@ -21,6 +21,9 @@ namespace FakeItEasy.IntegrationTests
 
 #if FEATURE_BINARY_SERIALIZATION
         [Fact]
+#else
+        [Fact(Skip = "Binary serialization is not supported on this platform.")]
+#endif
         public void Should_be_able_to_use_a_fake_after_binary_deserializing_it()
         {
             // Arrange
@@ -32,9 +35,12 @@ namespace FakeItEasy.IntegrationTests
             // Assert
             deserializedPerson.Name.Should().Be(string.Empty, "because the default behavior should work");
         }
-#endif
 
+#if FEATURE_BINARY_SERIALIZATION
         [Fact]
+#else
+        [Fact(Skip = "Binary serialization is not supported on this platform.")]
+#endif
         public void Should_be_able_to_change_the_configuration_of_a_fake_after_binary_deserializing_it()
         {
             // Arrange
@@ -48,7 +54,9 @@ namespace FakeItEasy.IntegrationTests
             deserializedPerson.Name.Should().Be("Eric Cartman");
         }
 
+#if FEATURE_BINARY_SERIALIZATION
         [Serializable]
+#endif
         public class Person
         {
             public virtual string Name { get; set; }

--- a/tests/FakeItEasy.IntegrationTests/GeneralTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/GeneralTests.cs
@@ -3,6 +3,9 @@ namespace FakeItEasy.IntegrationTests
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+#if FEATURE_NETCORE_REFLECTION
+    using System.Reflection;
+#endif
     using FakeItEasy.Configuration;
     using FakeItEasy.Core;
     using FakeItEasy.Tests;
@@ -55,7 +58,7 @@ namespace FakeItEasy.IntegrationTests
             var fake = A.Fake<IEmpty>(a => a.WithAttributes(() => new ForTestAttribute()));
 
             // Assert
-            fake.GetType().GetCustomAttributes(typeof(ForTestAttribute), true).Should().HaveCount(1);
+            fake.GetType().GetTypeInfo().GetCustomAttributes(typeof(ForTestAttribute), true).Should().HaveCount(1);
         }
 
         [Fact]
@@ -68,7 +71,7 @@ namespace FakeItEasy.IntegrationTests
             var secondFake = A.Fake<IFormattable>();
 
             // Assert
-            secondFake.GetType().GetCustomAttributes(typeof(ForTestAttribute), true).Should().BeEmpty();
+            secondFake.GetType().GetTypeInfo().GetCustomAttributes(typeof(ForTestAttribute), true).Should().BeEmpty();
         }
 
         [Fact]

--- a/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
@@ -18,6 +18,7 @@ namespace FakeItEasy.IntegrationTests
             // Arrange
             var originalExternalDll = GetPathToOriginalExternalDll();
             var copyOfExternalDll = GetPathToCopyOfExternalDll();
+            File.Copy(originalExternalDll, copyOfExternalDll, overwrite: true);
 
             var expectedMessageFormat =
 @"*Warning: FakeItEasy failed to load assembly '*{0}' while scanning for extension points. Any IArgumentValueFormatters, IDummyFactories, and IFakeOptionsBuilders in that assembly will not be available.*";


### PR DESCRIPTION
Connects to #531.
Was finally able to clear (IMO) the last couple hurdles after @jeremymeng's work to add integration tests to the .NET Standard build.
In the end I'd probably squash the whole bit, but I wanted you to be able to see the first commit, which @jermeymeng gets credit for (I tweaked slightly so we could rebase), and the others, which I get blame for.

The most interesting thing is that when loading assemblies from files, the .NET Standard loader does not error out if you load the same assembly from different paths. Hence the skipping of `Should_warn_of_duplicate_input_assemblies_with_different_paths`.

Oh! And our original method of telling whether an assembly reference FakeItEasy did not work for assemblies explicitly loaded from files (the so-called "external" assemblies). Turns out we can simplify a lot. 