### PR TITLE
Automatic cancellation behavior

### DIFF
--- a/docs/default-fake-behavior.md
+++ b/docs/default-fake-behavior.md
@@ -22,11 +22,20 @@ invoked on the fake, no action will be taken by the fake. It is as if
 the body of the member were empty. If the member has a return type (or
 is a get property), the return value will depend on the type `T` of
 the member:
-  
+
 * If `T` can be made into a [Dummy](dummies.md), then a Dummy `T` will
   be returned. Note that this may be a Fake or an instance of a
   concrete, pre-existing type;
-* othewise, `default(T)` will be returned.
+* otherwise, `default(T)` will be returned.
+
+### Cancellation tokens
+
+When a faked method that accepts a `CancellationToken` receives a cancelled token
+(i.e. with `IsCancellationRequested` set to `true`), it will either:
+
+* return a cancelled task, if it is asynchronous (i.e. if it returns a `Task` or
+  `Task<T>`);
+* throw an `OperationCanceledException`, if it is synchronous.
 
 ## Examples
 
@@ -55,7 +64,7 @@ public void Members_should_return_empty_string_default_or_fake_another_fake()
 
     Assert.AreEqual(default(int), fakeLibrary.IntProperty);
 
-    Assert.AreEqual(typeof(string), fakeLibrary.StringFunction().GetType()); 
+    Assert.AreEqual(typeof(string), fakeLibrary.StringFunction().GetType());
     Assert.AreEqual(string.Empty, fakeLibrary.StringFunction());
 
     Assert.IsInstanceOfType(fakeLibrary.FakeableClassFunction(), typeof(FakeableClass));

--- a/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
+++ b/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
@@ -69,6 +69,9 @@
     <Compile Include="..\FakeItEasy\Configuration\PropertySetterConfiguration.cs">
       <Link>Configuration\PropertySetterConfiguration.cs</Link>
     </Compile>
+    <Compile Include="..\FakeItEasy\Core\FakeManager.CancellationRule.cs">
+      <Link>Core\FakeManager.CancellationRule.cs</Link>
+    </Compile>
     <Compile Include="..\FakeItEasy\ExceptionExtensions.cs">
       <Link>ExceptionExtensions.cs</Link>
     </Compile>

--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -9,6 +9,7 @@ namespace FakeItEasy
 #if FEATURE_NETCORE_REFLECTION
     using System.Reflection;
 #endif
+    using System.Threading;
 
     /// <summary>
     /// Provides validation extensions for <see cref="IArgumentConstraintManager{T}"/>.
@@ -264,6 +265,26 @@ namespace FakeItEasy
             return manager.Matches(
                 x => ((object)x) != null && predicate(x),
                 descriptionWriter);
+        }
+
+        /// <summary>
+        /// Constrains the <see cref="CancellationToken"/> argument to be cancelled (<c>IsCancellationRequested</c> is true).
+        /// </summary>
+        /// <param name="manager">The constraint manager.</param>
+        /// <returns>A dummy argument value.</returns>
+        public static CancellationToken IsCancelled(this IArgumentConstraintManager<CancellationToken> manager)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Constrains the <see cref="CancellationToken"/> argument to be not cancelled (<c>IsCancellationRequested</c> is false).
+        /// </summary>
+        /// <param name="manager">The constraint manager.</param>
+        /// <returns>A dummy argument value.</returns>
+        public static CancellationToken IsNotCancelled(this IArgumentConstraintManager<CancellationToken> manager)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -274,7 +274,11 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static CancellationToken IsCancelled(this IArgumentConstraintManager<CancellationToken> manager)
         {
-            throw new NotImplementedException();
+            Guard.AgainstNull(manager, nameof(manager));
+
+            return manager.Matches(
+                token => token.IsCancellationRequested,
+                x => x.Write("cancelled cancellation token"));
         }
 
         /// <summary>
