### PR TITLE
Use Type.ToString() instead of Type.FullName in call descriptions

### DIFF
--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -169,7 +169,7 @@ namespace FakeItEasy
         /// <returns>A dummy value.</returns>
         public static T IsInstanceOf<T>(this IArgumentConstraintManager<T> manager, Type type)
         {
-            return manager.NullCheckedMatches(x => type.IsAssignableFrom(x.GetType()), x => x.Write("Instance of ").Write(type.FullName));
+            return manager.NullCheckedMatches(x => type.IsAssignableFrom(x.GetType()), x => x.Write("Instance of ").Write(type.ToString()));
         }
 
         /// <summary>

--- a/src/FakeItEasy/Configuration/AnyCallCallRule.cs
+++ b/src/FakeItEasy/Configuration/AnyCallCallRule.cs
@@ -23,7 +23,7 @@ namespace FakeItEasy.Configuration
             {
                 if (this.ApplicableToMembersWithReturnType != null)
                 {
-                    return "Any call with return type {0} to the fake object.".FormatInvariant(this.ApplicableToMembersWithReturnType.FullName);
+                    return "Any call with return type {0} to the fake object.".FormatInvariant(this.ApplicableToMembersWithReturnType.ToString());
                 }
 
                 if (this.ApplicableToAllNonVoidReturnTypes)

--- a/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
@@ -87,7 +87,7 @@ namespace FakeItEasy.Core
                     return false;
                 }
 
-                fakeObjectCall.SetReturnValue("Faked {0}".FormatInvariant(this.fakeManager.FakeObjectType.FullName));
+                fakeObjectCall.SetReturnValue("Faked {0}".FormatInvariant(this.fakeManager.FakeObjectType.ToString()));
 
                 return true;
             }

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
@@ -41,7 +41,7 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
             {
                 FakeManager manager = Fake.TryGetFakeManager(this.ExpectedValue);
                 return manager != null
-                    ? $"Faked {manager.FakeObjectType.FullName}"
+                    ? $"Faked {manager.FakeObjectType.ToString()}"
                     : this.ExpectedValue.GetType().ToString();
             }
         }

--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -64,7 +64,7 @@ namespace FakeItEasy.Expressions
         {
             var result = new StringBuilder();
 
-            result.Append(this.Method.DeclaringType.FullName);
+            result.Append(this.Method.DeclaringType);
             result.Append(".");
             result.Append(this.Method.Name);
             result.Append(this.Method.GetGenericArgumentsCSharp());

--- a/src/FakeItEasy/FakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/FakeObjectCallExtensions.cs
@@ -78,7 +78,7 @@ namespace FakeItEasy
         internal static string GetDescription(this IFakeObjectCall fakeObjectCall)
         {
             var method = fakeObjectCall.Method;
-            return "{0}.{1}({2})".FormatInvariant(method.DeclaringType.FullName, method.Name, GetParametersString(fakeObjectCall));
+            return "{0}.{1}({2})".FormatInvariant(method.DeclaringType.ToString(), method.Name, GetParametersString(fakeObjectCall));
         }
 
         private static string GetParametersString(IFakeObjectCall fakeObjectCall)

--- a/src/FakeItEasy/TypeExtensions.cs
+++ b/src/FakeItEasy/TypeExtensions.cs
@@ -19,10 +19,10 @@ namespace FakeItEasy
 
             if (!type.GetTypeInfo().IsGenericType)
             {
-                return type.FullName;
+                return type.ToString();
             }
 
-            var partName = type.FullName.Split('`')[0];
+            var partName = type.ToString().Split('`')[0];
             var genericArgNames = type.GetGenericArguments().Select(arg => arg.FullNameCSharp()).ToArray();
             return string.Format(CultureInfo.InvariantCulture, "{0}<{1}>", partName, string.Join(", ", genericArgNames));
         }

