### PR TITLE
Add CallsToSet to unnatural fakes

### DIFF
--- a/src/FakeItEasy.Analyzer.Shared/UnusedReturnValueAnalyzer.cs
+++ b/src/FakeItEasy.Analyzer.Shared/UnusedReturnValueAnalyzer.cs
@@ -73,6 +73,7 @@ namespace FakeItEasy.Analyzer
                 "FakeItEasy.A.CallTo`1",
                 "FakeItEasy.A.CallToSet`1",
                 "FakeItEasy.Fake`1.CallsTo`1",
+                "FakeItEasy.Fake`1.CallsToSet`1",
                 "FakeItEasy.Fake`1.AnyCall",
                 "FakeItEasy.ArgumentValidationConfigurationExtensions.WithAnyArguments`1",
                 "FakeItEasy.WhereConfigurationExtensions.Where`1",

--- a/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
+++ b/src/FakeItEasy.netstd/FakeItEasy.netstd.csproj
@@ -69,6 +69,9 @@
     <Compile Include="..\FakeItEasy\Configuration\IThenConfiguration.cs">
       <Link>Configuration\IThenConfiguration.cs</Link>
     </Compile>
+    <Compile Include="..\FakeItEasy\Configuration\PropertyExpressionHelper.cs">
+      <Link>Configuration\PropertyExpressionHelper.cs</Link>
+    </Compile>
     <Compile Include="..\FakeItEasy\Configuration\PropertySetterConfiguration.cs">
       <Link>Configuration\PropertySetterConfiguration.cs</Link>
     </Compile>

--- a/src/FakeItEasy/Configuration/FakeConfigurationManager.cs
+++ b/src/FakeItEasy/Configuration/FakeConfigurationManager.cs
@@ -2,9 +2,7 @@ namespace FakeItEasy.Configuration
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
     using System.Linq.Expressions;
-    using System.Reflection;
     using FakeItEasy.Core;
     using FakeItEasy.Expressions;
 
@@ -70,38 +68,12 @@ namespace FakeItEasy.Configuration
             this.AssertThatMemberCanBeIntercepted(parsedCallExpression);
 
             var fake = Fake.GetFakeManager(parsedCallExpression.CallTarget);
-            var parsedSetterCallExpression = BuildSetterFromGetter<TValue>(parsedCallExpression);
+            var parsedSetterCallExpression = PropertyExpressionHelper.BuildSetterFromGetter<TValue>(parsedCallExpression);
 
             return new PropertySetterConfiguration<TValue>(
                 parsedSetterCallExpression,
                 newParsedSetterCallExpression =>
                     this.CreateVoidArgumentValidationConfiguration(fake, newParsedSetterCallExpression));
-        }
-
-        private static string GetPropertyName(ParsedCallExpression parsedCallExpression)
-        {
-            var calledMethod = parsedCallExpression.CalledMethod;
-            if (HasThis(calledMethod) && calledMethod.IsSpecialName)
-            {
-                var methodName = calledMethod.Name;
-                if (methodName.StartsWith("get_", StringComparison.Ordinal))
-                {
-                    return methodName.Substring(4);
-                }
-            }
-
-            return null;
-        }
-
-        private static bool HasThis(MethodInfo methodCall)
-        {
-            return methodCall.CallingConvention.HasFlag(CallingConventions.HasThis);
-        }
-
-        private static Expression BuildArgumentThatMatchesAnything<TValue>()
-        {
-            Expression<Func<TValue>> value = () => A<TValue>.Ignored;
-            return value.Body;
         }
 
         private static void GuardAgainstNonFake(object target)
@@ -110,62 +82,6 @@ namespace FakeItEasy.Configuration
             {
                 Fake.GetFakeManager(target);
             }
