### PR TITLE
Improved docs: Added .NET Standard 1.6 as supported platform

### DIFF
--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -3,3 +3,4 @@
 FakeItEasy officially supports the following platforms:
 
 * .NET Framework 4.0 onwards
+* .NET Standard 1.6


### PR DESCRIPTION
Arising from a recent question in Gitter, I send in this pull request to improve the documentation that we officially support .NET Standard 1.6.