### PR TITLE
Upgrade to Castle.Core 4.0.0-beta002

### DIFF
--- a/docs/creating-fakes.md
+++ b/docs/creating-fakes.md
@@ -27,7 +27,7 @@ When creating fakes you can, through a fluent interface, specify options for how
 
 * Specify arguments for the constructor of the faked type.
 * Specify additional interfaces that the fake should implement.
-* Assign additional custom attributes to the faked class.
+* Assign additional custom attributes to the faked type.
 * Cause a fake to have [strict mocking semantics](strict-fakes.md).
 * Configure all of a fake's methods to [use their original implementation](calling-base-methods.md).
 * Create a fake that wraps another object.
@@ -51,13 +51,9 @@ var foo = A.Fake<FooClass>(x => x.Implements(typeof(IFoo)));
 // or
 var foo = A.Fake<FooClass>(x => x.Implements<IFoo>());
 
-// Assigning custom attributes to the faked class.
-// Get a parameterless constructor for our attribute and create a builder
-var constructor = typeof(FooAttribute).GetConstructor(new Type[0]);
-var builder = new CustomAttributeBuilder(constructor, new object[0]);
-var builders = new List<CustomAttributeBuilder>() { builder };
-// foo and foo's type should both have "FooAttribute"
-var foo = A.Fake<IFoo>(x => x.WithAdditionalAttributes(builders));
+// Assigning custom attributes to the faked type.
+// foo's type should have "FooAttribute"
+var foo = A.Fake<IFoo>(x => x.WithAttributes(() => new FooAttribute()));
 
 // Create wrapper - unconfigured calls will be forwarded to wrapped
 var wrapped = new FooClass("foo", "bar");

--- a/src/FakeItEasy.netstd/project.json
+++ b/src/FakeItEasy.netstd/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Castle.Core": "4.0.0-beta001",
+    "Castle.Core": "4.0.0-beta002",
     "Microsoft.Extensions.DependencyModel": "1.0.0",
     "StyleCop.MSBuild": {
       "version": "4.7.54",

--- a/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
+++ b/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
@@ -2,7 +2,7 @@ namespace FakeItEasy.Core
 {
     using System;
     using System.Collections.Generic;
-    using System.Reflection.Emit;
+    using System.Linq.Expressions;
     using FakeItEasy.Creation;
 #if FEATURE_SELF_INITIALIZED_FAKES
     using FakeItEasy.SelfInitializedFakes;
@@ -38,9 +38,9 @@ namespace FakeItEasy.Core
             return this.fakeOptions.Wrapping(wrappedInstance);
         }
 
-        public override IFakeOptions<T> WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders)
+        public override IFakeOptions<T> WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes)
         {
-            return this.fakeOptions.WithAdditionalAttributes(customAttributeBuilders);
+            return this.fakeOptions.WithAdditionalAttributes(attributes);
         }
 
         public override IFakeOptions<T> Implements(Type interfaceType)

--- a/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
+++ b/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
@@ -38,9 +38,9 @@ namespace FakeItEasy.Core
             return this.fakeOptions.Wrapping(wrappedInstance);
         }
 
-        public override IFakeOptions<T> WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes)
+        public override IFakeOptions<T> WithAttributes(params Expression<Func<Attribute>>[] attributes)
         {
-            return this.fakeOptions.WithAdditionalAttributes(attributes);
+            return this.fakeOptions.WithAttributes(attributes);
         }
 
         public override IFakeOptions<T> Implements(Type interfaceType)

--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
@@ -5,13 +5,13 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
+    using System.Linq.Expressions;
     using System.Reflection;
-    using System.Reflection.Emit;
     using Castle.DynamicProxy;
     using FakeItEasy.Core;
 
     internal class CastleDynamicProxyGenerator
-        : IProxyGenerator
+        : FakeItEasy.Creation.IProxyGenerator
     {
         private static readonly IProxyGenerationHook ProxyGenerationHook = new InterceptEverythingHook();
         private static readonly ProxyGenerator ProxyGenerator = new ProxyGenerator();
@@ -26,15 +26,15 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
             Type typeOfProxy,
             IEnumerable<Type> additionalInterfacesToImplement,
             IEnumerable<object> argumentsForConstructor,
-            IEnumerable<CustomAttributeBuilder> customAttributeBuilders,
+            IEnumerable<Expression<Func<Attribute>>> attributes,
             IFakeCallProcessorProvider fakeCallProcessorProvider)
         {
-            Guard.AgainstNull(customAttributeBuilders, nameof(customAttributeBuilders));
+            Guard.AgainstNull(attributes, nameof(attributes));
 
             var options = CreateProxyGenerationOptions();
-            foreach (CustomAttributeBuilder builder in customAttributeBuilders)
+            foreach (var attribute in attributes)
             {
-                options.AdditionalAttributes.Add(builder);
+                options.AdditionalAttributes.Add(CustomAttributeInfo.FromExpression(attribute));
             }
 
             return GenerateProxy(typeOfProxy, options, additionalInterfacesToImplement, argumentsForConstructor, fakeCallProcessorProvider);

--- a/src/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
+++ b/src/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
@@ -83,7 +83,7 @@ namespace FakeItEasy.Creation
                 return this;
             }
 
