### PR TITLE
Remove IFileSystem, FileSystem from .NET Standard build

### DIFF
--- a/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
+++ b/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
@@ -537,9 +537,6 @@
     <Compile Include="..\FakeItEasy\IFakeOptionsBuilder.cs">
       <Link>IFakeOptionsBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\FakeItEasy\IFileSystem.cs">
-      <Link>IFileSystem.cs</Link>
-    </Compile>
     <Compile Include="..\FakeItEasy\IHideObjectMembers.cs">
       <Link>IHideObjectMembers.cs</Link>
     </Compile>

--- a/src/FakeItEasy/RootModule.cs
+++ b/src/FakeItEasy/RootModule.cs
@@ -145,6 +145,7 @@ namespace FakeItEasy
             }
         }
 
+#if FEATURE_SELF_INITIALIZED_FAKES
         private class FileSystem : IFileSystem
         {
             public Stream Open(string fileName, FileMode mode)
@@ -162,6 +163,7 @@ namespace FakeItEasy
                 File.Create(fileName).Dispose();
             }
         }
+#endif
 
         private class SessionFakeObjectCreator
             : IFakeObjectCreator


### PR DESCRIPTION
They're only used by self-initializing fakes