### PR TITLE
Fix 'suppress' style warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Try to keep lines of code no longer than 160 characters wide. This isn't a stric
 
 ## Coding Style
 
-Try to keep your coding style in line with the existing code. It might not exactly match your preferred style but it's better to keep things consistent. StyleCop compliance is enforced through analysis on each build and the treatment of warnings as errors. Any StyleCop settings changes or suppressions must be clearly justified.
+Try to keep your coding style in line with the existing code. It might not exactly match your preferred style but it's better to keep things consistent. Coding style compliance is enforced through analysis on each build. Any StyleCop.Analyzers settings changes or suppressions must be clearly justified.
 
 ## String Formatting
 

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -125,8 +125,7 @@ namespace FakeItEasy.Core
             this.interceptionListeners.AddFirst(listener);
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes",
-            Justification = "Explicit implementation to be able to make the IFakeCallProcessor interface internal.")]
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "Explicit implementation to be able to make the IFakeCallProcessor interface internal.")]
         void IFakeCallProcessor.Process(IInterceptedFakeObjectCall fakeObjectCall)
         {
             foreach (var listener in this.interceptionListeners)

--- a/src/FakeItEasy/FakeOptionsBuilder.cs
+++ b/src/FakeItEasy/FakeOptionsBuilder.cs
@@ -25,8 +25,7 @@ namespace FakeItEasy
         /// <c>true</c> if <paramref name="type"/> is <typeparamref name="TFake"/>.
         /// Otherwise <c>false</c>.
         /// </returns>
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes",
-            Justification = "Explicit implementation reduces the chance of misusing object. Explicit methods are superseded by BuildOptions(IFakeOptions<TFake>)")]
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "Explicit implementation reduces the chance of misusing object. Explicit methods are superseded by BuildOptions(IFakeOptions<TFake>)")]
         bool IFakeOptionsBuilder.CanBuildOptionsForFakeOfType(Type type)
         {
             return type == typeof(TFake);
@@ -39,8 +38,7 @@ namespace FakeItEasy
         /// <param name="typeOfFake">The type the fake object represents.</param>
         /// <param name="options">The fake options to manipulate.</param>
         /// <exception cref="InvalidOperationException">When <paramref name="typeOfFake"/> is not <typeparamref name="TFake"/>.</exception>
-        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes",
-            Justification = "Explicit implementation reduces the chance of misusing object. Explicit methods are superseded by BuildOptions(IFakeOptions<TFake>)")]
+        [SuppressMessage("Microsoft.Design", "CA1033:InterfaceMethodsShouldBeCallableByChildTypes", Justification = "Explicit implementation reduces the chance of misusing object. Explicit methods are superseded by BuildOptions(IFakeOptions<TFake>)")]
         void IFakeOptionsBuilder.BuildOptions(Type typeOfFake, IFakeOptions options)
         {
             if (!((IFakeOptionsBuilder)this).CanBuildOptionsForFakeOfType(typeOfFake))

--- a/tests/FakeItEasy.IntegrationTests/DummyTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/DummyTests.cs
@@ -101,8 +101,7 @@ namespace FakeItEasy.IntegrationTests
             }
         }
 
-        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses",
-            Justification = "Required for testing.")]
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Required for testing.")]
         private class NonInstance
         {
             private NonInstance()
@@ -111,8 +110,7 @@ namespace FakeItEasy.IntegrationTests
         }
     }
 
-    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass",
-        Justification = "Tidier.")]
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "Tidier.")]
     public class DummyTestsDummyFactory : IDummyFactory
     {
         public Priority Priority => Priority.Default;

--- a/tests/FakeItEasy.Tests/ArgumentConstraintTestBase.of.T.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintTestBase.of.T.cs
@@ -6,8 +6,7 @@ namespace FakeItEasy.Tests
     public abstract class ArgumentConstraintTestBase<T>
         : ArgumentConstraintTestBase
     {
-        [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors",
-            Justification = "CreateCosntraint has no unsafe side effects.")]
+        [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "CreateCosntraint has no unsafe side effects.")]
         protected ArgumentConstraintTestBase()
         {
             this.CreateConstraint(new DefaultArgumentConstraintManager<T>(x => this.ConstraintField = x));

--- a/tests/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
@@ -288,8 +288,7 @@ namespace FakeItEasy.Tests.Configuration
         {
         }
 
-        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses",
-            Justification = "This class is loaded dynamically as an extension point")]
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "This class is loaded dynamically as an extension point")]
         private class DummyableClassFactory : DummyFactory<DummyableClass>
         {
             private static readonly DummyableClass Instance = new DummyableClass();

--- a/tests/FakeItEasy.Tests/TestHelpers/UsingCultureAttribute.cs
+++ b/tests/FakeItEasy.Tests/TestHelpers/UsingCultureAttribute.cs
@@ -7,8 +7,7 @@
     using System.Threading;
     using Xunit.Sdk;
 
-    [SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments",
-        Justification = "No need to access culture name.")]
+    [SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Justification = "No need to access culture name.")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public sealed class UsingCultureAttribute : BeforeAfterTestAttribute
     {


### PR DESCRIPTION
Cleans up style warnings revealed after conversion to StyleCop.Analyzers in #1090.