-        }
-
-        private static string GetExpressionDescription(ParsedCallExpression parsedCallExpression)
-        {
-            var matcher = new ExpressionCallMatcher(
-                parsedCallExpression,
-                ServiceLocator.Current.Resolve<ExpressionArgumentConstraintFactory>(),
-                ServiceLocator.Current.Resolve<MethodInfoManager>());
-
-            return matcher.DescriptionOfMatchingCall;
-        }
-
-        private static ParsedCallExpression BuildSetterFromGetter<TValue>(
-            ParsedCallExpression parsedCallExpression)
-        {
-            var propertyName = GetPropertyName(parsedCallExpression);
-            if (propertyName == null)
-            {
-                var expressionDescription = GetExpressionDescription(parsedCallExpression);
-                throw new ArgumentException("Expression '" + expressionDescription +
-                                            "' must refer to a property or indexer getter, but doesn't.");
-            }
-
-            var parsedArgumentExpressions = parsedCallExpression.ArgumentsExpressions ?? new ParsedArgumentExpression[0];
-            var parameterTypes = parsedArgumentExpressions
-                .Select(p => p.ArgumentInformation.ParameterType)
-                .Concat(new[] { parsedCallExpression.CalledMethod.ReturnType })
-                .ToArray();
-
-            var indexerSetterInfo = parsedCallExpression.CallTarget.GetType()
-                .GetMethod("set_" + propertyName, parameterTypes);
-
-            if (indexerSetterInfo == null)
-            {
-                if (parsedArgumentExpressions.Any())
-                {
-                    var expressionDescription = GetExpressionDescription(parsedCallExpression);
-                    throw new ArgumentException("Expression '" + expressionDescription +
-                                                "' refers to an indexed property that does not have a setter.");
-                }
-
-                throw new ArgumentException(
-                    "The property '" + propertyName + "' does not have a setter.");
-            }
-
-            var originalParameterInfos = indexerSetterInfo.GetParameters();
-
-            var newParsedSetterValueExpression = new ParsedArgumentExpression(
-                BuildArgumentThatMatchesAnything<TValue>(),
-                originalParameterInfos.Last());
-
-            var arguments = parsedArgumentExpressions
-                .Take(originalParameterInfos.Length - 1)
-                .Concat(new[] { newParsedSetterValueExpression });
-
-            return new ParsedCallExpression(indexerSetterInfo, parsedCallExpression.CallTarget, arguments);
         }
 
         private IVoidArgumentValidationConfiguration CreateVoidArgumentValidationConfiguration(FakeManager fake, ParsedCallExpression parsedCallExpression)

--- a/src/FakeItEasy/Configuration/IStartConfiguration.cs
+++ b/src/FakeItEasy/Configuration/IStartConfiguration.cs
@@ -30,6 +30,15 @@ namespace FakeItEasy.Configuration
         IVoidArgumentValidationConfiguration CallsTo(Expression<Action<TFake>> callSpecification);
 
         /// <summary>
+        /// Configures the behavior of the fake object when the specified property is set.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property.</typeparam>
+        /// <param name="propertySpecification">An expression that specifies the property to configure.</param>
+        /// <returns>A configuration object.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design when using the Expression-, Action- and Func-types.")]
+        IPropertySetterAnyValueConfiguration<TValue> CallsToSet<TValue>(Expression<Func<TFake, TValue>> propertySpecification);
+
+        /// <summary>
         /// Configures the behavior of the fake object when a call is made to any method on the
         /// object.
         /// </summary>

