### PR TITLE
Rationalize use of quotation marks

### DIFF
--- a/src/FakeItEasy.Analyzer.CSharp/Resources.Designer.cs
+++ b/src/FakeItEasy.Analyzer.CSharp/Resources.Designer.cs
@@ -71,7 +71,7 @@ namespace FakeItEasy.Analyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Non virtual member &apos;{0}&apos; cannot be intercepted..
+        ///   Looks up a localized string similar to Non virtual member {0} cannot be intercepted..
         /// </summary>
         internal static string NonVirtualSetupSpecificationMessageFormat {
             get {

--- a/src/FakeItEasy.Analyzer.CSharp/Resources.resx
+++ b/src/FakeItEasy.Analyzer.CSharp/Resources.resx
@@ -122,7 +122,7 @@
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
   <data name="NonVirtualSetupSpecificationMessageFormat" xml:space="preserve">
-    <value>Non virtual member '{0}' cannot be intercepted.</value>
+    <value>Non virtual member {0} cannot be intercepted.</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
   <data name="NonVirtualSetupSpecificationTitle" xml:space="preserve">

--- a/src/FakeItEasy.Analyzer.VisualBasic/Resources.Designer.cs
+++ b/src/FakeItEasy.Analyzer.VisualBasic/Resources.Designer.cs
@@ -71,7 +71,7 @@ namespace FakeItEasy.Analyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Non overridable member &apos;{0}&apos; cannot be intercepted..
+        ///   Looks up a localized string similar to Non overridable member {0} cannot be intercepted..
         /// </summary>
         internal static string NonVirtualSetupSpecificationMessageFormat {
             get {

--- a/src/FakeItEasy.Analyzer.VisualBasic/Resources.resx
+++ b/src/FakeItEasy.Analyzer.VisualBasic/Resources.resx
@@ -122,7 +122,7 @@
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
   <data name="NonVirtualSetupSpecificationMessageFormat" xml:space="preserve">
-    <value>Non overridable member '{0}' cannot be intercepted.</value>
+    <value>Non overridable member {0} cannot be intercepted.</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
   <data name="NonVirtualSetupSpecificationTitle" xml:space="preserve">

--- a/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
+++ b/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
@@ -38,8 +38,7 @@ namespace FakeItEasy.Configuration
                                                 "' refers to an indexed property that does not have a setter.");
                 }
 
-                throw new ArgumentException(
-                    "The property '" + propertyName + "' does not have a setter.");
+                throw new ArgumentException($"The property {propertyName} does not have a setter.");
             }
 
             var originalParameterInfos = indexerSetterInfo.GetParameters();

--- a/src/FakeItEasy/Core/DefaultExceptionThrower.cs
+++ b/src/FakeItEasy/Core/DefaultExceptionThrower.cs
@@ -15,9 +15,9 @@ namespace FakeItEasy.Core
 
             message
                 .AppendLine()
-                .AppendIndented("  ", "Failed to create fake of type \"")
+                .AppendIndented("  ", "Failed to create fake of type ")
                 .Append(typeOfFake)
-                .AppendLine("\" with the specified arguments for the constructor:")
+                .AppendLine(" with the specified arguments for the constructor:")
                 .AppendIndented("    ", reasonForFailure)
                 .AppendLine();
 
@@ -30,9 +30,9 @@ namespace FakeItEasy.Core
 
             message
                 .AppendLine()
-                .AppendIndented("  ", "Failed to create fake of type \"")
+                .AppendIndented("  ", "Failed to create fake of type ")
                 .Append(typeOfFake)
-                .AppendLine("\".")
+                .AppendLine(".")
                 .AppendLine()
                 .AppendIndented("  ", "Below is a list of reasons for failure per attempted constructor:")
                 .AppendLine()

--- a/src/FakeItEasy/Core/DefaultFixtureInitializer.cs
+++ b/src/FakeItEasy/Core/DefaultFixtureInitializer.cs
@@ -31,7 +31,7 @@ namespace FakeItEasy.Core
 
             if (CountIsNoMoreThanOne(allSettersTaggedUnderTest))
             {
-                throw new InvalidOperationException("A fake fixture can only contain one member marked \"under test\".");
+                throw new InvalidOperationException($"A fake fixture can only contain one member marked with {nameof(UnderTestAttribute)}.");
             }
 
             return allSettersTaggedUnderTest.SingleOrDefault();

--- a/src/FakeItEasy/Creation/CastleDynamicProxy/DynamicProxyMessages.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/DynamicProxyMessages.cs
@@ -11,7 +11,7 @@
             "Arguments for constructor specified for interface type.";
 
         public static string ProxyIsSealedType(Type type) =>
-            $@"The type of proxy ""{type}"" is sealed.";
+            $"The type of proxy {type} is sealed.";
 
         public static string ProxyIsValueType(Type type) =>
             $"The type of proxy must be an interface or a class but it was {type}.";

--- a/src/FakeItEasy/Creation/ProxyOptions.cs
+++ b/src/FakeItEasy/Creation/ProxyOptions.cs
@@ -27,7 +27,7 @@ namespace FakeItEasy.Creation
 
             if (!interfaceType.GetTypeInfo().IsInterface)
             {
-                throw new ArgumentException($"The specified type '{interfaceType.FullNameCSharp()}' is not an interface");
+                throw new ArgumentException($"The specified type {interfaceType.FullNameCSharp()} is not an interface");
             }
 
             this.additionalInterfacesToImplement.Add(interfaceType);

--- a/src/FakeItEasy/DummyFactory.cs
+++ b/src/FakeItEasy/DummyFactory.cs
@@ -50,7 +50,7 @@ namespace FakeItEasy
         {
             if (type != typeof(T))
             {
-                var message = $"The {this.GetType()} can only create dummies of type '{typeof(T)}'.";
+                var message = $"The {this.GetType()} can only create dummies of type {typeof(T)}.";
 
                 throw new ArgumentException(message, nameof(type));
             }

--- a/src/FakeItEasy/ExceptionMessages.cs
+++ b/src/FakeItEasy/ExceptionMessages.cs
@@ -33,7 +33,7 @@
             $"Supplied constructor is for type {actualConstructorType.FullNameCSharp()}, but must be for {expectedConstructorType.FullNameCSharp()}.";
 
         public static string NotRecognizedAsAFake(object proxy, Type type) =>
-            $"Object '{proxy}' of type '{type.FullNameCSharp()}' is not recognized as a fake object.";
+            $"Object '{proxy}' of type {type.FullNameCSharp()} is not recognized as a fake object.";
 
         public static string CallToUnconfiguredMethodOfStrictFake(IFakeObjectCall call)
         {

--- a/src/FakeItEasy/FakeOptionsBuilder.cs
+++ b/src/FakeItEasy/FakeOptionsBuilder.cs
@@ -46,7 +46,7 @@ namespace FakeItEasy
             if (!((IFakeOptionsBuilder)this).CanBuildOptionsForFakeOfType(typeOfFake))
             {
                 throw new InvalidOperationException(
-                    $"Specified type '{typeOfFake.FullNameCSharp()}' is not valid. Only '{typeof(TFake).FullNameCSharp()}' is allowed.");
+                    $"Specified type {typeOfFake.FullNameCSharp()} is not valid. Only {typeof(TFake).FullNameCSharp()} is allowed.");
             }
 
             this.BuildOptions((IFakeOptions<TFake>)options);

--- a/src/FakeItEasy/IoC/DictionaryContainer.cs
+++ b/src/FakeItEasy/IoC/DictionaryContainer.cs
@@ -35,7 +35,7 @@ namespace FakeItEasy.IoC
 
             if (!this.registeredServices.TryGetValue(componentType, out creator))
             {
-                throw new KeyNotFoundException($"The specified service '{componentType}' was not registered in the container.");
+                throw new KeyNotFoundException($"The specified service {componentType} was not registered in the container.");
             }
 
             return creator.Invoke(this);

--- a/tests/FakeItEasy.Analyzer.CSharp.Tests/NonVirtualSetupAnalyzerTests.cs
+++ b/tests/FakeItEasy.Analyzer.CSharp.Tests/NonVirtualSetupAnalyzerTests.cs
@@ -154,7 +154,7 @@ namespace FakeItEasy.Analyzer.Tests
                 {
                     Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
                     Message =
-                        "Non virtual member 'Bar' cannot be intercepted.",
+                        "Non virtual member Bar cannot be intercepted.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 28) }
                 });
@@ -194,7 +194,7 @@ namespace FakeItEasy.Analyzer.Tests
      {
          Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
          Message =
-             "Non virtual member 'Bar' cannot be intercepted.",
+             "Non virtual member Bar cannot be intercepted.",
          Severity = DiagnosticSeverity.Warning,
          Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 28) }
      });
