### PR TITLE
Fix nuspec castle version

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -13,7 +13,6 @@ solution        = "FakeItEasy.sln"
 assembly_info   = "src/CommonAssemblyInfo.cs"
 version         = IO.read(assembly_info)[/AssemblyInformationalVersion\("([^"]+)"\)/, 1]
 version_suffix  = ENV["VERSION_SUFFIX"]
-version_suffix  = version_suffix.to_s.empty? ? "-adhoc" : version_suffix
 build           = (ENV["BUILD"] || "").rjust(6, "0");
 build_suffix    = version_suffix.to_s.empty? ? "" : "-build" + build;
 repo_url        = "https://github.com/FakeItEasy/FakeItEasy"

--- a/src/FakeItEasy.nuspec
+++ b/src/FakeItEasy.nuspec
@@ -19,7 +19,7 @@
         <dependency id="Microsoft.Extensions.DependencyModel" version="1.0.0" />
         <dependency id="System.Collections.Concurrent" version="4.0.12" />
         <dependency id="System.Runtime.Loader" version="4.0.0" />
-        <dependency id="Castle.Core" version="4.0.0-beta002" />
+        <dependency id="Castle.Core" version="4.0.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Forgot the nuspec in #974...

Also, the `-adhoc` default version suffix was only necessary when the Castle.Core dependency was a pre-release version, so I removed it (I set the VERSION_SUFFIX to `-rc001` in AppVeyor)