-            public override IFakeOptions<T> WithAdditionalAttributes(
+            public override IFakeOptions<T> WithAttributes(
                 params Expression<Func<Attribute>>[] attributes)
             {
                 Guard.AgainstNull(attributes, nameof(attributes));

--- a/src/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
+++ b/src/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
@@ -2,10 +2,10 @@ namespace FakeItEasy.Creation
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq.Expressions;
 #if FEATURE_NETCORE_REFLECTION
     using System.Reflection;
 #endif
-    using System.Reflection.Emit;
     using FakeItEasy.Core;
 
     /// <summary>
@@ -84,13 +84,13 @@ namespace FakeItEasy.Creation
             }
 
             public override IFakeOptions<T> WithAdditionalAttributes(
-                IEnumerable<CustomAttributeBuilder> customAttributeBuilders)
+                params Expression<Func<Attribute>>[] attributes)
             {
-                Guard.AgainstNull(customAttributeBuilders, nameof(customAttributeBuilders));
+                Guard.AgainstNull(attributes, nameof(attributes));
 
-                foreach (var customAttributeBuilder in customAttributeBuilders)
+                foreach (var attribute in attributes)
                 {
-                    this.proxyOptions.AddAttribute(customAttributeBuilder);
+                    this.proxyOptions.AddAttribute(attribute);
                 }
 
                 return this;

--- a/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
@@ -5,7 +5,6 @@ namespace FakeItEasy.Creation.DelegateProxies
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using System.Reflection.Emit;
     using FakeItEasy.Configuration;
     using FakeItEasy.Core;
 
@@ -36,7 +35,7 @@ namespace FakeItEasy.Creation.DelegateProxies
             Type typeOfProxy,
             IEnumerable<Type> additionalInterfacesToImplement,
             IEnumerable<object> argumentsForConstructor,
-            IEnumerable<CustomAttributeBuilder> customAttributeBuilders,
+            IEnumerable<Expression<Func<Attribute>>> attributes,
             IFakeCallProcessorProvider fakeCallProcessorProvider)
         {
             return this.GenerateProxy(

--- a/src/FakeItEasy/Creation/FakeObjectCreator.cs
+++ b/src/FakeItEasy/Creation/FakeObjectCreator.cs
@@ -114,7 +114,7 @@ namespace FakeItEasy.Creation
                     typeOfFake,
                     proxyOptions.AdditionalInterfacesToImplement,
                     argumentsForConstructor,
-                    proxyOptions.AdditionalAttributes,
+                    proxyOptions.Attributes,
                     fakeCallProcessorProvider);
         }
     }

--- a/src/FakeItEasy/Creation/FakeOptionsBase.cs
+++ b/src/FakeItEasy/Creation/FakeOptionsBase.cs
@@ -5,7 +5,6 @@ namespace FakeItEasy.Creation
     using System.Globalization;
     using System.Linq;
     using System.Linq.Expressions;
-    using System.Reflection.Emit;
 
     internal abstract class FakeOptionsBase<T> : IFakeOptions<T>, IFakeOptions
     {
@@ -14,9 +13,9 @@ namespace FakeItEasy.Creation
             return (IFakeOptions)this.ConfigureFake(fake => action(fake));
         }
 
-        IFakeOptions IFakeOptions.WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders)
+        IFakeOptions IFakeOptions.WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes)
         {
-            return (IFakeOptions)this.WithAdditionalAttributes(customAttributeBuilders);
+            return (IFakeOptions)this.WithAdditionalAttributes(attributes);
         }
 
         IFakeOptions IFakeOptions.Implements(Type interfaceType)
@@ -58,7 +57,7 @@ namespace FakeItEasy.Creation
 
         public abstract IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);
 
-        public abstract IFakeOptions<T> WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders);
+        public abstract IFakeOptions<T> WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes);
 
         public abstract IFakeOptions<T> Implements(Type interfaceType);
 

--- a/src/FakeItEasy/Creation/FakeOptionsBase.cs
+++ b/src/FakeItEasy/Creation/FakeOptionsBase.cs
@@ -13,9 +13,9 @@ namespace FakeItEasy.Creation
             return (IFakeOptions)this.ConfigureFake(fake => action(fake));
         }
 
-        IFakeOptions IFakeOptions.WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes)
+        IFakeOptions IFakeOptions.WithAttributes(params Expression<Func<Attribute>>[] attributes)
         {
-            return (IFakeOptions)this.WithAdditionalAttributes(attributes);
+            return (IFakeOptions)this.WithAttributes(attributes);
         }
 
         IFakeOptions IFakeOptions.Implements(Type interfaceType)
@@ -57,7 +57,7 @@ namespace FakeItEasy.Creation
 
         public abstract IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);
 
-        public abstract IFakeOptions<T> WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes);
+        public abstract IFakeOptions<T> WithAttributes(params Expression<Func<Attribute>>[] attributes);
 
         public abstract IFakeOptions<T> Implements(Type interfaceType);
 

--- a/src/FakeItEasy/Creation/IFakeOptions.cs
+++ b/src/FakeItEasy/Creation/IFakeOptions.cs
@@ -4,7 +4,6 @@ namespace FakeItEasy.Creation
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq.Expressions;
-    using System.Reflection.Emit;
 
     /// <summary>
     /// Provides options for generating fake object.
@@ -33,9 +32,9 @@ namespace FakeItEasy.Creation
         /// <summary>
         /// Specifies that the fake should be created with these additional attributes.
         /// </summary>
-        /// <param name="customAttributeBuilders">The attributes to build into the proxy.</param>
+        /// <param name="attributes">Expressions that create attributes to add to the proxy.</param>
         /// <returns>Options object.</returns>
-        IFakeOptions WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders);
+        IFakeOptions WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes);
 
         /// <summary>
         /// Specifies an action that should be run over the fake object for the initial configuration (during the creation of the fake proxy).

--- a/src/FakeItEasy/Creation/IFakeOptions.cs
+++ b/src/FakeItEasy/Creation/IFakeOptions.cs
@@ -34,7 +34,7 @@ namespace FakeItEasy.Creation
         /// </summary>
         /// <param name="attributes">Expressions that create attributes to add to the proxy.</param>
         /// <returns>Options object.</returns>
