### PR TITLE
Stop requiring event args to extend EventArgs (for .NET Standard)

### DIFF
--- a/docs/raising-events.md
+++ b/docs/raising-events.md
@@ -36,6 +36,10 @@ robot.FellInLove += Raise.With(sender: robot, e: someEventArgs);
 
 Events of type `EventHandler<TEventArgs>` can be raised in exactly the same way. 
 
+Note that as of version 3.1.0, for the .NET Standard version of the FakeItEasy
+library, `TEventArgs` need not extend `EventArgs` to support the above syntax, but
+the .NET 4.0 library requires `TEventArgs` to extend `EventArgs`.
+
 If an event is defined using a **custom delegate**, then `Raise` needs
 a typeparam to help it out:
 

--- a/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
+++ b/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
@@ -8,8 +8,10 @@ namespace FakeItEasy.Core
     /// in order to raise that event.
     /// </summary>
     /// <typeparam name="TEventArgs">The type of the event args.</typeparam>
-    public class Raise<TEventArgs>
-        : IEventRaiserArgumentProvider where TEventArgs : EventArgs
+    public class Raise<TEventArgs> : IEventRaiserArgumentProvider
+#if FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS
+        where TEventArgs : EventArgs
+#endif
     {
         private readonly TEventArgs eventArguments;
         private readonly object eventSender;

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -30,7 +30,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FEATURE_BINARY_SERIALIZATION FEATURE_REFLECTION_GETASSEMBLIES FEATURE_SELF_INITIALIZED_FAKES</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_BINARY_SERIALIZATION;FEATURE_REFLECTION_GETASSEMBLIES;FEATURE_SELF_INITIALIZED_FAKES;FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\..\FakeItEasy.ruleset</CodeAnalysisRuleSet>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;FEATURE_BINARY_SERIALIZATION FEATURE_REFLECTION_GETASSEMBLIES FEATURE_SELF_INITIALIZED_FAKES</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_BINARY_SERIALIZATION;FEATURE_REFLECTION_GETASSEMBLIES;FEATURE_SELF_INITIALIZED_FAKES;FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>Bin\Release\FakeItEasy.xml</DocumentationFile>

--- a/src/FakeItEasy/Raise.cs
+++ b/src/FakeItEasy/Raise.cs
@@ -22,7 +22,10 @@ namespace FakeItEasy
         /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
         /// <returns>A Raise(TEventArgs)-object that exposes the event handler to attach.</returns>
         [SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers", Justification = "Must be visible to provide the event raising syntax.")]
-        public static Raise<TEventArgs> With<TEventArgs>(object sender, TEventArgs e) where TEventArgs : EventArgs
+        public static Raise<TEventArgs> With<TEventArgs>(object sender, TEventArgs e)
+#if FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS
+            where TEventArgs : EventArgs
+#endif
         {
             return new Raise<TEventArgs>(sender, e, ArgumentProviderMap);
         }
@@ -36,7 +39,10 @@ namespace FakeItEasy
         /// <returns>
         /// A Raise(TEventArgs)-object that exposes the event handler to attach.
         /// </returns>
-        public static Raise<TEventArgs> With<TEventArgs>(TEventArgs e) where TEventArgs : EventArgs
+        public static Raise<TEventArgs> With<TEventArgs>(TEventArgs e)
+#if FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS
+            where TEventArgs : EventArgs
+#endif
         {
             return new Raise<TEventArgs>(e, ArgumentProviderMap);
         }

--- a/tests/FakeItEasy.Specs/EventRaisingSpecs.cs
+++ b/tests/FakeItEasy.Specs/EventRaisingSpecs.cs
@@ -45,6 +45,10 @@ namespace FakeItEasy.Specs
 
             event EventHandler<CustomEventArgs> GenericEvent;
 
+#if !FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS
+            event EventHandler<ReferenceType> EventHandlerOfNonEventArgsEvent;
+#endif
+
             event CustomEventHandler CustomEvent;
 
             event ReferenceTypeEventHandler ReferenceTypeEvent;
@@ -79,6 +83,14 @@ namespace FakeItEasy.Specs
                 CapturedSender = sender;
                 CapturedArgs1 = e;
             };
+
+#if !FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS
+            Fake.EventHandlerOfNonEventArgsEvent += (sender, e) =>
+            {
+                CapturedSender = sender;
+                CapturedArgs1 = e;
+            };
+#endif
 
             Fake.GenericEvent += (sender, e) =>
             {
@@ -232,6 +244,21 @@ namespace FakeItEasy.Specs
             "it should pass the event arguments"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.customEventArgs));
         }
