### PR TITLE
Fix integration tests for external assembly

### DIFF
--- a/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
@@ -150,7 +150,7 @@ namespace FakeItEasy.IntegrationTests
 
         private string GetPathToOriginalExternalDll()
         {
-            var executingAssemblyPath = new Uri(this.GetType().GetTypeInfo().Assembly.Location).LocalPath
+            var executingAssemblyPath = new Uri(this.GetType().GetTypeInfo().Assembly.CodeBase).LocalPath
                 .Replace("FakeItEasy.IntegrationTests", "FakeItEasy.IntegrationTests.External")
                 .Replace("netcoreapp1.0", "netstandard1.6");
             return Path.GetFullPath(executingAssemblyPath);


### PR DESCRIPTION
Some tests were failing when run from ReSharper. I think this is because it shadow copies assemblies, so the `Location` isn't the original location. Using `CodeBase` instead fixes it.