-        IFakeOptions WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes);
+        IFakeOptions WithAttributes(params Expression<Func<Attribute>>[] attributes);
 
         /// <summary>
         /// Specifies an action that should be run over the fake object for the initial configuration (during the creation of the fake proxy).

--- a/src/FakeItEasy/Creation/IFakeOptions.of.T.cs
+++ b/src/FakeItEasy/Creation/IFakeOptions.of.T.cs
@@ -39,7 +39,7 @@ namespace FakeItEasy.Creation
         /// </summary>
         /// <param name="attributes">Expressions that create attributes to add to the proxy.</param>
         /// <returns>Options object.</returns>
-        IFakeOptions<T> WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes);
+        IFakeOptions<T> WithAttributes(params Expression<Func<Attribute>>[] attributes);
 
         /// <summary>
         /// Sets up the fake to implement the specified interface in addition to the

--- a/src/FakeItEasy/Creation/IFakeOptions.of.T.cs
+++ b/src/FakeItEasy/Creation/IFakeOptions.of.T.cs
@@ -4,7 +4,6 @@ namespace FakeItEasy.Creation
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq.Expressions;
-    using System.Reflection.Emit;
 
     /// <summary>
     /// Provides options for generating fake object.
@@ -38,9 +37,9 @@ namespace FakeItEasy.Creation
         /// <summary>
         /// Specifies that the fake should be created with these additional attributes.
         /// </summary>
-        /// <param name="customAttributeBuilders">The attributes to build into the proxy.</param>
+        /// <param name="attributes">Expressions that create attributes to add to the proxy.</param>
         /// <returns>Options object.</returns>
-        IFakeOptions<T> WithAdditionalAttributes(IEnumerable<CustomAttributeBuilder> customAttributeBuilders);
+        IFakeOptions<T> WithAdditionalAttributes(params Expression<Func<Attribute>>[] attributes);
 
         /// <summary>
         /// Sets up the fake to implement the specified interface in addition to the

--- a/src/FakeItEasy/Creation/IProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/IProxyGenerator.cs
@@ -3,8 +3,8 @@ namespace FakeItEasy.Creation
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq.Expressions;
     using System.Reflection;
-    using System.Reflection.Emit;
     using FakeItEasy.Core;
 
     /// <summary>
@@ -19,10 +19,10 @@ namespace FakeItEasy.Creation
         /// <param name="typeOfProxy">The type of proxy to generate.</param>
         /// <param name="additionalInterfacesToImplement">Interfaces to be implemented by the proxy.</param>
         /// <param name="argumentsForConstructor">Arguments to pass to the constructor of the type in <paramref name="typeOfProxy" />.</param>
-        /// <param name="customAttributeBuilders">The custom attribute builders.</param>
+        /// <param name="attributes">The expressions that describe the attributes to add to the proxy.</param>
         /// <param name="fakeCallProcessorProvider">The call processor provider.</param>
         /// <returns>A result containing the generated proxy.</returns>
-        ProxyGeneratorResult GenerateProxy(Type typeOfProxy, IEnumerable<Type> additionalInterfacesToImplement, IEnumerable<object> argumentsForConstructor, IEnumerable<CustomAttributeBuilder> customAttributeBuilders, IFakeCallProcessorProvider fakeCallProcessorProvider);
+        ProxyGeneratorResult GenerateProxy(Type typeOfProxy, IEnumerable<Type> additionalInterfacesToImplement, IEnumerable<object> argumentsForConstructor, IEnumerable<Expression<Func<Attribute>>> attributes, IFakeCallProcessorProvider fakeCallProcessorProvider);
 
         /// <summary>
         /// Generates a proxy of the specified type and returns a result object containing information

--- a/src/FakeItEasy/Creation/IProxyOptions.cs
+++ b/src/FakeItEasy/Creation/IProxyOptions.cs
@@ -12,6 +12,6 @@ namespace FakeItEasy.Creation
 
         IEnumerable<Action<object>> ProxyConfigurationActions { get; }
 
-        IEnumerable<Expression<Func<Attribute>>> AdditionalAttributes { get; }
+        IEnumerable<Expression<Func<Attribute>>> Attributes { get; }
     }
 }

--- a/src/FakeItEasy/Creation/IProxyOptions.cs
+++ b/src/FakeItEasy/Creation/IProxyOptions.cs
@@ -2,7 +2,7 @@ namespace FakeItEasy.Creation
 {
     using System;
     using System.Collections.Generic;
-    using System.Reflection.Emit;
+    using System.Linq.Expressions;
 
     internal interface IProxyOptions
     {
@@ -12,6 +12,6 @@ namespace FakeItEasy.Creation
 
         IEnumerable<Action<object>> ProxyConfigurationActions { get; }
 
-        IEnumerable<CustomAttributeBuilder> AdditionalAttributes { get; }
+        IEnumerable<Expression<Func<Attribute>>> AdditionalAttributes { get; }
     }
 }

--- a/src/FakeItEasy/Creation/ProxyGeneratorSelector.cs
+++ b/src/FakeItEasy/Creation/ProxyGeneratorSelector.cs
@@ -2,10 +2,8 @@ namespace FakeItEasy.Creation
 {
     using System;
     using System.Collections.Generic;
-#if FEATURE_NETCORE_REFLECTION
+    using System.Linq.Expressions;
     using System.Reflection;
-#endif
-    using System.Reflection.Emit;
     using FakeItEasy.Core;
     using FakeItEasy.Creation.DelegateProxies;
 
@@ -21,21 +19,21 @@ namespace FakeItEasy.Creation
             this.defaultProxyGenerator = defaultProxyGenerator;
         }
 