+
+#if !FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS
+        [Scenario]
+        public void EventArgumentsThatDoNotExtenedEventArg()
+        {
+            "when raising event passing arguments"
+                .x(() => Fake.EventHandlerOfNonEventArgsEvent += Raise.With(this.referenceTypeEventArgs));
+
+            "it should pass the fake as sender"
+                .x(() => CapturedSender.Should().BeSameAs(Fake));
+
+            "it should pass the event arguments"
+                .x(() => CapturedArgs1.Should().BeSameAs(this.referenceTypeEventArgs));
+        }
+#endif
 
         [Scenario]
         public void CustomEventHandler()

--- a/tests/FakeItEasy.Specs/EventRaisingSpecs.cs
+++ b/tests/FakeItEasy.Specs/EventRaisingSpecs.cs
@@ -123,16 +123,16 @@ namespace FakeItEasy.Specs
 
         [Scenario]
         public void UnsubscribedEvent(
-            Exception caughtException)
+            Exception exception)
         {
             "Given an event with no subscribers"
                 .See(() => nameof(Fake.UnsubscribedEvent));
 
             "When I raise the event"
-                .x(() => caughtException = Record.Exception(() => Fake.UnsubscribedEvent += Raise.WithEmpty()));
+                .x(() => exception = Record.Exception(() => Fake.UnsubscribedEvent += Raise.WithEmpty()));
 
             "Then the call doesn't throw"
-                .x(() => caughtException.Should().BeNull());
+                .x(() => exception.Should().BeNull());
         }
 
         [Scenario]
@@ -209,10 +209,10 @@ namespace FakeItEasy.Specs
 
             "And the event has multiple subscribers"
                 .x(() =>
-                    {
-                        Fake.SubscribedEvent += (s, e) => handler1InvocationCount++;
-                        Fake.SubscribedEvent += (s, e) => handler2InvocationCount++;
-                    });
+                {
+                    Fake.SubscribedEvent += (s, e) => handler1InvocationCount++;
+                    Fake.SubscribedEvent += (s, e) => handler2InvocationCount++;
+                });
 
             "When I raise the event"
                 .x(() => Fake.SubscribedEvent += Raise.WithEmpty());
@@ -326,72 +326,64 @@ namespace FakeItEasy.Specs
                 .See(() => nameof(Fake.ReferenceTypeEvent));
 
             "When I raise the event specifying an argument of a derived type"
-                .x(() => Fake.ReferenceTypeEvent += Raise.With<ReferenceTypeEventHandler>(this.derivedReferenceTypeEventArgs));
+                .x(() => Fake.ReferenceTypeEvent +=
+                    Raise.With<ReferenceTypeEventHandler>(this.derivedReferenceTypeEventArgs));
 
             "Then the supplied value is passed as the event argument"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.derivedReferenceTypeEventArgs));
         }
 
         [Scenario]
