### PR TITLE
Disable CA1822 code analysis warning

### DIFF
--- a/tests/FakeItEasy.Tests.ruleset
+++ b/tests/FakeItEasy.Tests.ruleset
@@ -23,6 +23,7 @@
     <Rule Id="CA1709" Action="None" />
     <Rule Id="CA1716" Action="None" />
     <Rule Id="CA1720" Action="None" />
+    <Rule Id="CA1822" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2204" Action="None" />
     <Rule Id="CA2210" Action="None" />


### PR DESCRIPTION
It was mistakenly re-enabled in #1026 
