### PR TITLE
specify VS2015 in config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '{build}'
+image: Visual Studio 2015
 
 pull_requests:
   do_not_increment_build_number: true


### PR DESCRIPTION
We should really specify this in config, rather than relying on the UI.