### PR TITLE
Build on new AppVeyor VS2015 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@ version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
 
-image: Previous Visual Studio 2015
-
 environment:
     PATH: 'C:\Ruby200\bin;%PATH%'
     BUILD: $(APPVEYOR_BUILD_NUMBER)


### PR DESCRIPTION
Reverts cb0edf0e6402b97141c71bc6c0035c86b4093fe2 because 
the bug reported in  https://github.com/appveyor/ci/issues/1202
has been fixed.