@@ -284,7 +288,11 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static CancellationToken IsNotCancelled(this IArgumentConstraintManager<CancellationToken> manager)
         {
-            throw new NotImplementedException();
+            Guard.AgainstNull(manager, nameof(manager));
+
+            return manager.Matches(
+                token => !token.IsCancellationRequested,
+                x => x.Write("non-cancelled cancellation token"));
         }
     }
 }

--- a/src/FakeItEasy/Core/FakeManager.CancellationRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.CancellationRule.cs
@@ -1,0 +1,60 @@
+namespace FakeItEasy.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+#if FEATURE_NETCORE_REFLECTION
+    using System.Reflection;
+#endif
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <content>Event rule.</content>
+    public partial class FakeManager
+    {
+#if FEATURE_BINARY_SERIALIZATION
+        [Serializable]
+#endif
+        private class CancellationRule : IFakeObjectCallRule
+        {
+            public int? NumberOfTimesToCall => null;
+
+            public bool IsApplicableTo(IFakeObjectCall fakeObjectCall) =>
+                GetCancelledTokens(fakeObjectCall).Any();
+
+            public void Apply(IInterceptedFakeObjectCall fakeObjectCall)
+            {
+                var returnType = fakeObjectCall.Method.ReturnType;
+                if (typeof(Task).GetTypeInfo().IsAssignableFrom(returnType))
+                {
+                    Task task;
+                    if (returnType == typeof(Task))
+                    {
+                        task = TaskHelper.Cancelled();
+                    }
+                    else
+                    {
+                        var taskResultType = returnType.GetTypeInfo().GetGenericArguments()[0];
+                        task = TaskHelper.Cancelled(taskResultType);
+                    }
+
+                    fakeObjectCall.SetReturnValue(task);
+                }
+                else
+                {
+                    var token = GetCancelledTokens(fakeObjectCall).First();
+                    token.ThrowIfCancellationRequested();
+                }
+            }
+
+            private static IEnumerable<CancellationToken> GetCancelledTokens(IFakeObjectCall call)
+            {
+                return call.Method.GetParameters()
+                    .Select((param, index) => new { param, index })
+                    .Where(x => x.param.ParameterType == typeof(CancellationToken))
+                    .Select(x => (CancellationToken)call.Arguments[x.index])
+                    .Where(token => token.IsCancellationRequested);
+            }
+        }
+    }
+}

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -45,6 +45,7 @@ namespace FakeItEasy.Core
                                          new CallRuleMetadata { Rule = new ObjectMemberRule(this) },
                                          new CallRuleMetadata { Rule = new AutoFakePropertyRule(this) },
                                          new CallRuleMetadata { Rule = new PropertySetterRule(this) },
+                                         new CallRuleMetadata { Rule = new CancellationRule() },
                                          new CallRuleMetadata { Rule = new DefaultReturnValueRule() }
                                      };
 

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Configuration\IPropertySetterConfiguration.cs" />
     <Compile Include="Configuration\IThenConfiguration.cs" />
     <Compile Include="Configuration\PropertySetterConfiguration.cs" />
+    <Compile Include="Core\FakeManager.CancellationRule.cs" />
     <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="Core\InterceptedFakeObjectCallExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/FakeItEasy/TaskHelper.cs
