### PR TITLE
[WIP] Automatic cancellation (POC)

### DIFF
--- a/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
+++ b/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\FakeItEasy\Configuration\PropertySetterConfiguration.cs">
       <Link>Configuration\PropertySetterConfiguration.cs</Link>
     </Compile>
+    <Compile Include="..\FakeItEasy\Core\FakeManager.CancellationRule.cs">
+      <Link>Core\FakeManager.CancellationRule.cs</Link>
+    </Compile>
     <Compile Include="..\FakeItEasy\ExceptionExtensions.cs">
       <Link>ExceptionExtensions.cs</Link>
     </Compile>

--- a/src/FakeItEasy/Core/FakeManager.CancellationRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.CancellationRule.cs
@@ -1,0 +1,51 @@
+namespace FakeItEasy.Core
+{
+    using System;
+    using System.Linq;
+#if FEATURE_NETCORE_REFLECTION
+    using System.Reflection;
+#endif
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <content>Event rule.</content>
+    public partial class FakeManager
+    {
+#if FEATURE_BINARY_SERIALIZATION
+        [Serializable]
+#endif
+        private class CancellationRule : IFakeObjectCallRule
+        {
+            public int? NumberOfTimesToCall => null;
+
+            public bool IsApplicableTo(IFakeObjectCall fakeObjectCall) =>
+                fakeObjectCall.Arguments.OfType<CancellationToken>().Any(ct => ct.IsCancellationRequested);
+
+            public void Apply(IInterceptedFakeObjectCall fakeObjectCall)
+            {
+                var returnType = fakeObjectCall.Method.ReturnType;
+                if (typeof(Task).GetTypeInfo().IsAssignableFrom(returnType))
+                {
+                    Task task;
+                    if (returnType == typeof(Task))
+                    {
+                        task = TaskHelper.Cancelled();
+                    }
+                    else
+                    {
+                        var taskResultType = returnType.GetTypeInfo().GetGenericArguments()[0];
+                        task = TaskHelper.Cancelled(taskResultType);
+                    }
+
+                    fakeObjectCall.SetReturnValue(task);
+                }
+                else
+                {
+                    var token =
+                        fakeObjectCall.Arguments.OfType<CancellationToken>().First(ct => ct.IsCancellationRequested);
+                    token.ThrowIfCancellationRequested();
+                }
+            }
+        }
+    }
+}

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -39,7 +39,8 @@ namespace FakeItEasy.Core
 
             this.preUserRules = new[]
                                     {
-                                        new CallRuleMetadata { Rule = new EventRule(this) }
+                                        new CallRuleMetadata { Rule = new EventRule(this) },
+                                        new CallRuleMetadata { Rule = new CancellationRule() }
                                     };
             this.AllUserRules = new LinkedList<CallRuleMetadata>();
             this.postUserRules = new[]

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Configuration\IPropertySetterAnyValueConfiguration.cs" />
     <Compile Include="Configuration\IPropertySetterConfiguration.cs" />
     <Compile Include="Configuration\PropertySetterConfiguration.cs" />
+    <Compile Include="Core\FakeManager.CancellationRule.cs" />
     <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/FakeItEasy/TaskHelper.cs
