### PR TITLE
Enable test parallelization

### DIFF
--- a/tests/FakeItEasy.IntegrationTests/FakeItEasy.IntegrationTests.csproj
+++ b/tests/FakeItEasy.IntegrationTests/FakeItEasy.IntegrationTests.csproj
@@ -83,7 +83,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExceptionMessagesTests.cs" />
-    <Compile Include="Properties\XunitAssemblyInfo.cs" />
     <Compile Include="TypeCatalogueTests.cs" />
     <Compile Include="BootstrapperLocatorTests.cs" />
     <Compile Include="DoubleArgumentValueFormatter.cs" />

--- a/tests/FakeItEasy.IntegrationTests/Properties/XunitAssemblyInfo.cs
+++ b/tests/FakeItEasy.IntegrationTests/Properties/XunitAssemblyInfo.cs
@@ -1,1 +1,0 @@
-[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -100,7 +100,6 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="CreationSpecs.cs" />
     <Compile Include="DomainEvents.cs" />
-    <Compile Include="Properties\XunitAssemblyInfo.cs" />
     <Compile Include="SelfInitializedFakesSpecs.cs" />
     <Compile Include="LazySpecs.cs" />
     <Compile Include="DummyFactorySpecs.cs" />

--- a/tests/FakeItEasy.Specs/Properties/XunitAssemblyInfo.cs
+++ b/tests/FakeItEasy.Specs/Properties/XunitAssemblyInfo.cs
@@ -1,1 +1,0 @@
-[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/FakeItEasy.Tests/FakeItEasy.Tests.csproj
+++ b/tests/FakeItEasy.Tests/FakeItEasy.Tests.csproj
@@ -102,7 +102,6 @@
     <Compile Include="AutoInitializedFixture.cs" />
     <Compile Include="ArgumentConstraintTestBase.of.T.cs" />
     <Compile Include="ACallToTests.cs" />
-    <Compile Include="Properties\XunitAssemblyInfo.cs" />
     <Compile Include="RepeatConfigurationExtensionsTests.cs" />
     <Compile Include="ArgumentValidationConfigurationExtensionsTests.cs" />
     <Compile Include="AssertConfigurationExtensionsTests.cs" />

--- a/tests/FakeItEasy.Tests/Properties/XunitAssemblyInfo.cs
+++ b/tests/FakeItEasy.Tests/Properties/XunitAssemblyInfo.cs
@@ -1,1 +1,0 @@
-[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
Fixes #774.

As discussed with @blairconrad in chat

~~Some unit tests couldn't run in parallel because they mutated global state (`ServiceLocator.Current`). Making them part of the same test collection fixes the problem.~~ (fixed in #1029)

Specs and integration tests seem to have no problem running in parallel.