### PR TITLE
Have AppVeyor just build .NET Desktop version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
     - cmd: bundle install
 
 build_script:
-    - cmd: build.netstd.cmd
+    - cmd: build.cmd
 
 nuget:
     disable_publish_on_pr: true


### PR DESCRIPTION
1. we don't need the netstd build, and
2. the netstd build appends `-adhoc` to the version number, so we'd've had to change _something_