@@ -233,7 +233,7 @@ namespace AnalyzerPrototypeSubjectStatic
     {
         Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
         Message =
-            "Non virtual member 'Bar' cannot be intercepted.",
+            "Non virtual member Bar cannot be intercepted.",
         Severity = DiagnosticSeverity.Warning,
         Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 26) }
             });
@@ -271,7 +271,7 @@ namespace AnalyzerPrototypeSubjectStatic
         {
             Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
             Message =
-             "Non virtual member 'Bar' cannot be intercepted.",
+             "Non virtual member Bar cannot be intercepted.",
             Severity = DiagnosticSeverity.Warning,
             Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 28) }
         });
@@ -379,7 +379,7 @@ namespace PrototypeProperty
                 {
                     Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
                     Message =
-                        "Non virtual member 'Bar' cannot be intercepted.",
+                        "Non virtual member Bar cannot be intercepted.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 31) }
                 });
@@ -418,7 +418,7 @@ namespace PrototypeProperty
                 {
                     Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
                     Message =
-                     "Non virtual member 'DifferentNameThanOtherTests' cannot be intercepted.",
+                     "Non virtual member DifferentNameThanOtherTests cannot be intercepted.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 28) }
                 });

--- a/tests/FakeItEasy.Analyzer.VisualBasic.Tests/NonOverridableSetupAnalyzerTests.cs
+++ b/tests/FakeItEasy.Analyzer.VisualBasic.Tests/NonOverridableSetupAnalyzerTests.cs
@@ -134,7 +134,7 @@ End Namespace
                 {
                     Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
                     Message =
-                        "Non overridable member 'Bar' cannot be intercepted.",
+                        "Non overridable member Bar cannot be intercepted.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation("Test0.vb", 6, 33) }
                 });
