### PR TITLE
Improve message for methods which cannot be intercepted

### DIFF
--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidator.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidator.cs
@@ -34,7 +34,7 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
                 var explicitImplementation = method.Name.Contains('.');
                 if (!explicitImplementation)
                 {
-                    return "Sealed methods can not be intercepted.";
+                    return "Non-virtual methods can not be intercepted. Virtual methods are methods explicitly marked virtual, overriding methods, abstract methods, and interface methods.";
                 }
             }
 
@@ -46,7 +46,7 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
                 }
                 else
                 {
-                    return "Static methods can not be intercepted.";
+                    return "Non-virtual methods can not be intercepted. Virtual methods are methods explicitly marked virtual, overriding methods, abstract methods, and interface methods.";
                 }
             }
 

--- a/tests/FakeItEasy.IntegrationTests/ExceptionMessagesTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/ExceptionMessagesTests.cs
@@ -21,7 +21,7 @@ namespace FakeItEasy.IntegrationTests
 @"
 
   The current proxy generator can not intercept the method System.Object.Equals(System.Object objA, System.Object objB) for the following reason:
-    - Static methods can not be intercepted.
+    - Non-virtual methods can not be intercepted. Virtual methods are methods explicitly marked virtual, overriding methods, abstract methods, and interface methods.
 
 ";
 

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -267,7 +267,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws a fake configuration exception"
                .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                   .And.Message.Should().Contain("Sealed methods can not be intercepted."));
+                   .And.Message.Should().Contain("Method should be marked as virtual, abstract or part of an Interface in oreder to be intercepted."));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -267,11 +267,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws a fake configuration exception"
                .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-<<<<<<< HEAD
-                   .And.Message.Should().Contain("Method should be marked as virtual, abstract or part of an Interface in oreder to be intercepted."));
-=======
                    .And.Message.Should().Contain("Method should be marked as virtual, abstract or part of an interface in order to be intercepted."));
->>>>>>> Improve helpful messages
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -331,7 +331,7 @@ namespace FakeItEasy.Specs
 
              "Then it throws a fake configuration exception"
                 .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                    .And.Message.Should().Contain("Sealed methods can not be intercepted."));
+                    .And.Message.Should().Contain("Method should be marked as virtual, abstract or part of an Interface in oreder to be intercepted."));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -267,7 +267,11 @@ namespace FakeItEasy.Specs
 
             "Then it throws a fake configuration exception"
                .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
+<<<<<<< HEAD
                    .And.Message.Should().Contain("Method should be marked as virtual, abstract or part of an Interface in oreder to be intercepted."));
+=======
+                   .And.Message.Should().Contain("Method should be marked as virtual, abstract or part of an interface in order to be intercepted."));
+>>>>>>> Improve helpful messages
         }
 
         [Scenario]
@@ -331,7 +335,7 @@ namespace FakeItEasy.Specs
 
              "Then it throws a fake configuration exception"
                 .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                    .And.Message.Should().Contain("Method should be marked as virtual, abstract or part of an Interface in oreder to be intercepted."));
+                    .And.Message.Should().Contain("Method should be marked as virtual, abstract or part of an interface in order to be intercepted."));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidatorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidatorTests.cs
@@ -45,7 +45,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
                     "Extension methods can not be intercepted since they're static."),
                 NonInterceptableTestCase.Create(
                     () => new TypeWithSealedOverride().ToString(),
-                    "Sealed methods can not be intercepted."));
+                    "Method should be marked as virtual, abstract or part of an Interface in oreder to be intercepted."));
         }
 
         public static IEnumerable<object[]> InterceptableMethods()

--- a/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidatorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidatorTests.cs
@@ -36,16 +36,16 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             return TestCases.FromObject(
                 NonInterceptableTestCase.Create(
                     () => new object().GetType(),
-                    "Non virtual methods can not be intercepted."),
+                    "Non-virtual methods can not be intercepted. Virtual methods are methods explicitly marked virtual, overriding methods, abstract methods, and interface methods."),
                 NonInterceptableTestCase.Create(
                     () => object.Equals("foo", "bar"),
-                    "Static methods can not be intercepted."),
+                    "Non-virtual methods can not be intercepted. Virtual methods are methods explicitly marked virtual, overriding methods, abstract methods, and interface methods."),
                 NonInterceptableTestCase.Create(
                     () => "foo".Count(),
                     "Extension methods can not be intercepted since they're static."),
                 NonInterceptableTestCase.Create(
                     () => new TypeWithSealedOverride().ToString(),
-                    "Method should be marked as virtual, abstract or part of an Interface in oreder to be intercepted."));
+                    "Non-virtual methods can not be intercepted. Virtual methods are methods explicitly marked virtual, overriding methods, abstract methods, and interface methods."));
         }
 
         public static IEnumerable<object[]> InterceptableMethods()


### PR DESCRIPTION
For newer C# programmers it is not always understood that "sealed" is the default behaviour. So hopefully this new message will explain in an actionable way how to proceed.

https://gitter.im/FakeItEasy/FakeItEasy?at=58eb83578fcce56b20ea41af