-        public ProxyGeneratorResult GenerateProxy(Type typeOfProxy, System.Collections.Generic.IEnumerable<Type> additionalInterfacesToImplement, System.Collections.Generic.IEnumerable<object> argumentsForConstructor, IFakeCallProcessorProvider fakeCallProcessorProvider)
+        public ProxyGeneratorResult GenerateProxy(Type typeOfProxy, IEnumerable<Type> additionalInterfacesToImplement, IEnumerable<object> argumentsForConstructor, IFakeCallProcessorProvider fakeCallProcessorProvider)
         {
             var generator = this.SelectProxyGenerator(typeOfProxy);
 
             return generator.GenerateProxy(typeOfProxy, additionalInterfacesToImplement, argumentsForConstructor, fakeCallProcessorProvider);
         }
 
-        public ProxyGeneratorResult GenerateProxy(Type typeOfProxy, IEnumerable<Type> additionalInterfacesToImplement, IEnumerable<object> argumentsForConstructor, IEnumerable<CustomAttributeBuilder> customAttributeBuilders, IFakeCallProcessorProvider fakeCallProcessorProvider)
+        public ProxyGeneratorResult GenerateProxy(Type typeOfProxy, IEnumerable<Type> additionalInterfacesToImplement, IEnumerable<object> argumentsForConstructor, IEnumerable<Expression<Func<Attribute>>> attributes, IFakeCallProcessorProvider fakeCallProcessorProvider)
         {
             var generator = this.SelectProxyGenerator(typeOfProxy);
 
-            return generator.GenerateProxy(typeOfProxy, additionalInterfacesToImplement, argumentsForConstructor, customAttributeBuilders, fakeCallProcessorProvider);
+            return generator.GenerateProxy(typeOfProxy, additionalInterfacesToImplement, argumentsForConstructor, attributes, fakeCallProcessorProvider);
         }
 