@@ -165,7 +165,7 @@ End Namespace
                 {
                     Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
                     Message =
-                        "Non overridable member 'Bar' cannot be intercepted.",
+                        "Non overridable member Bar cannot be intercepted.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation("Test0.vb", 5, 33) }
                 });
@@ -199,7 +199,7 @@ End Namespace
                 {
                     Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
                     Message =
-                        "Non overridable member 'Bar' cannot be intercepted.",
+                        "Non overridable member Bar cannot be intercepted.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation("Test0.vb", 8, 26) }
                 });
@@ -231,7 +231,7 @@ End Namespace
                 {
                     Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
                     Message =
-                        "Non overridable member 'Bar' cannot be intercepted.",
+                        "Non overridable member Bar cannot be intercepted.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation("Test0.vb", 6, 33) }
                 });
@@ -332,7 +332,7 @@ End Namespace
                 {
                     Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
                     Message =
-                        "Non overridable member 'Bar' cannot be intercepted.",
+                        "Non overridable member Bar cannot be intercepted.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation("Test0.vb", 6, 36) }
                 });
@@ -364,7 +364,7 @@ End Namespace";
                 {
                     Id = DiagnosticDefinitions.NonVirtualSetupSpecification.Id,
                     Message =
-                        "Non overridable member 'DifferentNameThanOtherTests' cannot be intercepted.",
+                        "Non overridable member DifferentNameThanOtherTests cannot be intercepted.",
                     Severity = DiagnosticSeverity.Warning,
                     Locations = new[] { new DiagnosticResultLocation("Test0.vb", 6, 28) }
                 });

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -203,7 +203,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type FakeItEasy.Specs.ConfigurationSpecs+BaseClass is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -219,7 +219,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type FakeItEasy.Specs.ConfigurationSpecs+BaseClass is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -251,7 +251,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type FakeItEasy.Specs.ConfigurationSpecs+DerivedClass is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -283,7 +283,7 @@ namespace FakeItEasy.Specs
 
              "Then it throws an argument exception"
                 .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                    .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' is not recognized as a fake object."));
+                    .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type FakeItEasy.Specs.ConfigurationSpecs+BaseClass is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -315,7 +315,7 @@ namespace FakeItEasy.Specs
 
              "Then it throws an argument exception"
                 .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                    .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' is not recognized as a fake object."));
