### PR TITLE
Change behavior of auto properties to not override explicit configuration

### DIFF
--- a/docs/default-fake-behavior.md
+++ b/docs/default-fake-behavior.md
@@ -28,6 +28,27 @@ the member:
   concrete, pre-existing type;
 * otherwise, `default(T)` will be returned.
 
+### Read/write properties
+
+By default, any overrideable property that has both a `set` and `get` accessor,
+and that has not been explicitly configured to behave otherwise, behaves like
+you might expect. Setting a value and then getting the value returns the value
+that was set.
+
+```csharp
+var fakeShop = A.Fake<ICandyShop>();
+
+fakeShop.Address = "123 Fake Street";
+
+System.Console.Out.Write(fakeShop.Address);
+// prints "123 Fake Street"
+```
+
+This behavior can be used to
+
+* supply values for the system under test to use (via the getter) or to
+* verify that the system under test performed the `set` action on the Fake
+
 ### Cancellation tokens
 
 When a faked method that accepts a `CancellationToken` receives a canceled token

--- a/docs/read-write-property-behavior.md
+++ b/docs/read-write-property-behavior.md
@@ -1,24 +1,3 @@
-# Read/Write Property Behavior
-
-Although you can explicitly
-[specify the return value for a called property getter](specifying-return-values.md),
-there's an easier, more intuitive way to work with read/write
-properties.  By default, any
-[fakeable](what-can-be-faked.md#what-members-can-be-overridden) property
-that has both a `set` and `get` accessor behaves like you might
-expect. Setting a value and then getting the value returns the value
-that was set.
-
-```csharp
-var fakeShop = A.Fake<ICandyShop>();
-
-fakeShop.Address = "123 Fake Street";
-
-System.Console.Out.Write(fakeShop.Address); 
-// prints "123 Fake Street"
-```
-
-This behaviour can be used to 
-
-* supply values for the system under test to use (via the getter) or to
-* verify that the system under test performed the `set` action on the Fake
+The contents of this page have moved. See
+* [Default fake behavior](default-fake-behavior.md) for information about unconfigured properties and
+* [Specifying a Call to Configure](specifying-a-call-to-configure.md) for how to configure a property.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,6 @@ pages:
   - Specifying Return Values: specifying-return-values.md
   - Throwing Exceptions: throwing-exceptions.md
   - Doing Nothing: doing-nothing.md
-  - Read/Write Property Behavior: read-write-property-behavior.md
   - Assigning out and ref parameters: assigning-out-and-ref-parameters.md
   - Invoking Custom Code: invoking-custom-code.md
   - Calling base methods: calling-base-methods.md

--- a/src/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
@@ -35,7 +35,7 @@ namespace FakeItEasy.Core
 
                 var newRule = new CallRuleMetadata
                                   {
-                                      Rule = new PropertyBehaviorRule(fakeObjectCall.Method, this.fakeManager)
+                                      Rule = new PropertyBehaviorRule(fakeObjectCall.Method)
                                       {
                                           Value = fakeObjectCall.GetDefaultReturnValue(),
                                           Indices = fakeObjectCall.Arguments.ToArray(),

--- a/src/FakeItEasy/Core/FakeManager.PropertyBehaviorRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.PropertyBehaviorRule.cs
@@ -10,13 +10,11 @@ namespace FakeItEasy.Core
         private class PropertyBehaviorRule
             : IFakeObjectCallRule
         {
-            private readonly FakeManager fakeManager;
             private readonly MethodInfo propertyGetter;
             private readonly MethodInfo propertySetter;
 
-            public PropertyBehaviorRule(MethodInfo propertyGetterOrSetter, FakeManager fakeManager)
+            public PropertyBehaviorRule(MethodInfo propertyGetterOrSetter)
             {
-                this.fakeManager = fakeManager;
                 var property = GetProperty(propertyGetterOrSetter);
 
                 this.propertySetter = property.GetSetMethod();
@@ -39,25 +37,18 @@ namespace FakeItEasy.Core
                 return method.IsSpecialName && method.Name.StartsWith("get_", StringComparison.Ordinal);
             }
 
+            public bool IsMatchForSetter(IFakeObjectCall fakeObjectCall) => this.IsPropertySetter(fakeObjectCall);
+
             public bool IsApplicableTo(IFakeObjectCall fakeObjectCall)
             {
-                return this.IsPropertySetter(fakeObjectCall) || this.IsPropertyGetter(fakeObjectCall);
+                return this.IsPropertyGetter(fakeObjectCall);
             }
 
             public void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
                 Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
 
-                if (this.IsPropertyGetter(fakeObjectCall))
-                {
-                    fakeObjectCall.SetReturnValue(this.Value);
-                }
-                else
-                {
-                    this.Value = fakeObjectCall.Arguments.Last();
-                }
-
-                this.fakeManager.MoveRuleToFront(this);
+                fakeObjectCall.SetReturnValue(this.Value);
             }
 
             private static PropertyInfo GetProperty(MethodInfo propertyGetterOrSetter)

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -202,19 +202,5 @@ namespace FakeItEasy.Core
             rule.CalledNumberOfTimes++;
             rule.Rule.Apply(fakeObjectCall);
         }
-
-        private void MoveRuleToFront(CallRuleMetadata rule)
-        {
-            if (this.AllUserRules.Remove(rule))
-            {
-                this.AllUserRules.AddFirst(rule);
-            }
-        }
-
-        private void MoveRuleToFront(IFakeObjectCallRule rule)
-        {
-            var metadata = this.AllRules.Single(x => x.Rule.Equals(rule));
-            this.MoveRuleToFront(metadata);
-        }
     }
 }

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -89,6 +89,7 @@
     <Compile Include="ConfiguringPropertySetterSpecs.cs" />
     <Compile Include="DummyCreationSpecs.cs" />
     <Compile Include="FakeSpecs.cs" />
