### PR TITLE
Fix code analysis warning

### DIFF
--- a/src/FakeItEasy/Configuration/ArgumentCollection.cs
+++ b/src/FakeItEasy/Configuration/ArgumentCollection.cs
@@ -38,7 +38,7 @@ namespace FakeItEasy.Configuration
 
             if (arguments.Length != argumentNames.Length)
             {
-                throw new ArgumentException(ExceptionMessages.WrongNumberOfArgumentNames, nameof(argumentNames));
+                throw new ArgumentException(ExceptionMessages.WrongNumberOfArguments);
             }
 
             this.arguments = arguments;

--- a/src/FakeItEasy/ExceptionMessages.cs
+++ b/src/FakeItEasy/ExceptionMessages.cs
@@ -17,8 +17,8 @@
         public static string NumberOfOutAndRefParametersDoesNotMatchCall =>
             "The number of values for out and ref parameters specified does not match the number of out and ref parameters in the call.";
 
-        public static string WrongNumberOfArgumentNames =>
-            "The number of argument names does not match the number of arguments.";
+        public static string WrongNumberOfArguments =>
+            "The number of arguments does not match the number of parameters of the method.";
 
         public static string MethodMissmatchWhenPlayingBackRecording =>
             "The method of the call did not match the method of the recorded call, the recorded sequence is no longer valid.";


### PR DESCRIPTION
CA2208: Instantiate argument exceptions correctly

I remove the parameter name, because it's not one argument that is incorrect, but the fact that the arguments are mismatched. I also changed the exception message which no longer made sense.