### PR TITLE
Mark all Self-Initializing Fake types and members as obsolete

### DIFF
--- a/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
+++ b/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
@@ -20,7 +20,9 @@ namespace FakeItEasy.Core
     {
         private readonly IFakeOptions<T> fakeOptions;
 #if FEATURE_SELF_INITIALIZED_FAKES
+#pragma warning disable CS0618 // Type or member is obsolete
         private ISelfInitializingFakeRecorder recorder;
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
 
         public FakeWrapperConfigurator(IFakeOptions<T> fakeOptions, object wrappedObject)
@@ -61,12 +63,14 @@ namespace FakeItEasy.Core
         }
 
 #if FEATURE_SELF_INITIALIZED_FAKES
+        [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
         public IFakeOptions<T> RecordedBy(ISelfInitializingFakeRecorder fakeRecorder)
         {
             this.recorder = fakeRecorder;
             return this.fakeOptions;
         }
 
+        [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
         IFakeOptions IFakeOptionsForWrappers.RecordedBy(ISelfInitializingFakeRecorder fakeRecorder)
         {
             return (IFakeOptions)this.RecordedBy(fakeRecorder);
@@ -89,6 +93,7 @@ namespace FakeItEasy.Core
         }
 
 #if FEATURE_SELF_INITIALIZED_FAKES
+#pragma warning disable CS0618 // Type or member is obsolete
         private static void AddRecordingRuleWhenRecorderIsSpecified(ISelfInitializingFakeRecorder recorder, FakeManager fake, WrappedObjectRule wrapperRule)
         {
             if (recorder != null)
@@ -96,6 +101,7 @@ namespace FakeItEasy.Core
                 fake.AddRuleFirst(new SelfInitializationRule(wrapperRule, recorder));
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
 
         private static WrappedObjectRule CreateAndAddWrapperRule(object wrappedInstance, FakeManager fake)

--- a/src/FakeItEasy/Creation/IFakeOptionsForWrappers.cs
+++ b/src/FakeItEasy/Creation/IFakeOptionsForWrappers.cs
@@ -1,5 +1,6 @@
 namespace FakeItEasy.Creation
 {
+    using System;
     using FakeItEasy.SelfInitializedFakes;
 
     /// <summary>
@@ -13,6 +14,7 @@ namespace FakeItEasy.Creation
         /// </summary>
         /// <param name="recorder">The recorder to use.</param>
         /// <returns>Options object.</returns>
+        [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
         IFakeOptions RecordedBy(ISelfInitializingFakeRecorder recorder);
     }
 }

--- a/src/FakeItEasy/Creation/IFakeOptionsForWrappers.of.T.cs
+++ b/src/FakeItEasy/Creation/IFakeOptionsForWrappers.of.T.cs
@@ -1,5 +1,6 @@
 namespace FakeItEasy.Creation
 {
+    using System;
     using FakeItEasy.SelfInitializedFakes;
 
     /// <summary>
@@ -14,6 +15,7 @@ namespace FakeItEasy.Creation
         /// </summary>
         /// <param name="recorder">The recorder to use.</param>
         /// <returns>Options object.</returns>
+        [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
         IFakeOptions<T> RecordedBy(ISelfInitializingFakeRecorder recorder);
     }
 }

--- a/src/FakeItEasy/IFileSystem.cs
+++ b/src/FakeItEasy/IFileSystem.cs
@@ -1,10 +1,12 @@
 namespace FakeItEasy
 {
+    using System;
     using System.IO;
 
     /// <summary>
     /// Provides access to the file system.
     /// </summary>
+    [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
     internal interface IFileSystem
     {
         /// <summary>

--- a/src/FakeItEasy/Recorders.cs
+++ b/src/FakeItEasy/Recorders.cs
@@ -1,10 +1,12 @@
 namespace FakeItEasy
 {
+    using System;
     using FakeItEasy.SelfInitializedFakes;
 
     /// <summary>
     /// Provides methods for creating recorders for self initializing fakes.
     /// </summary>
+    [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
     public static class Recorders
     {
         /// <summary>

--- a/src/FakeItEasy/RootModule.cs
+++ b/src/FakeItEasy/RootModule.cs
@@ -69,6 +69,7 @@ namespace FakeItEasy
                 new CallWriter(c.Resolve<IFakeObjectCallFormatter>(), c.Resolve<IEqualityComparer<IFakeObjectCall>>()));
 
 #if FEATURE_SELF_INITIALIZED_FAKES
+#pragma warning disable CS0618 // Type or member is obsolete
             container.RegisterSingleton<RecordingManager.Factory>(c =>
                 x => new RecordingManager(x));
 
@@ -77,6 +78,7 @@ namespace FakeItEasy
 
             container.RegisterSingleton<FileStorage.Factory>(c =>
                 x => new FileStorage(x, c.Resolve<IFileSystem>()));
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
 
             container.RegisterSingleton<ICallExpressionParser>(c =>
@@ -146,6 +148,7 @@ namespace FakeItEasy
         }
 
 #if FEATURE_SELF_INITIALIZED_FAKES
+        [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
         private class FileSystem : IFileSystem
         {
             public Stream Open(string fileName, FileMode mode)

--- a/src/FakeItEasy/SelfInitializedFakes/CallData.cs
+++ b/src/FakeItEasy/SelfInitializedFakes/CallData.cs
@@ -9,6 +9,7 @@ namespace FakeItEasy.SelfInitializedFakes
     /// DTO for recorded calls.
     /// </summary>
     [Serializable]
+    [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
     public class CallData
     {
         /// <summary>

--- a/src/FakeItEasy/SelfInitializedFakes/FileStorage.cs
+++ b/src/FakeItEasy/SelfInitializedFakes/FileStorage.cs
@@ -1,10 +1,12 @@
 namespace FakeItEasy.SelfInitializedFakes
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization.Formatters.Binary;
 
+    [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
     internal class FileStorage
         : ICallStorage
     {

--- a/src/FakeItEasy/SelfInitializedFakes/ICallStorage.cs
+++ b/src/FakeItEasy/SelfInitializedFakes/ICallStorage.cs
@@ -1,11 +1,13 @@
 namespace FakeItEasy.SelfInitializedFakes
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
     /// Represents storage for recorded calls for self initializing
     /// fakes.
     /// </summary>
+    [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
     public interface ICallStorage
     {
         /// <summary>

--- a/src/FakeItEasy/SelfInitializedFakes/ISelfInitializingFakeRecorder.cs
+++ b/src/FakeItEasy/SelfInitializedFakes/ISelfInitializingFakeRecorder.cs
@@ -6,6 +6,7 @@ namespace FakeItEasy.SelfInitializedFakes
     /// <summary>
     /// An interface for recorders that provides stored responses for self initializing fakes.
     /// </summary>
+    [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
     public interface ISelfInitializingFakeRecorder
         : IDisposable
     {

--- a/src/FakeItEasy/SelfInitializedFakes/RecordingException.cs
+++ b/src/FakeItEasy/SelfInitializedFakes/RecordingException.cs
@@ -8,6 +8,7 @@ namespace FakeItEasy.SelfInitializedFakes
     /// fakes fails or when playback fails.
     /// </summary>
     [Serializable]
+    [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
     public class RecordingException
         : Exception
     {

--- a/src/FakeItEasy/SelfInitializedFakes/RecordingManager.cs
+++ b/src/FakeItEasy/SelfInitializedFakes/RecordingManager.cs
@@ -13,6 +13,7 @@ namespace FakeItEasy.SelfInitializedFakes
     /// using self initialized fakes.
     /// </summary>
     [SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly", Justification = "Implements the Disposable method to support the using statement only.")]
+    [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
     public class RecordingManager : ISelfInitializingFakeRecorder
     {
         private readonly Queue<CallDataMetadata> callQueue;

--- a/src/FakeItEasy/SelfInitializedFakes/SelfInitializationRule.cs
+++ b/src/FakeItEasy/SelfInitializedFakes/SelfInitializationRule.cs
@@ -1,11 +1,13 @@
 namespace FakeItEasy.SelfInitializedFakes
 {
+    using System;
     using FakeItEasy.Core;
 
     /// <summary>
     /// A call rule use for self initializing fakes, delegates call to
     /// be applied by the recorder.
     /// </summary>
+    [Obsolete("Self-initializing fakes will be removed in version 4.0.0.")]
     internal class SelfInitializationRule
         : IFakeObjectCallRule
     {

--- a/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
@@ -406,6 +406,7 @@ namespace FakeItEasy.Specs
     {
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     public class WrapsAValidObjectOptionsBuilder : ConventionBasedOptionsBuilder
     {
         public static AWrappedType WrappedObject { get; } = A.Fake<AWrappedType>();
@@ -422,6 +423,7 @@ namespace FakeItEasy.Specs
             }
         }
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     public class Strict
     {

--- a/tests/FakeItEasy.Specs/SelfInitializedFakesSpecs.cs
+++ b/tests/FakeItEasy.Specs/SelfInitializedFakesSpecs.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace FakeItEasy.Specs
 {
     using System;

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
@@ -302,6 +302,7 @@ namespace FakeItEasy
         public static TEventHandler With<TEventHandler>(params object[] arguments) { }
         public static FakeItEasy.Core.Raise<System.EventArgs> WithEmpty() { }
     }
+    [System.ObsoleteAttribute("Self-initializing fakes will be removed in version 4.0.0.")]
     public class static Recorders
     {
         public static FakeItEasy.SelfInitializedFakes.ISelfInitializingFakeRecorder FileRecorder(string fileName) { }
@@ -540,11 +541,13 @@ namespace FakeItEasy.Creation
     }
     public interface IFakeOptionsForWrappers : FakeItEasy.Creation.IFakeOptions, FakeItEasy.IHideObjectMembers
     {
+        [System.ObsoleteAttribute("Self-initializing fakes will be removed in version 4.0.0.")]
         FakeItEasy.Creation.IFakeOptions RecordedBy(FakeItEasy.SelfInitializedFakes.ISelfInitializingFakeRecorder recorder);
     }
     public interface IFakeOptionsForWrappers<T> : FakeItEasy.Creation.IFakeOptions<T>, FakeItEasy.IHideObjectMembers
     
     {
+        [System.ObsoleteAttribute("Self-initializing fakes will be removed in version 4.0.0.")]
         FakeItEasy.Creation.IFakeOptions<T> RecordedBy(FakeItEasy.SelfInitializedFakes.ISelfInitializingFakeRecorder recorder);
     }
     public interface ITaggable
@@ -568,6 +571,7 @@ namespace FakeItEasy.Sdk
 namespace FakeItEasy.SelfInitializedFakes
 {
     
+    [System.ObsoleteAttribute("Self-initializing fakes will be removed in version 4.0.0.")]
     public class CallData
     {
         public CallData(System.Reflection.MethodInfo method, System.Collections.Generic.IEnumerable<object> outputArguments, object returnValue) { }
@@ -575,17 +579,20 @@ namespace FakeItEasy.SelfInitializedFakes
         public System.Collections.Generic.IEnumerable<object> OutputArguments { get; }
         public object ReturnValue { get; }
     }
+    [System.ObsoleteAttribute("Self-initializing fakes will be removed in version 4.0.0.")]
     public interface ICallStorage
     {
         System.Collections.Generic.IEnumerable<FakeItEasy.SelfInitializedFakes.CallData> Load();
         void Save(System.Collections.Generic.IEnumerable<FakeItEasy.SelfInitializedFakes.CallData> calls);
     }
+    [System.ObsoleteAttribute("Self-initializing fakes will be removed in version 4.0.0.")]
     public interface ISelfInitializingFakeRecorder : System.IDisposable
     {
         bool IsRecording { get; }
         void ApplyNext(FakeItEasy.Core.IInterceptedFakeObjectCall fakeObjectCall);
         void RecordCall(FakeItEasy.Core.ICompletedFakeObjectCall fakeObjectCall);
     }
+    [System.ObsoleteAttribute("Self-initializing fakes will be removed in version 4.0.0.")]
     public class RecordingException : System.Exception
     {
         public RecordingException() { }
@@ -593,6 +600,7 @@ namespace FakeItEasy.SelfInitializedFakes
         public RecordingException(string message, System.Exception innerException) { }
         protected RecordingException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.ObsoleteAttribute("Self-initializing fakes will be removed in version 4.0.0.")]
     public class RecordingManager : FakeItEasy.SelfInitializedFakes.ISelfInitializingFakeRecorder, System.IDisposable
     {
         public RecordingManager(FakeItEasy.SelfInitializedFakes.ICallStorage storage) { }

--- a/tests/FakeItEasy.Tests/Core/FakeWrapperConfiguratorTests.cs
+++ b/tests/FakeItEasy.Tests/Core/FakeWrapperConfiguratorTests.cs
@@ -37,6 +37,7 @@ namespace FakeItEasy.Tests.Core
         }
 
 #if FEATURE_SELF_INITIALIZED_FAKES
+#pragma warning disable CS0618 // Type or member is obsolete
         [Fact]
         public void ConfigureFakeToWrap_should_add_self_initialization_rule_when_recorder_is_specified()
         {
@@ -63,6 +64,7 @@ namespace FakeItEasy.Tests.Core
             Fake.GetFakeManager(this.faked).Rules
                 .Should().NotContain(item => item.GetType().IsAssignableFrom(typeof(SelfInitializationRule)));
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
     }
 }

--- a/tests/FakeItEasy.Tests/RecordersTests.cs
+++ b/tests/FakeItEasy.Tests/RecordersTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace FakeItEasy.Tests
 {
     using FakeItEasy.SelfInitializedFakes;

--- a/tests/FakeItEasy.Tests/SelfInitializedFakes/CallDataTests.cs
+++ b/tests/FakeItEasy.Tests/SelfInitializedFakes/CallDataTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace FakeItEasy.Tests.SelfInitializedFakes
 {
     using System;

--- a/tests/FakeItEasy.Tests/SelfInitializedFakes/FileStorageTests.cs
+++ b/tests/FakeItEasy.Tests/SelfInitializedFakes/FileStorageTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace FakeItEasy.Tests.SelfInitializedFakes
 {
     using System;

--- a/tests/FakeItEasy.Tests/SelfInitializedFakes/RecordingExceptionTests.cs
+++ b/tests/FakeItEasy.Tests/SelfInitializedFakes/RecordingExceptionTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace FakeItEasy.Tests.SelfInitializedFakes
 {
     using FakeItEasy.SelfInitializedFakes;

--- a/tests/FakeItEasy.Tests/SelfInitializedFakes/RecordingManagerTests.cs
+++ b/tests/FakeItEasy.Tests/SelfInitializedFakes/RecordingManagerTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace FakeItEasy.Tests.SelfInitializedFakes
 {
     using System.Collections.Generic;

--- a/tests/FakeItEasy.Tests/SelfInitializedFakes/SelfInitializationRuleTests.cs
+++ b/tests/FakeItEasy.Tests/SelfInitializedFakes/SelfInitializationRuleTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace FakeItEasy.Tests.SelfInitializedFakes
 {
     using FakeItEasy.Core;


### PR DESCRIPTION
To be removed in 4.0.0.
Fixes #820.