-        public bool MethodCanBeInterceptedOnInstance(System.Reflection.MethodInfo method, object callTarget, out string failReason)
+        public bool MethodCanBeInterceptedOnInstance(MethodInfo method, object callTarget, out string failReason)
         {
             var generator = this.SelectProxyGenerator(callTarget == null ? null : callTarget.GetType());
 

--- a/src/FakeItEasy/Creation/ProxyOptions.cs
+++ b/src/FakeItEasy/Creation/ProxyOptions.cs
@@ -3,16 +3,16 @@ namespace FakeItEasy.Creation
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq.Expressions;
 #if FEATURE_NETCORE_REFLECTION
     using System.Reflection;
 #endif
-    using System.Reflection.Emit;
 
     internal class ProxyOptions : IProxyOptions
     {
         private readonly List<Type> additionalInterfacesToImplement = new List<Type>();
         private readonly List<Action<object>> proxyConfigurationActions = new List<Action<object>>();
-        private readonly List<CustomAttributeBuilder> additionalAttributes = new List<CustomAttributeBuilder>();
+        private readonly List<Expression<Func<Attribute>>> additionalAttributes = new List<Expression<Func<Attribute>>>();
 
         public IEnumerable<object> ArgumentsForConstructor { get; set; }
 
@@ -20,7 +20,7 @@ namespace FakeItEasy.Creation
 
         public IEnumerable<Action<object>> ProxyConfigurationActions => this.proxyConfigurationActions;
 
-        public IEnumerable<CustomAttributeBuilder> AdditionalAttributes => this.additionalAttributes;
+        public IEnumerable<Expression<Func<Attribute>>> AdditionalAttributes => this.additionalAttributes;
 
         public void AddInterfaceToImplement(Type interfaceType)
         {
@@ -43,7 +43,7 @@ namespace FakeItEasy.Creation
             this.proxyConfigurationActions.Add(action);
         }
 
-        public void AddAttribute(CustomAttributeBuilder attribute)
+        public void AddAttribute(Expression<Func<Attribute>> attribute)
         {
             this.additionalAttributes.Add(attribute);
         }

--- a/src/FakeItEasy/Creation/ProxyOptions.cs
+++ b/src/FakeItEasy/Creation/ProxyOptions.cs
@@ -12,7 +12,7 @@ namespace FakeItEasy.Creation
     {
         private readonly List<Type> additionalInterfacesToImplement = new List<Type>();
         private readonly List<Action<object>> proxyConfigurationActions = new List<Action<object>>();
-        private readonly List<Expression<Func<Attribute>>> additionalAttributes = new List<Expression<Func<Attribute>>>();
+        private readonly List<Expression<Func<Attribute>>> attributes = new List<Expression<Func<Attribute>>>();
 
         public IEnumerable<object> ArgumentsForConstructor { get; set; }
 
@@ -20,7 +20,7 @@ namespace FakeItEasy.Creation
 
         public IEnumerable<Action<object>> ProxyConfigurationActions => this.proxyConfigurationActions;
 
-        public IEnumerable<Expression<Func<Attribute>>> AdditionalAttributes => this.additionalAttributes;
+        public IEnumerable<Expression<Func<Attribute>>> Attributes => this.attributes;
 
         public void AddInterfaceToImplement(Type interfaceType)
         {
@@ -45,7 +45,7 @@ namespace FakeItEasy.Creation
 
         public void AddAttribute(Expression<Func<Attribute>> attribute)
         {
-            this.additionalAttributes.Add(attribute);
+            this.attributes.Add(attribute);
         }
     }
 }

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -52,8 +52,8 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net40-client\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.0.0-beta002\lib\net40-client\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/FakeItEasy/packages.config
+++ b/src/FakeItEasy/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net40" />
+  <package id="Castle.Core" version="4.0.0-beta002" targetFramework="net40" />
   <package id="ILMerge" version="2.14.1208" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/tests/FakeItEasy.IntegrationTests/GeneralTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/GeneralTests.cs
@@ -3,7 +3,6 @@ namespace FakeItEasy.IntegrationTests
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Reflection.Emit;
     using FakeItEasy.Configuration;
     using FakeItEasy.Core;
     using FakeItEasy.Tests;
@@ -51,14 +50,9 @@ namespace FakeItEasy.IntegrationTests
         public void Faked_object_with_additional_attributes_should_create_a_type_with_those_attributes()
         {
             // Arrange
-            var types = new Type[0];
-            var constructor = typeof(ForTestAttribute).GetConstructor(types);
-            var list = new object[0];
-            var attribute = new CustomAttributeBuilder(constructor, list);
-            var builder = new List<CustomAttributeBuilder> { attribute };
 
             // Act
-            var fake = A.Fake<IEmpty>(a => a.WithAdditionalAttributes(builder));
+            var fake = A.Fake<IEmpty>(a => a.WithAdditionalAttributes(() => new ForTestAttribute()));
 
             // Assert
             fake.GetType().GetCustomAttributes(typeof(ForTestAttribute), true).Should().HaveCount(1);
@@ -68,12 +62,7 @@ namespace FakeItEasy.IntegrationTests
         public void Additional_attributes_should_not_be_added_to_the_next_fake()
         {
             // Arrange
-            var types = new Type[0];
-            var constructor = typeof(ForTestAttribute).GetConstructor(types);
-            var list = new object[0];
-            var attribute = new CustomAttributeBuilder(constructor, list);
-            var builder = new List<CustomAttributeBuilder> { attribute };
-            A.Fake<IEmpty>(a => a.WithAdditionalAttributes(builder));
+            A.Fake<IEmpty>(a => a.WithAdditionalAttributes(() => new ForTestAttribute()));
 
             // Act
             var secondFake = A.Fake<IFormattable>();

--- a/tests/FakeItEasy.IntegrationTests/GeneralTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/GeneralTests.cs
@@ -52,7 +52,7 @@ namespace FakeItEasy.IntegrationTests
             // Arrange
 
             // Act
-            var fake = A.Fake<IEmpty>(a => a.WithAdditionalAttributes(() => new ForTestAttribute()));
+            var fake = A.Fake<IEmpty>(a => a.WithAttributes(() => new ForTestAttribute()));
 
             // Assert
             fake.GetType().GetCustomAttributes(typeof(ForTestAttribute), true).Should().HaveCount(1);
@@ -62,7 +62,7 @@ namespace FakeItEasy.IntegrationTests
         public void Additional_attributes_should_not_be_added_to_the_next_fake()
         {
             // Arrange
-            A.Fake<IEmpty>(a => a.WithAdditionalAttributes(() => new ForTestAttribute()));
+            A.Fake<IEmpty>(a => a.WithAttributes(() => new ForTestAttribute()));
 
             // Act
             var secondFake = A.Fake<IFormattable>();

--- a/tests/FakeItEasy.Specs/CreationOptionsSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationOptionsSpecs.cs
@@ -672,7 +672,7 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
-        public void WithAdditionalAttributes(
+        public void WithAttributes(
             IInterfaceThatWeWillAddAttributesTo1 fake,
             Action<IFakeOptions<IInterfaceThatWeWillAddAttributesTo1>> optionsBuilder)
         {
@@ -680,7 +680,7 @@ namespace FakeItEasy.Specs
                 .x(() =>
                 {
                     optionsBuilder = options => options
-                        .WithAdditionalAttributes(() => new ForTestAttribute());
+                        .WithAttributes(() => new ForTestAttribute());
                 });
 
             "When I create a fake using the options builder"
@@ -692,12 +692,12 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
-        public void WithAdditionalAttributesAndNullSetOfAttributes(
+        public void WithAttributesAndNullSetOfAttributes(
             Action<IFakeOptions<IInterfaceThatWeWillAddAttributesTo2>> optionsBuilder,
             Exception exception)
         {
             "Given an explicit options builder that adds a null attribute to a fake"
-                .x(() => optionsBuilder = options => options.WithAdditionalAttributes(null));
+                .x(() => optionsBuilder = options => options.WithAttributes(null));
 
             "When I create a fake using the options builder"
                 .x(() => exception = Record.Exception(() => this.CreateFake(optionsBuilder)));
@@ -708,7 +708,7 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
-        public void MultipleWithAdditionalAttributesConfigurations(
+        public void MultipleWithAttributesConfigurations(
             IInterfaceThatWeWillAddAttributesTo3 fake,
             Action<IFakeOptions<IInterfaceThatWeWillAddAttributesTo3>> optionsBuilder)
         {
@@ -716,8 +716,8 @@ namespace FakeItEasy.Specs
                 .x(() =>
                 {
                     optionsBuilder = options => options
-                        .WithAdditionalAttributes(() => new ScenarioAttribute())
-                        .WithAdditionalAttributes(() => new ExampleAttribute(), () => new DebuggerStepThroughAttribute());
+                        .WithAttributes(() => new ScenarioAttribute())
+                        .WithAttributes(() => new ExampleAttribute(), () => new DebuggerStepThroughAttribute());
                 });
 
             "When I create a fake using the options builder"
@@ -732,13 +732,13 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
-        public void WithSameAdditionalAttributes(
+        public void WithSameAttributes(
             IInterfaceThatWeWillAddAttributesTo1 fake1,
             IInterfaceThatWeWillAddAttributesTo1 fake2,
             Action<IFakeOptions<IInterfaceThatWeWillAddAttributesTo1>> optionsBuilder)
         {
             "Given an explicit options builder that adds an attribute to a fake"
-                .x(() => optionsBuilder = options => options.WithAdditionalAttributes(() => new ForTestAttribute()));
+                .x(() => optionsBuilder = options => options.WithAttributes(() => new ForTestAttribute()));
 
             "When I create a fake using the options builder"
                 .x(() => fake1 = A.Fake(optionsBuilder));
@@ -761,17 +761,17 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
-        public void WithDifferentAdditionalAttributes(
+        public void WithDifferentAttributes(
             IInterfaceThatWeWillAddAttributesTo1 fake1,
             IInterfaceThatWeWillAddAttributesTo1 fake2,
             Action<IFakeOptions<IInterfaceThatWeWillAddAttributesTo1>> optionsBuilder1,
             Action<IFakeOptions<IInterfaceThatWeWillAddAttributesTo1>> optionsBuilder2)
         {
             "Given an explicit options builder that adds an attribute to a fake"
-                .x(() => optionsBuilder1 = options => options.WithAdditionalAttributes(() => new ForTestAttribute()));
+                .x(() => optionsBuilder1 = options => options.WithAttributes(() => new ForTestAttribute()));
 
             "And another explicit options builder that adds another attribute to a fake"
-                .x(() => optionsBuilder2 = options => options.WithAdditionalAttributes(() => new DebuggerStepThroughAttribute()));
+                .x(() => optionsBuilder2 = options => options.WithAttributes(() => new DebuggerStepThroughAttribute()));
 
             "When I create a fake using the first options builder"
                 .x(() => fake1 = A.Fake(optionsBuilder1));

--- a/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
@@ -544,7 +544,7 @@ namespace FakeItEasy.Specs
                 domainEvent.ID = this.nextID++;
                 domainEvent.Name = typeOfFake.Name;
             })
-                .WithAdditionalAttributes(() => new ForTestAttribute())
+                .WithAttributes(() => new ForTestAttribute())
                 .Implements(typeof(IDisposable))
                 .Implements<ICloneable>();
         }

--- a/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
@@ -2,7 +2,6 @@ namespace FakeItEasy.Specs
 {
     using System;
     using System.Linq;
-    using System.Reflection.Emit;
     using FakeItEasy.Core;
     using FakeItEasy.Creation;
     using FakeItEasy.SelfInitializedFakes;
@@ -545,15 +544,9 @@ namespace FakeItEasy.Specs
                 domainEvent.ID = this.nextID++;
                 domainEvent.Name = typeOfFake.Name;
             })
-                .WithAdditionalAttributes(new[] { CreateCustomAttributeBuilder() })
+                .WithAdditionalAttributes(() => new ForTestAttribute())
                 .Implements(typeof(IDisposable))
                 .Implements<ICloneable>();
-        }
-
-        private static CustomAttributeBuilder CreateCustomAttributeBuilder()
-        {
-            var constructor = typeof(ForTestAttribute).GetConstructor(new Type[0]);
-            return new CustomAttributeBuilder(constructor, new object[0]);
         }
     }
 

--- a/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
@@ -436,7 +436,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions ConfigureFake(System.Action<object> action);
         FakeItEasy.Creation.IFakeOptions Implements(System.Type interfaceType);
         FakeItEasy.Creation.IFakeOptions Implements<TInterface>();
-        FakeItEasy.Creation.IFakeOptions WithAdditionalAttributes(System.Collections.Generic.IEnumerable<System.Reflection.Emit.CustomAttributeBuilder> customAttributeBuilders);
+        FakeItEasy.Creation.IFakeOptions WithAdditionalAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor<TConstructor>(System.Linq.Expressions.Expression<System.Func<TConstructor>> constructorCall);
         FakeItEasy.Creation.IFakeOptionsForWrappers Wrapping(object wrappedInstance);
@@ -447,7 +447,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions<T> ConfigureFake(System.Action<T> action);
         FakeItEasy.Creation.IFakeOptions<T> Implements(System.Type interfaceType);
         FakeItEasy.Creation.IFakeOptions<T> Implements<TInterface>();
-        FakeItEasy.Creation.IFakeOptions<T> WithAdditionalAttributes(System.Collections.Generic.IEnumerable<System.Reflection.Emit.CustomAttributeBuilder> customAttributeBuilders);
+        FakeItEasy.Creation.IFakeOptions<T> WithAdditionalAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Linq.Expressions.Expression<System.Func<T>> constructorCall);
         FakeItEasy.Creation.IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);

--- a/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
@@ -436,9 +436,9 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions ConfigureFake(System.Action<object> action);
         FakeItEasy.Creation.IFakeOptions Implements(System.Type interfaceType);
         FakeItEasy.Creation.IFakeOptions Implements<TInterface>();
-        FakeItEasy.Creation.IFakeOptions WithAdditionalAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor<TConstructor>(System.Linq.Expressions.Expression<System.Func<TConstructor>> constructorCall);
+        FakeItEasy.Creation.IFakeOptions WithAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptionsForWrappers Wrapping(object wrappedInstance);
     }
     public interface IFakeOptions<T> : FakeItEasy.IHideObjectMembers
@@ -447,9 +447,9 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions<T> ConfigureFake(System.Action<T> action);
         FakeItEasy.Creation.IFakeOptions<T> Implements(System.Type interfaceType);
         FakeItEasy.Creation.IFakeOptions<T> Implements<TInterface>();
-        FakeItEasy.Creation.IFakeOptions<T> WithAdditionalAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Linq.Expressions.Expression<System.Func<T>> constructorCall);
+        FakeItEasy.Creation.IFakeOptions<T> WithAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);
     }
     public interface IFakeOptionsForWrappers : FakeItEasy.Creation.IFakeOptions, FakeItEasy.IHideObjectMembers { }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
@@ -9,7 +9,7 @@
 namespace Castle.DynamicProxy
 {
     
-    public abstract class AbstractInvocation : Castle.DynamicProxy.IInvocation, System.Runtime.Serialization.ISerializable
+    public abstract class AbstractInvocation : Castle.DynamicProxy.IInvocation
     {
         protected readonly object proxyObject;
         protected AbstractInvocation(object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }
@@ -24,8 +24,6 @@ namespace Castle.DynamicProxy
         public object GetArgumentValue(int index) { }
         public System.Reflection.MethodInfo GetConcreteMethod() { }
         public System.Reflection.MethodInfo GetConcreteMethodInvocationTarget() { }
-        [System.Security.SecurityCriticalAttribute()]
-        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         protected abstract void InvokeMethodOnTarget();
         public void Proceed() { }
         public void SetArgumentValue(int index, object value) { }
@@ -45,7 +43,7 @@ namespace Castle.DynamicProxy.Generators
     {
         public static void Add(System.Type attribute) { }
         public static void Add<T>() { }
-        public static bool Contains(System.Type type) { }
+        public static bool Contains(System.Type attribute) { }
     }
 }
 namespace Castle.DynamicProxy.Internal
@@ -71,6 +69,7 @@ namespace Castle.DynamicProxy.Internal
     }
     public class static TypeUtil
     {
+        public static System.Type[] AsTypeArray(this System.Reflection.Emit.GenericTypeParameterBuilder[] typeInfos) { }
         public static System.Reflection.FieldInfo[] GetAllFields(this System.Type type) { }
         public static System.Type[] GetAllInterfaces(params System.Type[] types) { }
         public static System.Type[] GetAllInterfaces(this System.Type type) { }
@@ -520,7 +519,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions ConfigureFake(System.Action<object> action);
         FakeItEasy.Creation.IFakeOptions Implements(System.Type interfaceType);
         FakeItEasy.Creation.IFakeOptions Implements<TInterface>();
-        FakeItEasy.Creation.IFakeOptions WithAdditionalAttributes(System.Collections.Generic.IEnumerable<System.Reflection.Emit.CustomAttributeBuilder> customAttributeBuilders);
+        FakeItEasy.Creation.IFakeOptions WithAdditionalAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor<TConstructor>(System.Linq.Expressions.Expression<System.Func<TConstructor>> constructorCall);
         FakeItEasy.Creation.IFakeOptionsForWrappers Wrapping(object wrappedInstance);
@@ -531,7 +530,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions<T> ConfigureFake(System.Action<T> action);
         FakeItEasy.Creation.IFakeOptions<T> Implements(System.Type interfaceType);
         FakeItEasy.Creation.IFakeOptions<T> Implements<TInterface>();
-        FakeItEasy.Creation.IFakeOptions<T> WithAdditionalAttributes(System.Collections.Generic.IEnumerable<System.Reflection.Emit.CustomAttributeBuilder> customAttributeBuilders);
+        FakeItEasy.Creation.IFakeOptions<T> WithAdditionalAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Linq.Expressions.Expression<System.Func<T>> constructorCall);
         FakeItEasy.Creation.IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
@@ -519,9 +519,9 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions ConfigureFake(System.Action<object> action);
         FakeItEasy.Creation.IFakeOptions Implements(System.Type interfaceType);
         FakeItEasy.Creation.IFakeOptions Implements<TInterface>();
-        FakeItEasy.Creation.IFakeOptions WithAdditionalAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor<TConstructor>(System.Linq.Expressions.Expression<System.Func<TConstructor>> constructorCall);
+        FakeItEasy.Creation.IFakeOptions WithAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptionsForWrappers Wrapping(object wrappedInstance);
     }
     public interface IFakeOptions<T> : FakeItEasy.IHideObjectMembers
@@ -530,9 +530,9 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions<T> ConfigureFake(System.Action<T> action);
         FakeItEasy.Creation.IFakeOptions<T> Implements(System.Type interfaceType);
         FakeItEasy.Creation.IFakeOptions<T> Implements<TInterface>();
-        FakeItEasy.Creation.IFakeOptions<T> WithAdditionalAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Linq.Expressions.Expression<System.Func<T>> constructorCall);
+        FakeItEasy.Creation.IFakeOptions<T> WithAttributes(params System.Linq.Expressions.Expression<>[] attributes);
         FakeItEasy.Creation.IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);
     }
     public interface IFakeOptionsForWrappers : FakeItEasy.Creation.IFakeOptions, FakeItEasy.IHideObjectMembers