+++ b/src/FakeItEasy/TaskHelper.cs
@@ -1,13 +1,51 @@
 namespace FakeItEasy
 {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Reflection;
     using System.Threading.Tasks;
 
     internal static class TaskHelper
     {
+        private static readonly ConcurrentDictionary<Type, Task> CachedCancelledTasks = new ConcurrentDictionary<Type, Task>();
+
+        private static readonly MethodInfo CreateGenericCancelledTaskGenericDefinition =
+            typeof(TaskHelper).GetMethod(
+                nameof(CreateGenericCancelledTask),
+                BindingFlags.Static | BindingFlags.NonPublic);
+
         public static Task<T> FromResult<T>(T result)
         {
             var source = new TaskCompletionSource<T>();
             source.SetResult(result);
+            return source.Task;
+        }
+
+        public static Task Cancelled()
+        {
+            return Cancelled(typeof(int));
+        }
+
+        public static Task Cancelled(Type resultType)
+        {
+            if (resultType == typeof(void))
+            {
+                return Cancelled();
+            }
+
+            return CachedCancelledTasks.GetOrAdd(
+                resultType,
+                type =>
+                {
+                    var method = CreateGenericCancelledTaskGenericDefinition.MakeGenericMethod(type);
+                    return (Task)method.Invoke(null, new object[0]);
+                });
+        }
+
+        private static Task<T> CreateGenericCancelledTask<T>()
+        {
+            var source = new TaskCompletionSource<T>();
+            source.SetCanceled();
             return source.Task;
         }
     }

--- a/tests/FakeItEasy.Specs/CancellationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CancellationSpecs.cs
@@ -1,0 +1,364 @@
+﻿namespace FakeItEasy.Specs
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FakeItEasy.Tests.TestHelpers;
+    using FluentAssertions;
+    using Xbehave;
+    using Xunit;
+
+    public class CancellationSpecs
+    {
+        public interface IFoo
+        {
+            int Bar(CancellationToken cancellationToken);
+
+            int Bar(object obj);
+
+            Task<int> BarAsync(CancellationToken cancellationToken);
+
+            Task BazAsync(CancellationToken cancellationToken);
+        }
+
+        [Scenario]
+        public void NonCancelledToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            int result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When a method is called with this cancellation token"
+                .x(() => result = fake.Bar(cancellationToken));
+
+            "Then it doesn't throw and returns the default value"
+                .x(() => result.Should().Be(0));
+        }
+
+        [Scenario]
+        public void NonCancelledTokenWithConfiguredCall(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            int result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.Bar(A<CancellationToken>._)).Returns(42));
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When the configured method is called with this cancellation token"
+                .x(() => result = fake.Bar(cancellationToken));
+
+            "Then it doesn't throw and returns the configured value"
+                .x(() => result.Should().Be(42));
+        }
+
+        [Scenario]
+        public void CancelledToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When a method is called with this cancellation token"
+                .x(() => exception = Record.Exception(() => fake.Bar(cancellationToken)));
+
+            "Then it throws an OperationCanceledException"
+                .x(() => exception.Should().BeAnExceptionAssignableTo<OperationCanceledException>());
+        }
+
+        [Scenario]
+        public void CancelledTokenPassedAsObject(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            int result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When a method is called with this cancellation token passed as Object"
+                .x(() => result = fake.Bar((object)cancellationToken));
+
+            "Then it doesn't throw and returns the default value"
+                .x(() => result.Should().Be(0));
+        }
+
+        [Scenario]
+        public void CancelledTokenWithConfiguredCallForAnyToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            int result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.Bar(A<CancellationToken>._)).Returns(42));
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When the configured method is called with this cancellation token"
+                .x(() => result = fake.Bar(cancellationToken));
+
+            "Then it doesn't throw and returns the configured value"
+                .x(() => result.Should().Be(42));
+        }
+
+        [Scenario]
+        public void CancelledTokenWithConfiguredCallForNonCancelledToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake for a non-cancelled token"
+                .x(() => A.CallTo(() => fake.Bar(A<CancellationToken>.That.IsNotCancelled())).Returns(42));
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When the configured method is called with this cancellation token"
+                .x(() => exception = Record.Exception(() => fake.Bar(cancellationToken)));
+
+            "Then it throws an OperationCancelledException"
+                .x(() => exception.Should().BeAnExceptionAssignableTo<OperationCanceledException>());
+        }
+
+        [Scenario]
+        public void AsyncWithResultNonCancelledToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task<int> task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When an async method is called with this cancellation token"
+                .x(() => { task = fake.BarAsync(cancellationToken); });
+
+            "Then it returns a successfully completed task"
+                .x(() => task.Status.Should().Be(TaskStatus.RanToCompletion));
+
+            "And the task's result should be the default value"
+                .x(() => task.Result.Should().Be(0));
+        }
+
+        [Scenario]
+        public void AsyncWithResultNonCancelledTokenWithConfiguredCall(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task<int> task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.BarAsync(A<CancellationToken>._)).Returns(42));
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When the configured async method is called with this cancellation token"
+                .x(() => { task = fake.BarAsync(cancellationToken); });
+
+            "Then it returns a successfully completed task"
+                .x(() => task.Status.Should().Be(TaskStatus.RanToCompletion));
+
+            "And the task's result is the configured value"
+                .x(() => task.Result.Should().Be(42));
+        }
+
+        [Scenario]
+        public void AsyncWithResultCancelledToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task<int> task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When an async method is called with this cancellation token"
+                .x(() => { task = fake.BarAsync(cancellationToken); });
+
+            "Then it returns a cancelled task"
+                .x(() => task.Status.Should().Be(TaskStatus.Canceled));
+        }
+
+        [Scenario]
+        public void AsyncWithResultCancelledTokenWithConfiguredCallForAnyToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task<int> task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.BarAsync(A<CancellationToken>._)).Returns(42));
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When the configured async method is called with this cancellation token"
+                .x(() => { task = fake.BarAsync(cancellationToken); });
+
+            "Then it returns a successfully completed task"
+                .x(() => task.Status.Should().Be(TaskStatus.RanToCompletion));
+
+            "And the task's result is the configured value"
+                .x(() => task.Result.Should().Be(42));
+        }
+
+        [Scenario]
+        public void AsyncWithResultCancelledTokenWithConfiguredCallForNonCancelledToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task<int> task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake for a non-cancelled token"
+                .x(() => A.CallTo(() => fake.BarAsync(A<CancellationToken>.That.IsNotCancelled())).Returns(42));
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When the configured async method is called with this cancellation token"
+                .x(() => { task = fake.BarAsync(cancellationToken); });
+
+            "Then it returns a cancelled task"
+                .x(() => task.Status.Should().Be(TaskStatus.Canceled));
+        }
+
+        [Scenario]
+        public void AsyncWithoutResultNonCancelledToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When an async method is called with this cancellation token"
+                .x(() => { task = fake.BazAsync(cancellationToken); });
+
+            "Then it returns a successfully completed task"
+                .x(() => task.Status.Should().Be(TaskStatus.RanToCompletion));
+        }
+
+        [Scenario]
+        public void AsyncWithoutResultNonCancelledTokenWithConfiguredCall(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.BazAsync(A<CancellationToken>._)).Returns(Task.FromResult(0)));
+
+            "And a cancellation token that is not cancelled"
+                .x(() => cancellationToken = new CancellationToken(false));
+
+            "When the configured async method is called with this cancellation token"
+                .x(() => { task = fake.BazAsync(cancellationToken); });
+
+            "Then it returns a successfully completed task"
+                .x(() => task.Status.Should().Be(TaskStatus.RanToCompletion));
+        }
+
+        [Scenario]
+        public void AsyncWithoutResultCancelledToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When an async method is called with this cancellation token"
+                .x(() => { task = fake.BazAsync(cancellationToken); });
+
+            "Then it returns a cancelled task"
+                .x(() => task.Status.Should().Be(TaskStatus.Canceled));
+        }
+
+        [Scenario]
+        public void AsyncWithoutResultCancelledTokenWithConfiguredCallForAnyToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake"
+                .x(() => A.CallTo(() => fake.BazAsync(A<CancellationToken>._)).Returns(Task.FromResult(0)));
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When the configured async method is called with this cancellation token"
+                .x(() => { task = fake.BazAsync(cancellationToken); });
+
+            "Then it returns a successfully completed task"
+                .x(() => task.Status.Should().Be(TaskStatus.RanToCompletion));
+        }
+
+        [Scenario]
+        public void AsyncWithoutResultCancelledTokenWithConfiguredCallForNonCancelledToken(
+            IFoo fake,
+            CancellationToken cancellationToken,
+            Task task)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call configured on that fake for a non-cancelled token"
+                .x(() => A.CallTo(() => fake.BazAsync(A<CancellationToken>.That.IsNotCancelled())).Returns(Task.FromResult(0)));
+
+            "And a cancellation token that is cancelled"
+                .x(() => cancellationToken = new CancellationToken(true));
+
+            "When the configured async method is called with this cancellation token"
+                .x(() => { task = fake.BazAsync(cancellationToken); });
+
+            "Then it returns a cancelled task"
+                .x(() => task.Status.Should().Be(TaskStatus.Canceled));
+        }
+    }
+}

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -85,6 +85,7 @@
     <Compile Include="AnyCallConfigurationSpecs.cs" />
     <Compile Include="ArgumentValueFormatterSpecs.cs" />
     <Compile Include="AssertingOnSetOnlyPropertiesSpecs.cs" />