-        public void ReferenceTypeEventHandlerWithInvalidArgumentType()
+        public void ReferenceTypeEventHandlerWithInvalidArgumentType(
+            Exception exception)
         {
+            const string ExpectedMessage =
+                "The event has the signature (FakeItEasy.Specs.ReferenceType), " +
+                "but the provided arguments have types (System.Collections.Hashtable).";
+
             "Given an event of a custom delegate type taking only a reference type as an argument"
                 .See(() => nameof(Fake.ReferenceTypeEvent));
 
             "When I raise the event specifying an argument of an invalid type"
-                .x(() => CatchException(() =>
+                .x(() => exception = Record.Exception(() =>
                         Fake.ReferenceTypeEvent += Raise.With<ReferenceTypeEventHandler>(new Hashtable())));
 
             "Then the call fails with a meaningful message"
-                .x(() =>
-                {
-                    const string ExpectedMessage =
-                        "The event has the signature (FakeItEasy.Specs.ReferenceType), " +
-                        "but the provided arguments have types (System.Collections.Hashtable).";
-
-                    CaughtException.Should().BeAnExceptionOfType<FakeConfigurationException>().And
-                        .Message.Should().Be(ExpectedMessage);
-                });
+                .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>().And
+                    .Message.Should().Be(ExpectedMessage));
         }
 
         [Scenario]
-        public void ValueTypeEventHandlerWithNullValue()
+        public void ValueTypeEventHandlerWithNullValue(
+            Exception exception)
         {
             "Given an event of a custom delegate type taking only a value type as an argument"
                 .See(() => nameof(Fake.ValueTypeEvent));
 
             "When I raise the event specifying a null argument"
-                .x(() => CatchException(() =>
-                                        Fake.ValueTypeEvent += Raise.With<ValueTypeEventHandler>((object)null)));
+                .x(() => exception = Record.Exception(() =>
+                        Fake.ValueTypeEvent += Raise.With<ValueTypeEventHandler>((object)null)));
 
             "Then the call fails with a meaningful message"
-                .x(() => CaughtException.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                             .And.Message.Should().Be(
-                                 "The event has the signature (System.Int32), but the provided arguments have types (<NULL>)."));
+                .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
+                    .And.Message.Should().Be(
+                        "The event has the signature (System.Int32), but the provided arguments have types (<NULL>)."));
         }
 
         [Scenario]
         public void ActionEvent()
         {
-            var eventArgs1 = 19;
-            var eventArgs2 = true;
-
             "Given an event of type Action"
                 .See(() => nameof(Fake.ActionEvent));
 
             "When I raise the event specifying the arguments"
-                .x(() => Fake.ActionEvent += Raise.With<Action<int, bool>>(eventArgs1, eventArgs2));
+                .x(() => Fake.ActionEvent += Raise.With<Action<int, bool>>(19, true));
 
             "Then the first value is passed as the first event argument"
-                .x(() => CapturedArgs1.Should().Be(eventArgs1));
+                .x(() => CapturedArgs1.Should().Be(19));
 
             "Then the second value is passed as the second event argument"
-                .x(() => CapturedArgs2.Should().Be(eventArgs2));
-        }
-
-        private static void CatchException(Action action)
-        {
-            CaughtException = Record.Exception(action);
+                .x(() => CapturedArgs2.Should().Be(true));
         }
     }
 }

--- a/tests/FakeItEasy.Specs/EventRaisingSpecs.cs
+++ b/tests/FakeItEasy.Specs/EventRaisingSpecs.cs
@@ -125,62 +125,77 @@ namespace FakeItEasy.Specs
         public void UnsubscribedEvent(
             Exception caughtException)
         {
-            "when raising unsubscribed event"
+            "Given an event with no subscribers"
+                .See(() => nameof(Fake.UnsubscribedEvent));
+
+            "When I raise the event"
                 .x(() => caughtException = Record.Exception(() => Fake.UnsubscribedEvent += Raise.WithEmpty()));
 
-            "it should not throw"
+            "Then the call doesn't throw"
                 .x(() => caughtException.Should().BeNull());
         }
 
         [Scenario]
         public void WithEmpty()
         {
-            "when raising event with empty arguments"
+            "Given an event of type EventHandler"
+                .See(() => nameof(Fake.SubscribedEvent));
+
+            "When I raise the event without specifying sender or arguments"
                 .x(() => Fake.SubscribedEvent += Raise.WithEmpty());
 
-            "it should pass the fake as sender"
+            "Then the fake is passed as the sender"
                 .x(() => CapturedSender.Should().BeSameAs(Fake));
 
-            "it should pass empty event arguments"
+            "And an empty EventArgs is passed as the event arguments"
                 .x(() => CapturedArgs1.Should().Be(EventArgs.Empty));
         }
 
         [Scenario]
         public void EventArguments()
         {
-            "when raising event passing arguments"
+            "Given an event of type EventHandler"
+                .See(() => nameof(Fake.SubscribedEvent));
+
+            "When I raise the event specifying only the event arguments"
                 .x(() => Fake.SubscribedEvent += Raise.With(this.eventArgs));
 
-            "it should pass the fake as sender"
+            "Then the fake is passed as the sender"
                 .x(() => CapturedSender.Should().BeSameAs(Fake));
 
-            "it should pass the event arguments"
+            "And the supplied value is passed as the event arguments"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.eventArgs));
         }
 
         [Scenario]
         public void SenderAndEventArguments()
         {
-            "when raising event passing sender and arguments"
+            "Given an event of type EventHandler"
+                .See(() => nameof(Fake.SubscribedEvent));
+
+            "When I raise the event specifying the sender and the event arguments"
                 .x(() => Fake.SubscribedEvent += Raise.With(SampleSender, this.eventArgs));
 
-            "it should pass the sender"
+            "Then the supplied sender is passed as the event sender"
                 .x(() => CapturedSender.Should().BeSameAs(SampleSender));
 
-            "it should pass the event arguments"
+            "And the supplied value is passed as the event arguments"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.eventArgs));
         }
 
         [Scenario]
         public void NullSenderAndEventArguments()
         {
-            "when raising event passing arguments and null sender"
+            "Given an event of type EventHandler"
+                .See(() => nameof(Fake.SubscribedEvent));
+
+            "When I raise the event specifying the event arguments and a null sender"
                 .x(() => Fake.SubscribedEvent += Raise.With(null, this.eventArgs));
 
-            "it should pass null as the sender"
+            "Then null is passed as the event sender"
                 .x(() => CapturedSender.Should().BeNull());
 
-            "it should pass the event arguments"
+            "And the supplied value is passed as the event arguments"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.eventArgs));
         }
 
