### PR TITLE
Add explicit dependency to fix build issue

### DIFF
--- a/FakeItEasy.sln
+++ b/FakeItEasy.sln
@@ -152,6 +152,9 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FakeItEasy.IntegrationTests
 	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FakeItEasy.IntegrationTests.External.netstd", "tests\FakeItEasy.IntegrationTests.External.netstd\FakeItEasy.IntegrationTests.External.netstd.xproj", "{BB92D188-5666-46DC-935A-81F0C5173D20}"
+	ProjectSection(ProjectDependencies) = postProject
+		{CF137AE3-7C4F-41BD-A4AD-762BBED2255E} = {CF137AE3-7C4F-41BD-A4AD-762BBED2255E}
+	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FakeItEasy.Specs.netstd", "tests\FakeItEasy.Specs.netstd\FakeItEasy.Specs.netstd.xproj", "{317507FF-520B-41C7-B71C-73DDA068204F}"
 EndProject


### PR DESCRIPTION
FakeItEasy.IntegrationTests.External.netstd sometimes fails to build when using the Rebuild command in Visual Studio. MSBuild tries to build it too early, before FakeItEasy.netstd has been built. Adding an explicit build dependency in the solution fixes the problem.