--- a/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
+++ b/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
@@ -1,0 +1,94 @@
+namespace FakeItEasy.Configuration
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using FakeItEasy.Core;
+    using FakeItEasy.Expressions;
+
+    internal class PropertyExpressionHelper
+    {
+        public static ParsedCallExpression BuildSetterFromGetter<TValue>(
+            ParsedCallExpression parsedCallExpression)
+        {
+            var propertyName = GetPropertyName(parsedCallExpression);
+            if (propertyName == null)
+            {
+                var expressionDescription = GetExpressionDescription(parsedCallExpression);
+                throw new ArgumentException("Expression '" + expressionDescription +
+                                            "' must refer to a property or indexer getter, but doesn't.");
+            }
+
+            var parsedArgumentExpressions = parsedCallExpression.ArgumentsExpressions ?? new ParsedArgumentExpression[0];
+            var parameterTypes = parsedArgumentExpressions
+                .Select(p => p.ArgumentInformation.ParameterType)
+                .Concat(new[] { parsedCallExpression.CalledMethod.ReturnType })
+                .ToArray();
+
+            var indexerSetterInfo = parsedCallExpression.CallTarget.GetType()
+                .GetMethod("set_" + propertyName, parameterTypes);
+
+            if (indexerSetterInfo == null)
+            {
+                if (parsedArgumentExpressions.Any())
+                {
+                    var expressionDescription = GetExpressionDescription(parsedCallExpression);
+                    throw new ArgumentException("Expression '" + expressionDescription +
+                                                "' refers to an indexed property that does not have a setter.");
+                }
+
+                throw new ArgumentException(
+                    "The property '" + propertyName + "' does not have a setter.");
+            }
+
+            var originalParameterInfos = indexerSetterInfo.GetParameters();
+
+            var newParsedSetterValueExpression = new ParsedArgumentExpression(
+                BuildArgumentThatMatchesAnything<TValue>(),
+                originalParameterInfos.Last());
+
+            var arguments = parsedArgumentExpressions
+                .Take(originalParameterInfos.Length - 1)
+                .Concat(new[] { newParsedSetterValueExpression });
+
+            return new ParsedCallExpression(indexerSetterInfo, parsedCallExpression.CallTarget, arguments);
+        }
+
+        private static string GetExpressionDescription(ParsedCallExpression parsedCallExpression)
+        {
+            var matcher = new ExpressionCallMatcher(
+                parsedCallExpression,
+                ServiceLocator.Current.Resolve<ExpressionArgumentConstraintFactory>(),
+                ServiceLocator.Current.Resolve<MethodInfoManager>());
+
+            return matcher.DescriptionOfMatchingCall;
+        }
+
+        private static string GetPropertyName(ParsedCallExpression parsedCallExpression)
+        {
+            var calledMethod = parsedCallExpression.CalledMethod;
+            if (HasThis(calledMethod) && calledMethod.IsSpecialName)
+            {
+                var methodName = calledMethod.Name;
+                if (methodName.StartsWith("get_", StringComparison.Ordinal))
+                {
+                    return methodName.Substring(4);
+                }
+            }
+
+            return null;
+        }
+
+        private static bool HasThis(MethodInfo methodCall)
+        {
+            return methodCall.CallingConvention.HasFlag(CallingConventions.HasThis);
+        }
+
+        private static Expression BuildArgumentThatMatchesAnything<TValue>()
+        {
+            Expression<Func<TValue>> value = () => A<TValue>.Ignored;
+            return value.Body;
+        }
+    }
+}

--- a/src/FakeItEasy/Configuration/StartConfiguration.cs
+++ b/src/FakeItEasy/Configuration/StartConfiguration.cs
@@ -26,9 +26,11 @@ namespace FakeItEasy.Configuration
         {
             Guard.AgainstNull(callSpecification, nameof(callSpecification));
 
-            this.AssertThatMemberCanBeIntercepted(callSpecification);
+            var parsedCallExpression = this.expressionParser.Parse(callSpecification, this.manager.Object);
+            this.GuardAgainstWrongFake(parsedCallExpression.CallTarget);
+            this.AssertThatMemberCanBeIntercepted(parsedCallExpression);
 
-            var rule = this.callRuleFactory(this.expressionParser.Parse(callSpecification));
+            var rule = this.callRuleFactory(parsedCallExpression);
             return this.configurationFactory.CreateConfiguration<TMember>(this.manager, rule);
         }
 
@@ -36,9 +38,11 @@ namespace FakeItEasy.Configuration
         {
             Guard.AgainstNull(callSpecification, nameof(callSpecification));
 
-            this.AssertThatMemberCanBeIntercepted(callSpecification);
+            var parsedCallExpression = this.expressionParser.Parse(callSpecification, this.manager.Object);
+            this.GuardAgainstWrongFake(parsedCallExpression.CallTarget);
+            this.AssertThatMemberCanBeIntercepted(parsedCallExpression);
 
-            var rule = this.callRuleFactory(this.expressionParser.Parse(callSpecification));
+            var rule = this.callRuleFactory(parsedCallExpression);
             return this.configurationFactory.CreateConfiguration(this.manager, rule);
         }
 
@@ -48,10 +52,17 @@ namespace FakeItEasy.Configuration
             return this.configurationFactory.CreateAnyCallConfiguration(this.manager, rule);
         }
 
-        private void AssertThatMemberCanBeIntercepted(LambdaExpression callSpecification)
+        private void AssertThatMemberCanBeIntercepted(ParsedCallExpression parsedCall)
         {
-            var parsedCall = this.expressionParser.Parse(callSpecification);
             this.interceptionAsserter.AssertThatMethodCanBeInterceptedOnInstance(parsedCall.CalledMethod, this.manager.Object);
+        }
+
+        private void GuardAgainstWrongFake(object callTarget)
+        {
+            if (callTarget != this.manager.Object)
+            {
+                throw new ArgumentException("The target of this call is not the fake object being configured.");
+            }
         }
     }
 }