@@ -189,59 +204,71 @@ namespace FakeItEasy.Specs
             int handler1InvocationCount,
             int handler2InvocationCount)
         {
-            "establish"
+            "Given an event of type EventHandler"
+                .See(() => nameof(Fake.SubscribedEvent));
+
+            "And the event has multiple subscribers"
                 .x(() =>
                     {
                         Fake.SubscribedEvent += (s, e) => handler1InvocationCount++;
                         Fake.SubscribedEvent += (s, e) => handler2InvocationCount++;
                     });
 
-            "when raising event with multiple subscribers"
+            "When I raise the event"
                 .x(() => Fake.SubscribedEvent += Raise.WithEmpty());
 
-            "it should invoke the first handler once"
+            "Then the first subscriber is invoked once"
                 .x(() => handler1InvocationCount.Should().Be(1));
 
-            "it should invoke the second handler once"
+            "And the second subscriber is invoked once"
                 .x(() => handler2InvocationCount.Should().Be(1));
         }
 
         [Scenario]
         public void CustomEventArguments()
         {
-            "when raising generic event passing arguments"
+            "Given an event of type EventHandler with custom event arguments type"
+                .See(() => nameof(Fake.GenericEvent));
+
+            "When I raise the event specifying only the event arguments"
                 .x(() => Fake.GenericEvent += Raise.With(this.customEventArgs));
 
-            "it should pass the fake as sender"
+            "Then the fake is passed as the sender"
                 .x(() => CapturedSender.Should().BeSameAs(Fake));
 
-            "it should pass the event arguments"
+            "And the supplied value is passed as the event arguments"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.customEventArgs));
         }
 
         [Scenario]
         public void SenderAndCustomEventArguments()
         {
-            "when raising generic event passing sender and arguments"
+            "Given an event of type EventHandler with custom event arguments type"
+                .See(() => nameof(Fake.GenericEvent));
+
+            "When I raise the event specifying the sender and the event arguments"
                 .x(() => Fake.GenericEvent += Raise.With(SampleSender, this.customEventArgs));
 
-            "it should pass the sender"
+            "Then the supplied sender is passed as the event sender"
                 .x(() => CapturedSender.Should().BeSameAs(SampleSender));
 
-            "it should pass the event arguments"
+            "And the supplied value is passed as the event arguments"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.customEventArgs));
         }
 
         [Scenario]
         public void NullSenderAndCustomEventArguments()
         {
-            "when raising generic event passing arguments and null sender"
+            "Given an event of type EventHandler with custom event arguments type"
+                .See(() => nameof(Fake.GenericEvent));
+
+            "When I raise the event specifying the event arguments and a null sender"
                 .x(() => Fake.GenericEvent += Raise.With(null, this.customEventArgs));
 
-            "it should pass null as the sender"
+            "Then null is passed as the event sender"
                 .x(() => CapturedSender.Should().BeNull());
 
-            "it should pass the event arguments"
+            "And the supplied value is passed as the event arguments"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.customEventArgs));
         }
 