+    <Compile Include="ReadWritePropertySpecs.cs" />
     <Compile Include="TaskSpecs.cs" />
     <Compile Include="ConfigurationSpecs.cs" />
     <Compile Include="CreationOptionsSpecs.cs" />

--- a/tests/FakeItEasy.Specs/ReadWritePropertySpecs.cs
+++ b/tests/FakeItEasy.Specs/ReadWritePropertySpecs.cs
@@ -1,0 +1,61 @@
+﻿namespace FakeItEasy.Specs
+{
+    using FluentAssertions;
+    using Xbehave;
+
+    public static class ReadWritePropertySpecs
+    {
+        public interface IFoo
+        {
+            int Bar { get; set; }
+        }
+
+        [Scenario]
+        public static void AssignNonConfiguredProperty(IFoo foo)
+        {
+            "Given a fake"
+                .x(() => foo = A.Fake<IFoo>());
+
+            "When I assign a value to a read-write property"
+                .x(() => foo.Bar = 123);
+
+            "Then the property returns the assigned value"
+                .x(() => foo.Bar.Should().Be(123));
+        }
+
+        [Scenario]
+        public static void AssignPropertyWithConfiguredGetter(IFoo foo)
+        {
+            "Given a fake"
+                .x(() => foo = A.Fake<IFoo>());
+
+            "And the getter of a read-write property of the fake is explicitly configured to return a value"
+                .x(() => A.CallTo(() => foo.Bar).Returns(42));
+
+            "When I assign another value to that property"
+                .x(() => foo.Bar = 123);
+
+            "Then the assignment has no effect and the property returns the explicitly configured value"
+                .x(() => foo.Bar.Should().Be(42));
+        }
+
+        [Scenario]
+        public static void GetPropertyWithConfiguredSetter(IFoo foo, int value)
+        {
+            "Given a fake"
+                .x(() => foo = A.Fake<IFoo>());
+
+            "And the setter of a read-write property of the fake is explicitly configured to do nothing"
+                .x(() => A.CallToSet(() => foo.Bar).DoesNothing());
+
+            "When I get the value of that property"
+                .x(() => value = foo.Bar);
+
+            "And I assign another value to that property"
+                .x(() => foo.Bar = 123);
+
+            "Then the assignment has no effect and the property returns the initial default value"
+                .x(() => foo.Bar.Should().Be(value));
+        }
+    }
+}

--- a/tests/FakeItEasy.Tests/Core/FakeManagerTests.cs
+++ b/tests/FakeItEasy.Tests/Core/FakeManagerTests.cs
@@ -200,12 +200,14 @@ namespace FakeItEasy.Tests.Core
             var foo = A.Fake<IFoo>();
 
             foo.SomeProperty = 10;
-
             foo.SomeProperty.Should().Be(10);
+
+            foo.SomeProperty = 5;
+            foo.SomeProperty.Should().Be(5);
         }
 
         [Fact]
-        public void Object_properties_be_set_directly_and_configured_as_methods_interchangeably()
+        public void Object_properties_do_not_have_property_behavior_when_explicitly_configured()
         {
             var foo = A.Fake<IFoo>();
 
@@ -213,13 +215,13 @@ namespace FakeItEasy.Tests.Core
             foo.SomeProperty.Should().Be(2);
 
             foo.SomeProperty = 5;
-            foo.SomeProperty.Should().Be(5);
+            foo.SomeProperty.Should().Be(2);
 
             A.CallTo(() => foo.SomeProperty).Returns(20);
             foo.SomeProperty.Should().Be(20);
 
             foo.SomeProperty = 10;
-            foo.SomeProperty.Should().Be(10);
+            foo.SomeProperty.Should().Be(20);
         }
 
         [Fact]


### PR DESCRIPTION
This PR is an experiment to demonstrate a new behavior for "auto properties", as discussed in the chat.

Fixes #962 