### PR TITLE
Deprecate FakeObjectCallExtensions.Write and .WriteToConsole

### DIFF
--- a/src/FakeItEasy/FakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/FakeObjectCallExtensions.cs
@@ -51,6 +51,7 @@ namespace FakeItEasy
         /// <typeparam name="T">The type of the calls.</typeparam>
         /// <param name="calls">The calls to write.</param>
         /// <param name="writer">The writer to write the calls to.</param>
+        [Obsolete("This feature will be removed in version 4.0.0.")]
         public static void Write<T>(this IEnumerable<T> calls, IOutputWriter writer) where T : IFakeObjectCall
         {
             Guard.AgainstNull(calls, nameof(calls));
@@ -65,6 +66,7 @@ namespace FakeItEasy
         /// </summary>
         /// <typeparam name="T">The type of the calls.</typeparam>
         /// <param name="calls">The calls to write.</param>
+        [Obsolete("This feature will be removed in version 4.0.0.")]
         public static void WriteToConsole<T>(this IEnumerable<T> calls) where T : IFakeObjectCall
         {
             calls.Write(new DefaultOutputWriter(Console.Write));

--- a/tests/FakeItEasy.Specs/ObjectCallSpecs.cs
+++ b/tests/FakeItEasy.Specs/ObjectCallSpecs.cs
@@ -31,8 +31,10 @@
             "And I query the fake for its calls"
                 .x(() => calls = Fake.GetCalls(fake));
 
+#pragma warning disable CS0618 // Type or member is obsolete
             "When I write the calls to the output writer"
                 .x(() => calls.Write(writer));
+#pragma warning restore CS0618 // Type or member is obsolete
 
             "Then the output lists the call"
                 .x(() => writer.ToString().Should().Be("1: FakeItEasy.Specs.ObjectCallSpecs+IFoo.VoidMethod()\r\n"));
@@ -56,8 +58,10 @@
             "And I query the fake for its calls"
                 .x(() => calls = Fake.GetCalls(fake));
 
+#pragma warning disable CS0618 // Type or member is obsolete
             "When I write the calls to the output writer"
                 .x(() => calls.Write(writer));
+#pragma warning restore CS0618 // Type or member is obsolete
 
             "Then the output lists the calls"
                 .x(() => writer.ToString().Should().Be(

--- a/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval.netstd/ApiApproval.ApproveApiNetStd.approved.txt
@@ -161,8 +161,10 @@ namespace FakeItEasy
     {
         public static T GetArgument<T>(this FakeItEasy.Core.IFakeObjectCall call, int argumentIndex) { }
         public static T GetArgument<T>(this FakeItEasy.Core.IFakeObjectCall call, string argumentName) { }
+        [System.ObsoleteAttribute("This feature will be removed in version 4.0.0.")]
         public static void Write<T>(this System.Collections.Generic.IEnumerable<T> calls, FakeItEasy.IOutputWriter writer)
             where T : FakeItEasy.Core.IFakeObjectCall { }
+        [System.ObsoleteAttribute("This feature will be removed in version 4.0.0.")]
         public static void WriteToConsole<T>(this System.Collections.Generic.IEnumerable<T> calls)
             where T : FakeItEasy.Core.IFakeObjectCall { }
     }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi.approved.txt
@@ -238,8 +238,10 @@ namespace FakeItEasy
     {
         public static T GetArgument<T>(this FakeItEasy.Core.IFakeObjectCall call, int argumentIndex) { }
         public static T GetArgument<T>(this FakeItEasy.Core.IFakeObjectCall call, string argumentName) { }
+        [System.ObsoleteAttribute("This feature will be removed in version 4.0.0.")]
         public static void Write<T>(this System.Collections.Generic.IEnumerable<T> calls, FakeItEasy.IOutputWriter writer)
             where T : FakeItEasy.Core.IFakeObjectCall { }
+        [System.ObsoleteAttribute("This feature will be removed in version 4.0.0.")]
         public static void WriteToConsole<T>(this System.Collections.Generic.IEnumerable<T> calls)
             where T : FakeItEasy.Core.IFakeObjectCall { }
     }

--- a/tests/FakeItEasy.Tests/FakeObjectCallExtensionsTests.cs
+++ b/tests/FakeItEasy.Tests/FakeObjectCallExtensionsTests.cs
@@ -121,7 +121,9 @@ namespace FakeItEasy.Tests
         [Fact]
         public void Write_should_be_null_guarded()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Expression<System.Action> call = () => Enumerable.Empty<IFakeObjectCall>().Write(A.Dummy<IOutputWriter>());
+#pragma warning restore CS0618 // Type or member is obsolete
             call.Should().BeNullGuarded();
         }
 
@@ -133,7 +135,9 @@ namespace FakeItEasy.Tests
             // Act
 
             // Assert
+#pragma warning disable CS0618 // Type or member is obsolete
             Expression<System.Action> call = () => Enumerable.Empty<IFakeObjectCall>().WriteToConsole();
+#pragma warning restore CS0618 // Type or member is obsolete
             call.Should().BeNullGuarded();
         }
 


### PR DESCRIPTION
Fixes #1030 