@@ -249,13 +276,16 @@ namespace FakeItEasy.Specs
         [Scenario]
         public void EventArgumentsThatDoNotExtenedEventArg()
         {
-            "when raising event passing arguments"
+            "Given an event of type EventHandler with custom event arguments type that does not extend EventArgs"
+                .See(() => nameof(Fake.EventHandlerOfNonEventArgsEvent));
+
+            "When I raise the event specifying only the event arguments"
                 .x(() => Fake.EventHandlerOfNonEventArgsEvent += Raise.With(this.referenceTypeEventArgs));
 
-            "it should pass the fake as sender"
+            "Then the fake is passed as the sender"
                 .x(() => CapturedSender.Should().BeSameAs(Fake));
 
-            "it should pass the event arguments"
+            "And the supplied value is passed as the event arguments"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.referenceTypeEventArgs));
         }
 #endif
@@ -263,62 +293,78 @@ namespace FakeItEasy.Specs
         [Scenario]
         public void CustomEventHandler()
         {
-            "when raising custom event passing sender and arguments"
+            "Given an event of a custom delegate type that takes a sender and event arguments"
+                .See(() => nameof(Fake.CustomEvent));
+
+            "When I raise the event specifying the sender and the event arguments"
                 .x(() => Fake.CustomEvent += Raise.With<CustomEventHandler>(SampleSender, this.customEventArgs));
 
-            "it should pass the sender"
+            "Then the supplied sender is passed as the event sender"
                 .x(() => CapturedSender.Should().BeSameAs(SampleSender));
 
-            "it should pass the event arguments"
+            "And the supplied value is passed as the event arguments"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.customEventArgs));
         }
 
         [Scenario]
         public void ReferenceTypeEventHandler()
         {
-            "when raising reference type event passing arguments"
+            "Given an event of a custom delegate type taking only a reference type as an argument"
+                .See(() => nameof(Fake.ReferenceTypeEvent));
+
+            "When I raise the event specifying the arguments"
                 .x(() => Fake.ReferenceTypeEvent += Raise.With<ReferenceTypeEventHandler>(this.referenceTypeEventArgs));
 
-            "it should pass the event arguments"
+            "Then the supplied value is passed as the event argument"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.referenceTypeEventArgs));
         }
 
         [Scenario]
         public void ReferenceTypeEventHandlerWithDerivedArguments()
         {
-            "when raising reference type event passing derived arguments"
+            "Given an event of a custom delegate type taking only a reference type as an argument"
+                .See(() => nameof(Fake.ReferenceTypeEvent));
+
+            "When I raise the event specifying an argument of a derived type"
                 .x(() => Fake.ReferenceTypeEvent += Raise.With<ReferenceTypeEventHandler>(this.derivedReferenceTypeEventArgs));
 
-            "it should pass the event arguments"
+            "Then the supplied value is passed as the event argument"
                 .x(() => CapturedArgs1.Should().BeSameAs(this.derivedReferenceTypeEventArgs));
         }
 
         [Scenario]
         public void ReferenceTypeEventHandlerWithInvalidArgumentType()
         {
-            "when raising reference type event passing invalid argument type"
-                .x(() => CatchException(() => Fake.ReferenceTypeEvent += Raise.With<ReferenceTypeEventHandler>(new Hashtable())));
+            "Given an event of a custom delegate type taking only a reference type as an argument"
+                .See(() => nameof(Fake.ReferenceTypeEvent));
 
-            "it should fail with good message"
+            "When I raise the event specifying an argument of an invalid type"
+                .x(() => CatchException(() =>
+                        Fake.ReferenceTypeEvent += Raise.With<ReferenceTypeEventHandler>(new Hashtable())));
+
+            "Then the call fails with a meaningful message"
                 .x(() =>
-                    {
-                        const string ExpectedMessage =
-                    "The event has the signature (FakeItEasy.Specs.ReferenceType), " +
-                    "but the provided arguments have types (System.Collections.Hashtable).";
+                {
+                    const string ExpectedMessage =
+                        "The event has the signature (FakeItEasy.Specs.ReferenceType), " +
+                        "but the provided arguments have types (System.Collections.Hashtable).";
 
-                        CaughtException.Should().BeAnExceptionOfType<FakeConfigurationException>().And
+                    CaughtException.Should().BeAnExceptionOfType<FakeConfigurationException>().And
                         .Message.Should().Be(ExpectedMessage);
-                    });
+                });
         }
 
         [Scenario]
         public void ValueTypeEventHandlerWithNullValue()
         {
-            "when raising value type event passing null argument"
+            "Given an event of a custom delegate type taking only a value type as an argument"
+                .See(() => nameof(Fake.ValueTypeEvent));
+
+            "When I raise the event specifying a null argument"
                 .x(() => CatchException(() =>
                                         Fake.ValueTypeEvent += Raise.With<ValueTypeEventHandler>((object)null)));
 
-            "it should fail with good message"
+            "Then the call fails with a meaningful message"
                 .x(() => CaughtException.Should().BeAnExceptionOfType<FakeConfigurationException>()
                              .And.Message.Should().Be(
                                  "The event has the signature (System.Int32), but the provided arguments have types (<NULL>)."));
@@ -330,13 +376,16 @@ namespace FakeItEasy.Specs
             var eventArgs1 = 19;
             var eventArgs2 = true;
 
-            "when raising action event passing arguments"
+            "Given an event of type Action"
+                .See(() => nameof(Fake.ActionEvent));
+
+            "When I raise the event specifying the arguments"
                 .x(() => Fake.ActionEvent += Raise.With<Action<int, bool>>(eventArgs1, eventArgs2));
 
-            "it should pass the first argument"
+            "Then the first value is passed as the first event argument"
                 .x(() => CapturedArgs1.Should().Be(eventArgs1));
 
-            "it should pass the second argument"
+            "Then the second value is passed as the second event argument"
                 .x(() => CapturedArgs2.Should().Be(eventArgs2));
         }
 

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FEATURE_SELF_INITIALIZED_FAKES</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_SELF_INITIALIZED_FAKES;FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
@@ -36,7 +36,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>Bin\Release\</OutputPath>
-    <DefineConstants>TRACE;FEATURE_SELF_INITIALIZED_FAKES</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_SELF_INITIALIZED_FAKES;FEATURE_EVENT_ARGS_MUST_EXTEND_EVENTARGS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>FakeItEasy.Specs.ruleset</CodeAnalysisRuleSet>

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -36,7 +36,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>Bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_SELF_INITIALIZED_FAKES</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>FakeItEasy.Specs.ruleset</CodeAnalysisRuleSet>