+    <Compile Include="CancellationSpecs.cs" />
     <Compile Include="ConfiguringPropertySetterSpecs.cs" />
     <Compile Include="DummyCreationSpecs.cs" />
     <Compile Include="FakeSpecs.cs" />

--- a/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
@@ -36,12 +36,14 @@ namespace FakeItEasy
         public static T Contains<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, object value)
             where T : System.Collections.IEnumerable { }
         public static string EndsWith(this FakeItEasy.IArgumentConstraintManager<string> manager, string value) { }
+        public static System.Threading.CancellationToken IsCancelled(this FakeItEasy.IArgumentConstraintManager<System.Threading.CancellationToken> manager) { }
         public static T IsEmpty<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
             where T : System.Collections.IEnumerable { }
         public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
         public static T IsGreaterThan<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value)
             where T : System.IComparable { }
         public static T IsInstanceOf<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Type type) { }
+        public static System.Threading.CancellationToken IsNotCancelled(this FakeItEasy.IArgumentConstraintManager<System.Threading.CancellationToken> manager) { }
         public static T IsNull<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
             where T :  class { }
         public static string IsNullOrEmpty(this FakeItEasy.IArgumentConstraintManager<string> manager) { }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
@@ -112,12 +112,14 @@ namespace FakeItEasy
         public static T Contains<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, object value)
             where T : System.Collections.IEnumerable { }
         public static string EndsWith(this FakeItEasy.IArgumentConstraintManager<string> manager, string value) { }