+                    .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type FakeItEasy.Specs.ConfigurationSpecs+DerivedClass is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -347,7 +347,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type FakeItEasy.Specs.ConfigurationSpecs+BaseClass is not recognized as a fake object."));
         }
 
         [Scenario]
@@ -379,7 +379,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' is not recognized as a fake object."));
+                   .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type FakeItEasy.Specs.ConfigurationSpecs+DerivedClass is not recognized as a fake object."));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Specs/ConfiguringPropertySetterSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfiguringPropertySetterSpecs.cs
@@ -36,7 +36,7 @@ namespace FakeItEasy.Specs
             "Then an argument null exception is thrown"
                 .x(() => exception.Should().BeAnExceptionOfType<ArgumentNullException>());
 
-            "And the parameter name is 'propertySpecification'"
+            "And the parameter name is propertySpecification"
                 .x(() => exception.As<ArgumentNullException>().ParamName.Should().Be("propertySpecification"));
         }
 
@@ -71,7 +71,7 @@ namespace FakeItEasy.Specs
 
             "And the exception message indicates that the property is read-only"
                 .x(() => exception.Message.Should().Be(
-                    $"The property '{nameof(IHaveInterestingProperties.ReadOnlyProperty)}' does not have a setter."));
+                    $"The property {nameof(IHaveInterestingProperties.ReadOnlyProperty)} does not have a setter."));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Specs/CreationOptionsSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationOptionsSpecs.cs
@@ -649,7 +649,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws an argument exception"
                 .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                    .WithMessage("*The specified type 'System.String' is not an interface*"));
+                    .WithMessage("*The specified type System.String is not an interface*"));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Specs/SelfInitializedFakesSpecs.cs
+++ b/tests/FakeItEasy.Specs/SelfInitializedFakesSpecs.cs
@@ -218,7 +218,7 @@ namespace FakeItEasy.Specs
             // These results demonstrate that the self-initialized fake relies on a script
             // defined by which methods are called, without regard to the arguments
             // passed to the methods.
-            "And the playback fake returns results in 'recorded order'"
+            "And the playback fake returns results in recorded order"
                 .x(() => countsDuringPlayback.Should().Equal(0x2, 0x1));
         }
 

--- a/tests/FakeItEasy.Tests/Core/DefaultExceptionThrowerTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DefaultExceptionThrowerTests.cs
@@ -19,7 +19,7 @@ namespace FakeItEasy.Tests.Core
                     ReasonForFailureOfDefaultConstructor = "reason",
                     ResolvedConstructors = new ResolvedConstructor[] { },
                     ExpectedMessage = @"
-  Failed to create fake of type ""System.String"".
+  Failed to create fake of type System.String.
 
   Below is a list of reasons for failure per attempted constructor:
     No constructor arguments failed:
@@ -67,7 +67,7 @@ namespace FakeItEasy.Tests.Core
                         }
                     },
                     ExpectedMessage = @"
-  Failed to create fake of type ""System.Int32"".
+  Failed to create fake of type System.Int32.
 
   Below is a list of reasons for failure per attempted constructor:
     No constructor arguments failed:
@@ -134,7 +134,7 @@ namespace FakeItEasy.Tests.Core
                         }
                     },
                     ExpectedMessage = @"
-  Failed to create fake of type ""System.Int32"".
+  Failed to create fake of type System.Int32.
 
   Below is a list of reasons for failure per attempted constructor:
     No constructor arguments failed:
@@ -168,7 +168,7 @@ that spans a couple of lines.";
             // Assert
             var expectedMessage =
 @"
-  Failed to create fake of type ""System.String"" with the specified arguments for the constructor:
+  Failed to create fake of type System.String with the specified arguments for the constructor:
     a reason
     that spans a couple of lines.
 ";

--- a/tests/FakeItEasy.Tests/Core/DefaultFakeManagerAccessorTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DefaultFakeManagerAccessorTests.cs
@@ -99,7 +99,7 @@ namespace FakeItEasy.Tests.Core
             // Assert
             exception.Should()
                 .BeAnExceptionOfType<ArgumentException>()
-                .And.Message.Should().Match("Object 'Faked FakeItEasy.Creation.ITaggable' of type 'Castle.Proxies.ObjectProxy*' is not recognized as a fake object.");
+                .And.Message.Should().Match("Object 'Faked FakeItEasy.Creation.ITaggable' of type Castle.Proxies.ObjectProxy* is not recognized as a fake object.");
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace FakeItEasy.Tests.Core
             // Assert
             exception.Should()
                 .BeAnExceptionOfType<ArgumentException>()
