### PR TITLE
Update release issue steps

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -55,30 +55,48 @@ approval_tests = [
 repo = 'FakeItEasy/FakeItEasy'
 appveyor_server_url = 'https://ci.appveyor.com/project/FakeItEasy/fakeiteasy/settings'
 release_issue_labels = ['P2', 'build', 'documentation']
-release_issue_common_steps = <<-eos
+release_issue_rtm_steps = <<-eos
 Can be labelled **ready** when all other issues on this milestone are closed.
 
 - [ ] run code analysis in VS in *Release* mode and address violations (send a regular PR which must be merged before continuing)
-- [ ] if necessary, change `VERSION_SUFFIX` in [AppVeyor](#{appveyor_server_url}) to appropriate "-beta123" or "" (for non-betas) value and initiate a build
+- [ ] change `VERSION_SUFFIX` in [AppVeyor](#{appveyor_server_url}) to "" and initiate a build
 - [ ] check build
 - edit draft release in [GitHub UI](https://github.com/FakeItEasy/FakeItEasy/releases):
     - [ ] ensure completeness of release notes, including non-owner contributors, if any (move release notes forward from any pre-releases to the current release)
-    - [ ] attach main nupkg and/or analyzer nupkg, whichever have content to release
+    - [ ] attach main nupkg and analyzer nupkg
     - [ ] publish the release
-- [ ] push nupkg(s) to NuGet
-- [ ] de-list pre-release or superseded buggy NuGet packages if present
-- [ ] tweet, mentioning contributors and post link as comment here for easy retweeting ;-)
+- [ ] push nupkgs to NuGet
+- [ ] tweet, mentioning contributors
+- [ ] post link to tweet as comment here for easy retweeting ;-)
 - [ ] post tweet in [Gitter](https://gitter.im/FakeItEasy/FakeItEasy)
 - [ ] post a link to the GitHub Release in each issue in this milestone, with thanks to contributors
-eos
-
-next_version_steps = <<-eos
 - [ ] run `rake next_version[new_version]` to
     - create a pull request that changes the version in CommonAssemblyInfo.cs to the expected version (of form _xx.yy.zz_)
     - create a new draft GitHub Release
     - create a new milestone for the next release
     - create a new issue (like this one) for the next release, adding it to the new milestone
 - [ ] close this milestone
+- [ ] close this issue
+eos
+
+release_issue_prerelease_steps = <<-eos
+Can be labelled **ready** when all other issues destined for this release are closed.
+
+- [ ] run code analysis in VS in *Release* mode and address violations (send a regular PR which must be merged before continuing)
+- [ ] change `VERSION_SUFFIX` in [AppVeyor](#{appveyor_server_url}) to "-%version_suffix%" and initiate a build
+- [ ] check build
+- edit draft release in [GitHub UI](https://github.com/FakeItEasy/FakeItEasy/releases):
+    - [ ] ensure completeness of release notes, including non-owner contributors, if any
+    - [ ] attach main nupkg and analyzer nupkg
+    - [ ] publish the release
+- [ ] push nupkgs to NuGet
+- [ ] tweet, mentioning contributors
+- [ ] post link to tweet as comment here for easy retweeting ;-)
+- [ ] post tweet in [Gitter](https://gitter.im/FakeItEasy/FakeItEasy)
+- [ ] if another pre-release is planned, run `rake pre_release[new_version]` to
+    - create a new draft GitHub Release
+    - create a new issue (like this one) for the next release, adding it to the next RTM milestone
+- [ ] close this issue
 eos
 
 release_body = <<-eos
@@ -189,7 +207,7 @@ task :next_version, :new_version do |asm, args|
                  milestone,
                  new_version,
                  release_body,
-                 release_issue_common_steps + next_version_steps,
+                 release_issue_rtm_steps,
                  release_issue_labels)
 end
 
@@ -216,7 +234,7 @@ task :pre_release, :version_suffix do |asm, args|
                  milestone,
                  "#{version}-#{version_suffix}",
                  release_body,
-                 release_issue_common_steps,
+                 release_issue_prerelease_steps.sub('%version_suffix%', version_suffix),
                  release_issue_labels)
 end
 
@@ -333,8 +351,8 @@ def print_vars(variables)
   puts
   vectors.select { |name, value| ![
                                    'release_body',
-                                   'release_issue_common_steps',
-                                   'next_version_steps',
+                                   'release_issue_rtm_steps',
+                                   'release_issue_prerelease_steps',
                                    'release_issue_labels'
                                   ].include? name }.each { |name, value|
     puts "#{name}:"


### PR DESCRIPTION
Fixes #913, I think.

1. no need to de-list pre-release packages
2. no need to post link to release in each issue for pre-release versions
3. always attach and publish both nupkgs
4. split out instruction to post tweet here
5. better wording around proper VERSION_SUFFIX environment variable on AppVeyor