### PR TITLE
Ignore all per-user project settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,7 @@
 artifacts
 packages
 
-*.csproj.user
-*.vbproj.user
-*.xproj.user
+*.*proj.user
 *.lock.json
 *.ncb
 *.suo


### PR DESCRIPTION
The `.user` files for the new shared projects (`.shproj`) weren't ignored; I updated the `.gitignore` to ignore all `*.*proj.user` files.