--- a/src/FakeItEasy/Expressions/ICallExpressionParser.cs
+++ b/src/FakeItEasy/Expressions/ICallExpressionParser.cs
@@ -9,10 +9,20 @@ namespace FakeItEasy.Expressions
     internal interface ICallExpressionParser
     {
         /// <summary>
-        /// Parses the specified expression.
+        /// Parses the specified expression that represents a call to a natural fake.
         /// </summary>
         /// <param name="callExpression">The expression to parse.</param>
         /// <returns>The parsed expression.</returns>
+        /// <remarks>The expression should have no parameter.</remarks>
         ParsedCallExpression Parse(LambdaExpression callExpression);
+
+        /// <summary>
+        /// Parses the specified expression that represents a call to an unnatural fake.
+        /// </summary>
+        /// <param name="callExpression">The expression to parse.</param>
+        /// <param name="fake">The fake configured by this expression.</param>
+        /// <returns>The parsed expression.</returns>
+        /// <remarks>The expression should have one parameter which corresponds to the fake being configured.</remarks>
+        ParsedCallExpression Parse(LambdaExpression callExpression, object fake);
     }
 }

--- a/src/FakeItEasy/Fake.of.T.cs
+++ b/src/FakeItEasy/Fake.of.T.cs
@@ -85,6 +85,17 @@ namespace FakeItEasy
         }
 
         /// <summary>
+        /// Configures calls to the setter of the specified property.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property.</typeparam>
+        /// <param name="propertySpecification">An expression specifying the property to configure.</param>
+        /// <returns>A configuration object.</returns>
+        public IPropertySetterAnyValueConfiguration<TValue> CallsToSet<TValue>(Expression<Func<T, TValue>> propertySpecification)
+        {
+            return this.StartConfiguration.CallsToSet(propertySpecification);
+        }
+
+        /// <summary>
         /// Configures any call to the fake object.
         /// </summary>
         /// <returns>A configuration object.</returns>

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Compile Include="AsyncReturnValueConfigurationExtensions.cs" />
     <Compile Include="Compatibility\MethodInfoWrapper.cs" />
+    <Compile Include="Configuration\PropertyExpressionHelper.cs" />
     <Compile Include="LinkedListExtensions.cs" />
     <Compile Include="Configuration\IDoNothingConfiguration.cs" />
     <Compile Include="Configuration\IPropertySetterAnyValueConfiguration.cs" />