--- a/tests/FakeItEasy.Tests.netstd/project.json
+++ b/tests/FakeItEasy.Tests.netstd/project.json
@@ -36,7 +36,7 @@
         "define": [ "NETCORE", "FEATURE_NETCORE_REFLECTION" ]
       },
       "dependencies": {
-        "Castle.Core": "4.0.0-beta001",
+        "Castle.Core": "4.0.0-beta002",
         "FakeItEasy": {
           "target": "project",
           "version": "99.99.99-wrapped"

--- a/tests/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Tests.Creation
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
-    using System.Reflection.Emit;
+    using System.Linq.Expressions;
     using FakeItEasy.Core;
     using FakeItEasy.Creation;
     using FluentAssertions;
@@ -34,7 +34,7 @@ namespace FakeItEasy.Tests.Creation
 
             var proxy = A.Fake<IFoo>();
 
-            A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>._, A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
+            A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>._, A<IEnumerable<Expression<Func<Attribute>>>>._, A<IFakeCallProcessorProvider>._))
                 .Returns(new ProxyGeneratorResult(proxy));
 
             // Act
@@ -68,7 +68,7 @@ namespace FakeItEasy.Tests.Creation
             // Assert
             A.CallTo(() => this.fakeCallProcessorProviderFactory(typeof(IFoo), options)).MustHaveHappened();
 
