### PR TITLE
Remove IFakeOptionsForWrappers from .NET Standard

### DIFF
--- a/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
+++ b/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
@@ -408,12 +408,6 @@
     <Compile Include="..\FakeItEasy\Creation\IFakeOptions.of.T.cs">
       <Link>Creation\IFakeOptions.of.T.cs</Link>
     </Compile>
-    <Compile Include="..\FakeItEasy\Creation\IFakeOptionsForWrappers.cs">
-      <Link>Creation\IFakeOptionsForWrappers.cs</Link>
-    </Compile>
-    <Compile Include="..\FakeItEasy\Creation\IFakeOptionsForWrappers.of.T.cs">
-      <Link>Creation\IFakeOptionsForWrappers.of.T.cs</Link>
-    </Compile>
     <Compile Include="..\FakeItEasy\Creation\IProxyGenerator.cs">
       <Link>Creation\IProxyGenerator.cs</Link>
     </Compile>

--- a/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
+++ b/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
@@ -13,7 +13,10 @@ namespace FakeItEasy.Core
     /// </summary>
     /// <typeparam name="T">The type of fake object generated.</typeparam>
     internal class FakeWrapperConfigurator<T>
-        : FakeOptionsBase<T>, IFakeOptionsForWrappers<T>, IFakeOptionsForWrappers
+        : FakeOptionsBase<T>
+#if FEATURE_SELF_INITIALIZED_FAKES
+        , IFakeOptionsForWrappers<T>, IFakeOptionsForWrappers
+#endif
     {
         private readonly IFakeOptions<T> fakeOptions;
 #if FEATURE_SELF_INITIALIZED_FAKES
@@ -33,7 +36,11 @@ namespace FakeItEasy.Core
             return this.fakeOptions.WithArgumentsForConstructor(argumentsForConstructor);
         }
 
+#if FEATURE_SELF_INITIALIZED_FAKES
         public override IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance)
+#else
+        public override IFakeOptions<T> Wrapping(T wrappedInstance)
+#endif
         {
             return this.fakeOptions.Wrapping(wrappedInstance);
         }

--- a/src/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
+++ b/src/FakeItEasy/Creation/DefaultFakeAndDummyManager.cs
@@ -96,7 +96,11 @@ namespace FakeItEasy.Creation
                 return this;
             }
 
+#if FEATURE_SELF_INITIALIZED_FAKES
             public override IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance)
+#else
+            public override IFakeOptions<T> Wrapping(T wrappedInstance)
+#endif
             {
                 Guard.AgainstNull(wrappedInstance, nameof(wrappedInstance));
 

--- a/src/FakeItEasy/Creation/FakeOptionsBase.cs
+++ b/src/FakeItEasy/Creation/FakeOptionsBase.cs
@@ -33,10 +33,17 @@ namespace FakeItEasy.Creation
             return this.Implements(typeof(TInterface));
         }
 
+#if FEATURE_SELF_INITIALIZED_FAKES
         IFakeOptionsForWrappers IFakeOptions.Wrapping(object wrappedInstance)
         {
             return (IFakeOptionsForWrappers)this.Wrapping((T)wrappedInstance);
         }
+#else
+        IFakeOptions IFakeOptions.Wrapping(object wrappedInstance)
+        {
+            return (IFakeOptions)this.Wrapping((T)wrappedInstance);
+        }
+#endif
 
         public IFakeOptions<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
         {
@@ -55,7 +62,11 @@ namespace FakeItEasy.Creation
 
         public abstract IFakeOptions<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor);
 
+#if FEATURE_SELF_INITIALIZED_FAKES
         public abstract IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);
+#else
+        public abstract IFakeOptions<T> Wrapping(T wrappedInstance);
+#endif
 
         public abstract IFakeOptions<T> WithAttributes(params Expression<Func<Attribute>>[] attributes);
 

--- a/src/FakeItEasy/Creation/IFakeOptions.cs
+++ b/src/FakeItEasy/Creation/IFakeOptions.cs
@@ -79,6 +79,10 @@ namespace FakeItEasy.Creation
         /// </summary>
         /// <param name="wrappedInstance">The object to delegate calls to.</param>
         /// <returns>Options object.</returns>
+#if FEATURE_SELF_INITIALIZED_FAKES
         IFakeOptionsForWrappers Wrapping(object wrappedInstance);