--- a/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
@@ -238,10 +238,8 @@ namespace FakeItEasy
     }
     public class static Raise
     {
-        public static FakeItEasy.Core.Raise<TEventArgs> With<TEventArgs>(object sender, TEventArgs e)
-            where TEventArgs : System.EventArgs { }
-        public static FakeItEasy.Core.Raise<TEventArgs> With<TEventArgs>(TEventArgs e)
-            where TEventArgs : System.EventArgs { }
+        public static FakeItEasy.Core.Raise<TEventArgs> With<TEventArgs>(object sender, TEventArgs e) { }
+        public static FakeItEasy.Core.Raise<TEventArgs> With<TEventArgs>(TEventArgs e) { }
         public static TEventHandler With<TEventHandler>(params object[] arguments) { }
         public static FakeItEasy.Core.Raise<System.EventArgs> WithEmpty() { }
     }
@@ -448,8 +446,7 @@ namespace FakeItEasy.Core
         void OnAfterCallIntercepted(FakeItEasy.Core.ICompletedFakeObjectCall interceptedCall, FakeItEasy.Core.IFakeObjectCallRule ruleThatWasApplied);
         void OnBeforeCallIntercepted(FakeItEasy.Core.IFakeObjectCall interceptedCall);
     }
-    public class Raise<TEventArgs> : FakeItEasy.Core.IEventRaiserArgumentProvider
-        where TEventArgs : System.EventArgs { }
+    public class Raise<TEventArgs> : FakeItEasy.Core.IEventRaiserArgumentProvider { }
 }
 namespace FakeItEasy.Creation
 {


### PR DESCRIPTION
Fixes #361.