-            A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>._, A<IEnumerable<CustomAttributeBuilder>>._, fakeCallProcessorProvider))
+            A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>._, A<IEnumerable<Expression<Func<Attribute>>>>._, fakeCallProcessorProvider))
                 .MustHaveHappened();
         }
 
@@ -154,13 +154,13 @@ namespace FakeItEasy.Tests.Creation
 
             // Assert
             A.CallTo(() =>
-                this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsNull(), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
+                this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsNull(), A<IEnumerable<Expression<Func<Attribute>>>>._, A<IFakeCallProcessorProvider>._))
                 .MustHaveHappened()
                 .Then(A.CallTo(() =>
-                    this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence(1, 1), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
+                    this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence(1, 1), A<IEnumerable<Expression<Func<Attribute>>>>._, A<IFakeCallProcessorProvider>._))
                     .MustHaveHappened())
                 .Then(A.CallTo(() =>
-                    this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence("dummy"), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
+                    this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence("dummy"), A<IEnumerable<Expression<Func<Attribute>>>>._, A<IFakeCallProcessorProvider>._))
                     .MustHaveHappened());
         }
 
@@ -198,9 +198,9 @@ namespace FakeItEasy.Tests.Creation
             var proxy = A.Fake<IFoo>();
 
             this.StubProxyGeneratorToFail();
