### PR TITLE
Deploy to NuGet on tag creation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,3 +26,11 @@ test: off
 
 artifacts:
     - path: .\artifacts\*\*
+
+deploy:
+    - provider: NuGet
+      api_key:
+          secure: dp94z3SQBsL1aBqjCdpw4Hlb5Va0XAJQwkjHSu5kJplmxTge8los8LBdbHI72kMi
+      skip_symbols: true
+      on:
+          appveyor_repo_tag: true


### PR DESCRIPTION
I generated a new API key just for AppVeyor. 
If I read things right, this is all we need for #1039, except to update instructions in #1015.
Of course, it's completely untested…