### PR TITLE
fix stylecop violation

### DIFF
--- a/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
+++ b/src/FakeItEasy/Core/FakeWrapperConfigurator.cs
@@ -13,9 +13,10 @@ namespace FakeItEasy.Core
     /// </summary>
     /// <typeparam name="T">The type of fake object generated.</typeparam>
     internal class FakeWrapperConfigurator<T>
-        : FakeOptionsBase<T>
 #if FEATURE_SELF_INITIALIZED_FAKES
-        , IFakeOptionsForWrappers<T>, IFakeOptionsForWrappers
+        : FakeOptionsBase<T>, IFakeOptionsForWrappers<T>, IFakeOptionsForWrappers
+#else
+        : FakeOptionsBase<T>
 #endif
     {
         private readonly IFakeOptions<T> fakeOptions;


### PR DESCRIPTION
- SA1001 : CSharp.Spacing : Invalid spacing around the comma.

connects to #914