-            A.CallTo(() => this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence(1, 1), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
+            A.CallTo(() => this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence(1, 1), A<IEnumerable<Expression<Func<Attribute>>>>._, A<IFakeCallProcessorProvider>._))
                 .Returns(new ProxyGeneratorResult(proxy));
-            A.CallTo(() => this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence(1), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
+            A.CallTo(() => this.proxyGenerator.GenerateProxy(typeof(TypeWithMultipleConstructors), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence(1), A<IEnumerable<Expression<Func<Attribute>>>>._, A<IFakeCallProcessorProvider>._))
                 .Returns(new ProxyGeneratorResult(new object()));
 
             // Act
@@ -222,7 +222,7 @@ namespace FakeItEasy.Tests.Creation
             this.fakeObjectCreator.CreateFake(typeof(TypeWithConstructorThatTakesDifferentTypes), new ProxyOptions(), session, throwOnFailure: false);
 
             // Assert
-            A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>.That.Not.IsNull(), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
+            A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>.That.Not.IsNull(), A<IEnumerable<Expression<Func<Attribute>>>>._, A<IFakeCallProcessorProvider>._))
                 .MustNotHaveHappened();
         }
 
@@ -240,7 +240,7 @@ namespace FakeItEasy.Tests.Creation
             this.fakeObjectCreator.CreateFake(typeof(TypeWithProtectedConstructor), options, session, throwOnFailure: false);
 
             // Assert
-            A.CallTo(() => this.proxyGenerator.GenerateProxy(typeof(TypeWithProtectedConstructor), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence(1), A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
+            A.CallTo(() => this.proxyGenerator.GenerateProxy(typeof(TypeWithProtectedConstructor), options.AdditionalInterfacesToImplement, A<IEnumerable<object>>.That.IsThisSequence(1), A<IEnumerable<Expression<Func<Attribute>>>>._, A<IFakeCallProcessorProvider>._))
                 .MustHaveHappened();
         }
 
@@ -355,7 +355,7 @@ namespace FakeItEasy.Tests.Creation
 
         private void StubProxyGeneratorToFail(string failReason)
         {
-            A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>._, A<IEnumerable<CustomAttributeBuilder>>._, A<IFakeCallProcessorProvider>._))
+            A.CallTo(() => this.proxyGenerator.GenerateProxy(A<Type>._, A<IEnumerable<Type>>._, A<IEnumerable<object>>._, A<IEnumerable<Expression<Func<Attribute>>>>._, A<IFakeCallProcessorProvider>._))
                 .Returns(new ProxyGeneratorResult(failReason));
         }
 

--- a/tests/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
@@ -47,7 +47,7 @@ namespace FakeItEasy.Tests.Creation
                     typeof(IFoo),
                     options.AdditionalInterfacesToImplement,
                     options.ArgumentsForConstructor,
-                    options.AdditionalAttributes,
+                    options.Attributes,
                     A<IFakeCallProcessorProvider>._))
                 .MustHaveHappened();
         }

--- a/tests/FakeItEasy.Tests/CustomArgumentConstraints.cs
+++ b/tests/FakeItEasy.Tests/CustomArgumentConstraints.cs
@@ -44,7 +44,7 @@ namespace FakeItEasy.Tests
                 x => !x.AdditionalInterfacesToImplement.Any()
                      && x.ArgumentsForConstructor == null
                      && !x.ProxyConfigurationActions.Any()
-                     && !x.AdditionalAttributes.Any(),
+                     && !x.Attributes.Any(),
                 x => x.Write("empty fake options"));
         }
 

--- a/wrap/FakeItEasy/project.json
+++ b/wrap/FakeItEasy/project.json
@@ -1,7 +1,7 @@
 {
   "version": "99.99.99-wrapped",
   "dependencies": {
-        "Castle.Core": "4.0.0-beta001"
+        "Castle.Core": "4.0.0-beta002"
   },
   "frameworks": {
     "netstandard1.6": {


### PR DESCRIPTION
Fixes #436 

The only visible API change is `IFakeOptions.WithAdditionalAttributes`, which now takes a `params Expression<Func<Attribute>>[]`.