--- a/src/FakeItEasy/ValueProducerSignatureHelper.cs
+++ b/src/FakeItEasy/ValueProducerSignatureHelper.cs
@@ -46,7 +46,7 @@ namespace FakeItEasy
 
         private static string BuildSignatureDescription(MethodInfo method)
         {
-            return method.GetParameters().ToCollectionString(x => x.ParameterType.FullName, ", ");
+            return method.GetParameters().ToCollectionString(x => x.ParameterType.ToString(), ", ");
         }
     }
 }

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -236,7 +236,7 @@ namespace FakeItEasy.Specs
                 .x(() => exception.Message.Should().Match(@"
 
   Assertion failed for the following call:
-    System.Collections.Generic.IDictionary`2[[System.String, *, Version=4.0.0.0, Culture=neutral, PublicKeyToken=*],[System.String, *, Version=4.0.0.0, Culture=neutral, PublicKeyToken=*]].TryGetValue(""any key"", <out parameter>)
+    System.Collections.Generic.IDictionary`2[System.String,System.String].TryGetValue(""any key"", <out parameter>)
   Expected to find it at least once but no calls were made to the fake object.
 
 "));
@@ -479,27 +479,24 @@ namespace FakeItEasy.Specs
 
         public static IEnumerable<object[]> Fakes()
         {
-            yield return new object[] { A.Fake<object>(), "Faked " + typeof(object).FullName };
-            yield return new object[] { A.Fake<object>(), "Faked " + typeof(object).ToString() };
-            yield return new object[] { A.Fake<List<int>>(), "Faked " + typeof(List<int>).FullName };
-            yield return new object[] { A.Fake<IList<int>>(), "Faked " + typeof(IList<int>).FullName };
+            yield return new object[] { A.Fake<object>(), "Faked " + typeof(object) };
+            yield return new object[] { A.Fake<List<int>>(), "Faked " + typeof(List<int>) };
+            yield return new object[] { A.Fake<IList<int>>(), "Faked " + typeof(IList<int>) };
             yield return new object[] { A.Fake<Action<int>>(), typeof(Action<int>).ToString() };
         }
 
         public static IEnumerable<object[]> FakesWithBadToString()
         {
-            yield return new object[] { A.Fake<object>(), "Faked " + typeof(object).FullName };
-            yield return new object[] { A.Fake<object>(), "Faked " + typeof(object).ToString() };
-            yield return new object[] { A.Fake<List<int>>(), "Faked " + typeof(List<int>).FullName };
-            yield return new object[] { A.Fake<IList<int>>(), "Faked " + typeof(IList<int>).FullName };
+            yield return new object[] { A.Fake<object>(), "Faked " + typeof(object) };
+            yield return new object[] { A.Fake<List<int>>(), "Faked " + typeof(List<int>) };
+            yield return new object[] { A.Fake<IList<int>>(), "Faked " + typeof(IList<int>) };
         }
 
         public static IEnumerable<object[]> StrictFakes()
         {
-            yield return new object[] { new Func<object>(() => A.Fake<object>(o => o.Strict())), "Faked " + typeof(object).FullName };
-            yield return new object[] { new Func<object>(() => A.Fake<object>(o => o.Strict())), "Faked " + typeof(object).ToString() };
-            yield return new object[] { new Func<object>(() => A.Fake<List<int>>(o => o.Strict())), "Faked " + typeof(List<int>).FullName };
-            yield return new object[] { new Func<object>(() => A.Fake<IList<int>>(o => o.Strict())), "Faked " + typeof(IList<int>).FullName };
+            yield return new object[] { new Func<object>(() => A.Fake<object>(o => o.Strict())), "Faked " + typeof(object) };
+            yield return new object[] { new Func<object>(() => A.Fake<List<int>>(o => o.Strict())), "Faked " + typeof(List<int>) };
+            yield return new object[] { new Func<object>(() => A.Fake<IList<int>>(o => o.Strict())), "Faked " + typeof(IList<int>) };
             yield return new object[] { new Func<object>(() => A.Fake<Action<int>>(o => o.Strict())), typeof(Action<int>).ToString() };
         }
 

--- a/tests/FakeItEasy.Tests/NullGuardedAssertion.cs
+++ b/tests/FakeItEasy.Tests/NullGuardedAssertion.cs
@@ -297,7 +297,7 @@ namespace FakeItEasy.Tests
                             }
                             else
                             {
-                                description.Write("threw unexpected {0}.".FormatInvariant(this.thrown.GetType().FullName));
+                                description.Write("threw unexpected {0}.".FormatInvariant(this.thrown.GetType().ToString()));
                             }
                         }
                     }
@@ -346,9 +346,9 @@ namespace FakeItEasy.Tests
                 }
 
 #if FEATURE_NETCORE_REFLECTION
-                protected override string CallDescription => this.constructorInfo.DeclaringType.FullName + ".ctor";
+                protected override string CallDescription => this.constructorInfo.DeclaringType.ToString() + ".ctor";
 #else
-                protected override string CallDescription => this.constructorInfo.ReflectedType.FullName + ".ctor";
+                protected override string CallDescription => this.constructorInfo.ReflectedType.ToString() + ".ctor";
 #endif
 
                 protected override void PerformCall(object[] arguments)


### PR DESCRIPTION
Fixes #994 