+++ b/src/FakeItEasy/TaskHelper.cs
@@ -1,13 +1,58 @@
 namespace FakeItEasy
 {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Reflection;
     using System.Threading.Tasks;
 
     internal static class TaskHelper
     {
+        private static readonly Lazy<Task> CachedCancelledTask = new Lazy<Task>(CreateGenericCancelledTask<int>);
+
+        private static readonly ConcurrentDictionary<Type, Task> CachedCancelledTasks = new ConcurrentDictionary<Type, Task>();
+
+        private static readonly MethodInfo CreateGenericCancelledTaskGenericDefinition =
+            typeof(TaskHelper).GetMethod(
+                nameof(CreateGenericCancelledTask),
+                BindingFlags.Static | BindingFlags.NonPublic);
+
         public static Task<T> FromResult<T>(T result)
         {
             var source = new TaskCompletionSource<T>();
             source.SetResult(result);
+            return source.Task;
+        }
+
+        public static Task Cancelled()
+        {
+            return CachedCancelledTask.Value;
+        }
+
+        public static Task Cancelled(Type resultType)
+        {
+            if (resultType == typeof(void))
+            {
+                return Cancelled();
+            }
+
+            return CachedCancelledTasks.GetOrAdd(
+                resultType,
+                type =>
+                {
+                    var method = CreateGenericCancelledTaskGenericDefinition.MakeGenericMethod(type);
+                    return (Task)method.Invoke(null, new object[0]);
+                });
+        }
+
+        public static Task Cancelled<T>()
+        {
+            return Cancelled(typeof(T));
+        }
+
+        private static Task<T> CreateGenericCancelledTask<T>()
+        {
+            var source = new TaskCompletionSource<T>();
+            source.TrySetCanceled();
             return source.Task;
         }
     }

--- a/tests/FakeItEasy.Specs/CancellationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CancellationSpecs.cs
@@ -1,0 +1,181 @@
+﻿namespace FakeItEasy.Specs
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FakeItEasy.Tests.TestHelpers;
+    using FluentAssertions;
+    using Xbehave;
+    using Xunit;
+
+    public class CancellationSpecs
+    {
+        public interface IFoo
+        {
+            int Bar();
+
+            int Bar(CancellationToken cancellationToken);
+
+            Task<int> BarAsync(CancellationToken cancellationToken);
+        }
+
+        [Scenario]
+        public void NoCancellationToken(IFoo fake, int result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "When a method which doesn't accept a cancellation token is called"
+                .x(() => result = fake.Bar());
+
+            "Then it doesn't throw and returns the default value"
+                .x(() => result.Should().Be(0));
+        }
+
+        [Scenario]
+        public void NonCancelledCancellationToken(IFoo fake, CancellationToken cancellationToken, int result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When a method is called with this cancellation token"
+                .x(() => result = fake.Bar(cancellationToken));
+
+            "Then it doesn't throw and returns the default value"
+                .x(() => result.Should().Be(0));
+        }
+
+        [Scenario]
+        public void NonCancelledCancellationTokenWithConfiguredCall(IFoo fake, CancellationToken cancellationToken, int result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.Bar(A<CancellationToken>._)).Returns(42));
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When the configured method is called with this cancellation token"
+                .x(() => result = fake.Bar(cancellationToken));
+
+            "Then it doesn't throw and returns the configured value"
+                .x(() => result.Should().Be(42));
+        }
+
+        [Scenario]
+        public void CancelledCancellationToken(IFoo fake, CancellationToken cancellationToken, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When a method is called with this cancellation token"
+                .x(() => exception = Record.Exception(() => fake.Bar(cancellationToken)));
+
+            "Then it throws an OperationCanceledException"
+                .x(() => exception.Should().BeAnExceptionAssignableTo<OperationCanceledException>());
+        }
+
+        [Scenario]
+        public void CancelledCancellationTokenWithConfiguredCall(IFoo fake, CancellationToken cancellationToken, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.Bar(A<CancellationToken>._)).Returns(42));
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When the configured method is called with this cancellation token"
+                .x(() => exception = Record.Exception(() => fake.Bar(cancellationToken)));
+
+            "Then it throws an OperationCanceledException, regardless of the configured call"
+                .x(() => exception.Should().BeAnExceptionAssignableTo<OperationCanceledException>());
+        }
+
+        [Scenario]
+        public void AsyncNonCancelledCancellationToken(IFoo fake, CancellationToken cancellationToken, Task<int> task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When an async method is called with this cancellation token"
+                .x(() => task = fake.BarAsync(cancellationToken));
+
+            "Then it returns a successfully completed task"
+                .x(() => task.Status.Should().Be(TaskStatus.RanToCompletion));
+
+            "And the task's result should be the default value"
+                .x(() => task.Result.Should().Be(0));
+        }
+
+        [Scenario]
+        public void AsyncNonCancelledCancellationTokenWithConfiguredCall(IFoo fake, CancellationToken cancellationToken, Task<int> task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.BarAsync(A<CancellationToken>._)).Returns(42));
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When the configured async method is called with this cancellation token"
+                .x(() => task = fake.BarAsync(cancellationToken));
+
+            "Then it returns a successfully completed task"
+                .x(() => task.Status.Should().Be(TaskStatus.RanToCompletion));
+
+            "And the task's result is the configured value"
+                .x(() => task.Result.Should().Be(42));
+        }
+
+        [Scenario]
+        public void AsyncCancelledCancellationToken(IFoo fake, CancellationToken cancellationToken, Task<int> task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When an async method is called with this cancellation token"
+                .x(() => { task = fake.BarAsync(cancellationToken); });
+
+            "Then it returns a cancelled task"
+                .x(() => task.Status.Should().Be(TaskStatus.Canceled));
+        }
+
+        [Scenario]
+        public void AsyncCancelledCancellationTokenWithConfiguredCall(IFoo fake, CancellationToken cancellationToken, Task<int> task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.BarAsync(A<CancellationToken>._)).Returns(42));
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When the configured async method is called with this cancellation token"
+                .x(() => { task = fake.BarAsync(cancellationToken); });
+
+            "Then it returns a cancelled task, regardless of the configured call"
+                .x(() => task.Status.Should().Be(TaskStatus.Canceled));
+        }
+    }
+}

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -85,6 +85,7 @@
     <Compile Include="AnyCallConfigurationSpecs.cs" />
     <Compile Include="ArgumentValueFormatterSpecs.cs" />
     <Compile Include="AssertingOnSetOnlyPropertiesSpecs.cs" />
+    <Compile Include="CancellationSpecs.cs" />
     <Compile Include="ConfiguringPropertySetterSpecs.cs" />
     <Compile Include="DummyCreationSpecs.cs" />
     <Compile Include="FakeSpecs.cs" />


### PR DESCRIPTION
Relates to #904 

For discussion

New behavior: any faked method that receives a cancelled `CancellationToken` will throw an `OperationCanceledException`, or return a cancelled `Task` if it's an async method (1). This behavior will not be overridden even if the method is explicitly configured (2).

(1) This is inconsistent with the current behavior for `Throws`. An async method configured to throw an exception will throw the exception directly, instead of returning a failed task. IMO this behavior is not ideal; the code under test might not await the task directly, and instead expect to receive a task that it can examine. Not sure how breaking it would be to change the behavior for `Throws`...

(2) The rationale for this is that it would be too easy to accidentally disable the automatic cancellation behavior. If normal call configurations could override the cancellation behavior, just doing `A.CallTo(() => foo.Bar(A<CancellationToken>._)).Returns(42)` would make the method always return 42, even if the token is cancelled. To avoid that, one would have to explicitly constrain the token to not be cancelled. The downside is that it becomes impossible to disable the automatic cancellation behavior; I think it's OK for most use cases, but we might want to add a way to disable it for specific use cases.