-                .And.Message.Should().Match("Object 'Faked FakeItEasy.Creation.ITaggable' of type 'Castle.Proxies.ObjectProxy*' is not recognized as a fake object.");
+                .And.Message.Should().Match("Object 'Faked FakeItEasy.Creation.ITaggable' of type Castle.Proxies.ObjectProxy* is not recognized as a fake object.");
         }
     }
 }

--- a/tests/FakeItEasy.Tests/Core/DefaultFixtureInitializerTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DefaultFixtureInitializerTests.cs
@@ -154,7 +154,7 @@ namespace FakeItEasy.Tests.Core
 
             // Assert
             exception.Should().BeAnExceptionOfType<InvalidOperationException>()
-                .WithMessage("A fake fixture can only contain one member marked \"under test\".");
+                .WithMessage($"A fake fixture can only contain one member marked with {nameof(UnderTestAttribute)}.");
         }
 
         public class Sut

--- a/tests/FakeItEasy.Tests/Core/DummyFactoryTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DummyFactoryTests.cs
@@ -22,7 +22,7 @@ namespace FakeItEasy.Tests.Core
         public void Create_should_guard_against_bad_type_argument()
         {
             string expectedMessage = string.Format(
-                "The {0} can only create dummies of type '{1}'.*",
+                "The {0} can only create dummies of type {1}.*",
                 typeof(TestableFakeFactory),
                 typeof(SomeType));
 

--- a/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyGeneratorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyGeneratorTests.cs
@@ -197,7 +197,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             var result = this.generator.GenerateProxy(typeof(SealedType), A.Dummy<IEnumerable<Type>>(), A.Dummy<IEnumerable<object>>(), A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
-            result.ReasonForFailure.Should().Be("The type of proxy \"FakeItEasy.Tests.Creation.CastleDynamicProxy.CastleDynamicProxyGeneratorTests+SealedType\" is sealed.");
+            result.ReasonForFailure.Should().Be("The type of proxy FakeItEasy.Tests.Creation.CastleDynamicProxy.CastleDynamicProxyGeneratorTests+SealedType is sealed.");
         }
 
         [Fact]

--- a/tests/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
+++ b/tests/FakeItEasy.Tests/FakeOptionsBuilderTests.cs
@@ -23,7 +23,7 @@ namespace FakeItEasy.Tests
 
             // Assert
             exception.Should().BeAnExceptionOfType<InvalidOperationException>()
-                .WithMessage("Specified type 'System.String' is not valid. Only 'FakeItEasy.Tests.FakeOptionsBuilderTests' is allowed.");
+                .WithMessage("Specified type System.String is not valid. Only FakeItEasy.Tests.FakeOptionsBuilderTests is allowed.");
         }
 
         [Fact]

--- a/tests/FakeItEasy.Tests/NullGuardedAssertion.cs
+++ b/tests/FakeItEasy.Tests/NullGuardedAssertion.cs
@@ -292,7 +292,7 @@ namespace FakeItEasy.Tests
                             if (argumentNullException != null)
                             {
                                 description.Write(
-                                    $@"threw ArgumentNullException with wrong argument name, it should be ""{this.ArgumentName}"".");
+                                    $"threw ArgumentNullException with wrong argument name, it should be {this.ArgumentName}.");
                             }
                             else
                             {

--- a/tests/FakeItEasy.Tests/NullGuardedAssertionTests.cs
+++ b/tests/FakeItEasy.Tests/NullGuardedAssertionTests.cs
@@ -86,7 +86,7 @@ namespace FakeItEasy.Tests
         public void Assert_should_include_call_signature_and_missing_argument_name_in_error_message_when_ArgumentNullException_was_thrown_with_wrong_name()
         {
             AssertShouldFail(() => this.GuardedWithWrongName("foo")).And.Message.Should()
-                .Contain("(NULL) threw ArgumentNullException with wrong argument name, it should be \"a\".");
+                .Contain("(NULL) threw ArgumentNullException with wrong argument name, it should be a.");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1011:
- double quotes for string values
- no quotes when values cannot have spaces
- single quotes otherwise