--- a/tests/FakeItEasy.Specs/UnnaturalFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/UnnaturalFakeSpecs.cs
@@ -11,6 +11,7 @@
     {
         public interface IFoo
         {
+            int Bar { get; set; }
 
             void VoidMethod();
 
@@ -194,6 +195,59 @@
                 .x(() => exception
                         .Should().BeAnExceptionOfType<ArgumentException>()
                         .And.Message.Should().Be("The target of this call is not the fake object being configured."));
+        }
+
+        [Scenario]
+        [Example(int.MinValue)]
+        [Example(-42)]
+        [Example(0)]
+        [Example(42)]
+        [Example(int.MaxValue)]
+        public static void CallsToSetAnyValue(int value, Fake<IFoo> fake, bool wasCalled)
+        {
+            "Given an unnatural fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And assignment of a property is configured for any value"
+                .x(() => fake.CallsToSet(f => f.Bar).Invokes(call => wasCalled = true));
+
+            $"When I assign {value} to the property"
+                .x(() => fake.FakedObject.Bar = value);
+
+            "Then the configured behavior is used"
+                .x(() => wasCalled.Should().BeTrue());
+        }
+
+        [Scenario]
+        public static void CallsToSetSpecificValueAndAssigningThatValue(Fake<IFoo> fake, bool wasCalled)
+        {
+            "Given an unnatural fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And assignment of a property is configured for a specific value"
+                .x(() => fake.CallsToSet(f => f.Bar).To(42).Invokes(call => wasCalled = true));
+
+            "When I assign that value to the property"
+                .x(() => fake.FakedObject.Bar = 42);
+
+            "Then the configured behavior is used"
+                .x(() => wasCalled.Should().BeTrue());
+        }
+
+        [Scenario]
+        public static void CallsToSetSpecificValueAndAssigningDifferentValue(Fake<IFoo> fake, bool wasCalled)
+        {
+            "Given an unnatural fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And assignment of a property is configured for a specific value"
+                .x(() => fake.CallsToSet(f => f.Bar).To(42).Invokes(call => wasCalled = true));
+
+            "When I assign a different value to the property"
+                .x(() => fake.FakedObject.Bar = 3);
+
+            "Then the configured behavior is not used"
+                .x(() => wasCalled.Should().BeFalse());
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Specs/UnnaturalFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/UnnaturalFakeSpecs.cs
@@ -11,6 +11,7 @@
     {
         public interface IFoo
         {
+
             void VoidMethod();
 
             int MethodWithResult();
@@ -157,6 +158,60 @@
 
             "Then it invokes the action"
                 .x(() => wasCalled.Should().BeTrue());
+        }
+
+        [Scenario]
+        public static void CallsToVoidWithCallToWrongFake(Fake<IFoo> fake, IFoo wrong, Exception exception)
+        {
+            "Given an unnatural fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And an unrelated instance of the faked type"
+                .x(() => wrong = A.Fake<IFoo>());
+
+            "When I configure a fake with an expression that calls the wrong fake"
+                .x(() => exception = Record.Exception(() => fake.CallsTo(f => wrong.VoidMethod()).DoesNothing()));
+
+            "Then it throws an exception that describes the problem"
+                .x(() => exception
+                        .Should().BeAnExceptionOfType<ArgumentException>()
+                        .And.Message.Should().Be("The target of this call is not the fake object being configured."));
+        }
+
+        [Scenario]
+        public static void CallsToNonVoidWithCallToWrongFake(Fake<IFoo> fake, IFoo wrong, Exception exception)
+        {
+            "Given an unnatural fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And an unrelated instance of the faked type"
+                .x(() => wrong = A.Fake<IFoo>());
+
+            "When I configure a fake with an expression that calls the wrong fake"
+                .x(() => exception = Record.Exception(() => fake.CallsTo(f => wrong.MethodWithResult()).Returns(42)));
+
+            "Then it throws an exception that describes the problem"
+                .x(() => exception
+                        .Should().BeAnExceptionOfType<ArgumentException>()
+                        .And.Message.Should().Be("The target of this call is not the fake object being configured."));
+        }
+
+        [Scenario]
+        public static void CallsToSetWithCallToWrongFake(Fake<IFoo> fake, IFoo wrong, Exception exception)
+        {
+            "Given an unnatural fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And an unrelated instance of the faked type"
+                .x(() => wrong = A.Fake<IFoo>());
+
+            "When I configure a fake with an expression that calls the wrong fake"
+                .x(() => exception = Record.Exception(() => fake.CallsToSet(f => wrong.Bar).DoesNothing()));
+
+            "Then it throws an exception that describes the problem"
+                .x(() => exception
+                        .Should().BeAnExceptionOfType<ArgumentException>()
+                        .And.Message.Should().Be("The target of this call is not the fake object being configured."));
         }
 
         public class AClass

--- a/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
@@ -145,6 +145,7 @@ namespace FakeItEasy
         public FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified AnyCall() { }
         public FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallsTo(System.Linq.Expressions.Expression<System.Action<T>> callSpecification) { }
         public FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<TMember> CallsTo<TMember>(System.Linq.Expressions.Expression<System.Func<T, TMember>> callSpecification) { }
+        public FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallsToSet<TValue>(System.Linq.Expressions.Expression<System.Func<T, TValue>> propertySpecification) { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.All)]
     public class FakeAttribute : System.Attribute

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
@@ -222,6 +222,7 @@ namespace FakeItEasy
         public FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified AnyCall() { }
         public FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallsTo(System.Linq.Expressions.Expression<System.Action<T>> callSpecification) { }
         public FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<TMember> CallsTo<TMember>(System.Linq.Expressions.Expression<System.Func<T, TMember>> callSpecification) { }
+        public FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallsToSet<TValue>(System.Linq.Expressions.Expression<System.Func<T, TValue>> propertySpecification) { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.All)]
     public class FakeAttribute : System.Attribute


### PR DESCRIPTION
Fixes #838 

I did a bit of refactoring to make `StartConfiguration` work more like `FakeConfigurationManager`.

I also had to change `CallExpressionParser` to work correctly with unnatural fakes. The call specification expression takes a parameter, so calling `ParsedCallExpression.CallTarget` was trying to evaluate an expression that was a `ParameterExpression`, which of course didn't work since the parameter value was unknown. I added a `ICallExpression.Parse` overload that accepts the fake itself and rewrites the expression from `f => f.TheMethod()` to `() => <value of fake.FakeObject>.TheMethod()`.