+        public static System.Threading.CancellationToken IsCancelled(this FakeItEasy.IArgumentConstraintManager<System.Threading.CancellationToken> manager) { }
         public static T IsEmpty<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
             where T : System.Collections.IEnumerable { }
         public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
         public static T IsGreaterThan<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value)
             where T : System.IComparable { }
         public static T IsInstanceOf<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Type type) { }
+        public static System.Threading.CancellationToken IsNotCancelled(this FakeItEasy.IArgumentConstraintManager<System.Threading.CancellationToken> manager) { }
         public static T IsNull<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
             where T :  class { }
         public static string IsNullOrEmpty(this FakeItEasy.IArgumentConstraintManager<string> manager) { }

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CancellationTokenConstraintTestsBase.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CancellationTokenConstraintTestsBase.cs
@@ -1,0 +1,38 @@
+﻿namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
+{
+    using System.Collections.Generic;
+    using System.Threading;
+
+    public abstract class CancellationTokenConstraintTestsBase : ArgumentConstraintTestBase<CancellationToken>
+    {
+        private static readonly CancellationTokenSource CancelledSource = CreateCancellationTokenSource(true);
+        private static readonly CancellationTokenSource NonCancelledSource = CreateCancellationTokenSource(false);
+
+        public static IEnumerable<object[]> NonCancelledTokens()
+        {
+            return TestCases.FromObject(
+                CancellationToken.None,
+                default(CancellationToken),
+                new CancellationToken(false),
+                NonCancelledSource.Token);
+        }
+
+        public static IEnumerable<object[]> CancelledTokens()
+        {
+            return TestCases.FromObject(
+                new CancellationToken(true),
+                CancelledSource.Token);
+        }
+
+        private static CancellationTokenSource CreateCancellationTokenSource(bool cancelled)
+        {
+            var source = new CancellationTokenSource();
+            if (cancelled)
+            {
+                source.Cancel();
+            }
+
+            return source;
+        }
+    }
+}

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CancellationTokenIsCancelledTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CancellationTokenIsCancelledTests.cs
@@ -1,0 +1,29 @@
+﻿namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
+{
+    using System.Threading;
+    using Xunit;
+
+    public class CancellationTokenIsCancelledTests : CancellationTokenConstraintTestsBase
+    {
+        protected override string ExpectedDescription => "cancelled cancellation token";
+
+        [Theory]
+        [MemberData(nameof(NonCancelledTokens))]
+        public override void IsValid_should_return_false_for_invalid_values(object invalidValue)
+        {
+            base.IsValid_should_return_false_for_invalid_values(invalidValue);
+        }
+
+        [Theory]
+        [MemberData(nameof(CancelledTokens))]
+        public override void IsValid_should_return_true_for_valid_values(object validValue)
+        {
+            base.IsValid_should_return_true_for_valid_values(validValue);
+        }
+
+        protected override void CreateConstraint(IArgumentConstraintManager<CancellationToken> scope)
+        {
+            scope.IsCancelled();
+        }
+    }
+}

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CancellationTokenIsNotCancelledTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CancellationTokenIsNotCancelledTests.cs
@@ -1,0 +1,29 @@
+﻿namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
+{
+    using System.Threading;
+    using Xunit;
+
+    public class CancellationTokenIsNotCancelledTests : CancellationTokenConstraintTestsBase
+    {
+        protected override string ExpectedDescription => "non-cancelled cancellation token";
+
+        [Theory]
+        [MemberData(nameof(CancelledTokens))]
+        public override void IsValid_should_return_false_for_invalid_values(object invalidValue)
+        {
+            base.IsValid_should_return_false_for_invalid_values(invalidValue);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonCancelledTokens))]
+        public override void IsValid_should_return_true_for_valid_values(object validValue)
+        {
+            base.IsValid_should_return_true_for_valid_values(validValue);
+        }
+
+        protected override void CreateConstraint(IArgumentConstraintManager<CancellationToken> scope)
+        {
+            scope.IsNotCancelled();
+        }
+    }
+}