+#else
+        IFakeOptions Wrapping(object wrappedInstance);
+#endif
     }
 }

--- a/src/FakeItEasy/Creation/IFakeOptions.of.T.cs
+++ b/src/FakeItEasy/Creation/IFakeOptions.of.T.cs
@@ -32,7 +32,11 @@ namespace FakeItEasy.Creation
         /// </summary>
         /// <param name="wrappedInstance">The object to delegate calls to.</param>
         /// <returns>Options object.</returns>
+#if FEATURE_SELF_INITIALIZED_FAKES
         IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);
+#else
+        IFakeOptions<T> Wrapping(T wrappedInstance);
+#endif
 
         /// <summary>
         /// Specifies that the fake should be created with these additional attributes.

--- a/src/FakeItEasy/Creation/IFakeOptionsForWrappers.cs
+++ b/src/FakeItEasy/Creation/IFakeOptionsForWrappers.cs
@@ -1,8 +1,6 @@
 namespace FakeItEasy.Creation
 {
-#if FEATURE_SELF_INITIALIZED_FAKES
     using FakeItEasy.SelfInitializedFakes;
-#endif
 
     /// <summary>
     /// Provides options for fake wrappers.
@@ -10,13 +8,11 @@ namespace FakeItEasy.Creation
     public interface IFakeOptionsForWrappers
         : IFakeOptions
     {
-#if FEATURE_SELF_INITIALIZED_FAKES
         /// <summary>
         /// Specifies a fake recorder to use.
         /// </summary>
         /// <param name="recorder">The recorder to use.</param>
         /// <returns>Options object.</returns>
         IFakeOptions RecordedBy(ISelfInitializingFakeRecorder recorder);
-#endif
     }
 }

--- a/src/FakeItEasy/Creation/IFakeOptionsForWrappers.of.T.cs
+++ b/src/FakeItEasy/Creation/IFakeOptionsForWrappers.of.T.cs
@@ -1,8 +1,6 @@
 namespace FakeItEasy.Creation
 {
-#if FEATURE_SELF_INITIALIZED_FAKES
     using FakeItEasy.SelfInitializedFakes;
-#endif
 
     /// <summary>
     /// Provides options for fake wrappers.
@@ -11,13 +9,11 @@ namespace FakeItEasy.Creation
     public interface IFakeOptionsForWrappers<T>
         : IFakeOptions<T>
     {
-#if FEATURE_SELF_INITIALIZED_FAKES
         /// <summary>
         /// Specifies a fake recorder to use.
         /// </summary>
         /// <param name="recorder">The recorder to use.</param>
         /// <returns>Options object.</returns>
         IFakeOptions<T> RecordedBy(ISelfInitializingFakeRecorder recorder);
-#endif
     }
 }

--- a/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
@@ -442,7 +442,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions WithArgumentsForConstructor<TConstructor>(System.Linq.Expressions.Expression<System.Func<TConstructor>> constructorCall);
         FakeItEasy.Creation.IFakeOptions WithAttributes(params System.Linq.Expressions.Expression<>[] attributes);
-        FakeItEasy.Creation.IFakeOptionsForWrappers Wrapping(object wrappedInstance);
+        FakeItEasy.Creation.IFakeOptions Wrapping(object wrappedInstance);
     }
     public interface IFakeOptions<T> : FakeItEasy.IHideObjectMembers
     
@@ -453,10 +453,8 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Collections.Generic.IEnumerable<object> argumentsForConstructor);
         FakeItEasy.Creation.IFakeOptions<T> WithArgumentsForConstructor(System.Linq.Expressions.Expression<System.Func<T>> constructorCall);
         FakeItEasy.Creation.IFakeOptions<T> WithAttributes(params System.Linq.Expressions.Expression<>[] attributes);
-        FakeItEasy.Creation.IFakeOptionsForWrappers<T> Wrapping(T wrappedInstance);
+        FakeItEasy.Creation.IFakeOptions<T> Wrapping(T wrappedInstance);
     }
-    public interface IFakeOptionsForWrappers : FakeItEasy.Creation.IFakeOptions, FakeItEasy.IHideObjectMembers { }
-    public interface IFakeOptionsForWrappers<T> : FakeItEasy.Creation.IFakeOptions<T>, FakeItEasy.IHideObjectMembers { }
     public interface ITaggable
     {
         object Tag { get; set; }


### PR DESCRIPTION
Fixes #914 