### PR TITLE
Added more detailed object exception output for proxy and its tag

### DIFF
--- a/src/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
+++ b/src/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
@@ -26,7 +26,7 @@ namespace FakeItEasy.Core
 
             if (result == null)
             {
-                throw new ArgumentException("The specified object is not recognized as a fake object.");
+                throw new ArgumentException(string.Format(ExceptionMessages.NotRecognizedAsAFake, proxy.ToString(), proxy.GetType().FullNameCSharp()));
             }
 
             return result;

--- a/src/FakeItEasy/ExceptionMessages.Designer.cs
+++ b/src/FakeItEasy/ExceptionMessages.Designer.cs
@@ -252,6 +252,17 @@ namespace FakeItEasy {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Object is not recognised as a fake.
+        /// </summary>
+        internal static string NotRecognizedAsAFake
+        {
+            get
+            {
+                return ResourceManager.GetString("NotRecognizedAsAFake", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The Now-method on the event raise is not meant to be called directly, only use it to register to an event on a fake object that you want to be raised..
         /// </summary>
         internal static string NowCalledDirectly {

--- a/src/FakeItEasy/ExceptionMessages.resx
+++ b/src/FakeItEasy/ExceptionMessages.resx
@@ -208,4 +208,7 @@ The following constructors failed:
   <data name="FakeManagerWasInitializedWithDifferentProxyMessage" xml:space="preserve">
     <value>The fake manager was initialized for a different proxy.</value>
   </data>
+  <data name="NotRecognizedAsAFake" xml:space="preserve">
+    <value>Object '{0}' of type '{1}' is not recognized as a fake object.</value>
+  </data>
 </root>

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -203,7 +203,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("The specified object is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -219,7 +219,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("The specified object is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -251,7 +251,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("The specified object is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -283,7 +283,7 @@ namespace FakeItEasy.Specs
 
              "Then it throws an argument exception"
                 .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                    .And.Message.Should().Contain("The specified object is not recognized as a fake object."));
+                    .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -315,7 +315,7 @@ namespace FakeItEasy.Specs
 
              "Then it throws an argument exception"
                 .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                    .And.Message.Should().Contain("The specified object is not recognized as a fake object."));
+                    .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -347,7 +347,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("The specified object is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -379,7 +379,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("The specified object is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' is not recognized as a fake object."));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Tests/Core/DefaultFakeManagerAccessorTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DefaultFakeManagerAccessorTests.cs
@@ -99,7 +99,7 @@ namespace FakeItEasy.Tests.Core
             // Assert
             exception.Should()
                 .BeAnExceptionOfType<ArgumentException>()
-                .WithMessage("The specified object is not recognized as a fake object.");
+                .And.Message.Should().Match("Object 'Faked FakeItEasy.Creation.ITaggable' of type 'Castle.Proxies.ObjectProxy*' is not recognized as a fake object.");
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace FakeItEasy.Tests.Core
             // Assert
             exception.Should()
                 .BeAnExceptionOfType<ArgumentException>()
-                .WithMessage("The specified object is not recognized as a fake object.");
+                .And.Message.Should().Match("Object 'Faked FakeItEasy.Creation.ITaggable' of type 'Castle.Proxies.ObjectProxy*' is not recognized as a fake object.");
         }
     }
 }


### PR DESCRIPTION
Fixes #530.

Added more detailed object exception output for proxy and its tag when they are not recognized as a fake, and moved the exception message to the resx. Adjusted unit tests to match.