--- a/tests/FakeItEasy.Tests/FakeItEasy.Tests.csproj
+++ b/tests/FakeItEasy.Tests/FakeItEasy.Tests.csproj
@@ -78,6 +78,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActionOverWriterValueFormatter.cs" />
+    <Compile Include="ArgumentConstraintManagerExtensions\CancellationTokenConstraintTestsBase.cs" />
+    <Compile Include="ArgumentConstraintManagerExtensions\CancellationTokenIsCancelledTests.cs" />
+    <Compile Include="ArgumentConstraintManagerExtensions\CancellationTokenIsNotCancelledTests.cs" />
     <Compile Include="ArgumentConstraintManagerExtensions\CollectionContainsTests.cs" />
     <Compile Include="ArgumentConstraintManagerExtensions\CollectionIsEmptyTests.cs" />
     <Compile Include="ArgumentConstraintManagerExtensions\DerivedTypeArgumentTests.cs" />


### PR DESCRIPTION
Fixes #904 

By default, calls that receive a cancelled `CancellationToken` argument will either:
- throw an `OperationCancelledException` (for synchronous methods)
- return a cancelled `Task` (for asynchronous methods)

This behavior will be overridden if the call is explicitly configured. To avoid this, the `CancellationToken` argument should be constrained to be not cancelled; a new `IsNotCancelled` extension method is provided as a shortcut for this scenario:

```
A.CallTo(() => foo.Bar(A<CancellationToken>.That.IsNotCancelled())).Returns(42);
```

A symmetric `IsCancelled` extension method is also available.