### PR TITLE
Handle case where some types can't be loaded from external assembly

### DIFF
--- a/tests/FakeItEasy.IntegrationTests/ExternalAssemblyGenerator.cs
+++ b/tests/FakeItEasy.IntegrationTests/ExternalAssemblyGenerator.cs
@@ -14,8 +14,10 @@
         public ExternalAssemblyGenerator()
         {
             this.CreateBaseDirectory();
-            this.AssemblyOriginalPath = this.PrepareAssemblyPath("Original");
-            this.AssemblyCopyPath = this.PrepareAssemblyPath("Copy");
+            this.AssemblyOriginalPath = this.PrepareAssemblyPath("Original", AssemblyName);
+            this.AssemblyCopyPath = this.PrepareAssemblyPath("Copy", AssemblyName);
+            this.AssemblyDependencyPath = this.PrepareAssemblyPath("Dependency", DependencyAssemblyName);
+            this.EmitDependencyAssembly();
             this.EmitAssembly();
             this.CopyAssembly();
         }
@@ -27,10 +29,20 @@
 
         /// <summary>
         /// Gets the path to a copy of <see cref="AssemblyOriginalPath"/>.
-        ///
+        /// </summary>
         public string AssemblyCopyPath { get; }
 
+        /// <summary>
+        /// Gets the path of an assembly on which a type of FakeItEasy.IntegrationTests.External depends.
+        /// </summary>
+        /// <remarks>
+        /// This assembly is referenced by FakeItEasy.ExtensionPoints.External, but won't be available at run time. This is done in order to
+        /// cause a type load error when we scan the types in FakeItEasy.ExtensionPoints.External, and ensure the error is handled properly.
+        /// </remarks>
+        public string AssemblyDependencyPath { get; }
+
         private const string AssemblyName = "FakeItEasy.ExtensionPoints.External";
+        private const string DependencyAssemblyName = "FakeItEasy.ExtensionPoints.ExternalDependency";
 
         private static IEnumerable<string> GetFrameworkAssemblyLocations()
         {
@@ -57,11 +69,35 @@
             Directory.CreateDirectory(this.baseDirectory);
         }
 
-        private string PrepareAssemblyPath(string subDirectory)
+        private string PrepareAssemblyPath(string subDirectory, string assemblyName)
         {
             string directory = Path.Combine(this.baseDirectory, subDirectory);
             Directory.CreateDirectory(directory);
-            return Path.Combine(directory, AssemblyName + ".dll");
+            return Path.Combine(directory, assemblyName + ".dll");
+        }
+
+        private void EmitDependencyAssembly()
+        {
+            string assemblyContent = @"
+namespace FakeItEasy.IntegrationTests.ExternalDependency
+{
+    public class Foo { }
+}";
+
+            var references = GetFrameworkAssemblyLocations()
+                .Select(l => MetadataReference.CreateFromFile(l));
+
+            var compilation = CSharpCompilation.Create(
+                DependencyAssemblyName,
+                syntaxTrees: new[] { CSharpSyntaxTree.ParseText(assemblyContent) },
+                references: references,
+                options: new CSharpCompilationOptions(outputKind: OutputKind.DynamicallyLinkedLibrary));
+
+            var emitResult = compilation.Emit(this.AssemblyDependencyPath);
+            if (!emitResult.Success)
+            {
+                throw new Exception("Failed to create assembly - " + emitResult.Diagnostics[0]);
+            }
         }
 
         private void EmitAssembly()
@@ -71,6 +107,7 @@ namespace FakeItEasy.IntegrationTests.External
 {
     using System;
     using FakeItEasy;
+    using FakeItEasy.IntegrationTests.ExternalDependency;
 
     public class GuidValueFormatter : ArgumentValueFormatter<Guid>
     {
@@ -79,13 +116,23 @@ namespace FakeItEasy.IntegrationTests.External
             return argumentValue.ToString(""B"");
         }
     }
+
+    // Will fail to load if the assembly containing Foo cannot be found
+    public class FooValueFormatter : ArgumentValueFormatter<Foo>
+    {
+        protected override string GetStringValue(Foo argumentValue)
+        {
+            return ""Foo"";
+        }
+    }
 }
 ";
 
             var references = GetFrameworkAssemblyLocations()
             .Concat(new[]
             {
-                typeof(A).GetTypeInformation().Assembly.Location
+                typeof(A).GetTypeInformation().Assembly.Location,
+                this.AssemblyDependencyPath
             })
             .Select(l => MetadataReference.CreateFromFile(l));
 

--- a/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
@@ -22,7 +22,7 @@
             this.externalAssemblyGenerator = externalAssemblyGenerator;
         }
 
-        private ExternalAssemblyGenerator externalAssemblyGenerator;
+        private readonly ExternalAssemblyGenerator externalAssemblyGenerator;
 
         [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "No exception is thrown.")]
 #if FEATURE_NETCORE_REFLECTION
@@ -129,6 +129,23 @@
 
             // Assert
             catalogue.GetAvailableTypes().Should().NotContain(typeof(string));
+        }
+
+        [Fact]
+        public void Should_warn_if_some_types_cannot_be_loaded_from_external_assembly()
+        {
+            // Arrange
+            var catalogue = new TypeCatalogue();
+
+            // Act
+            string output = CaptureConsoleOutput(
+                () => catalogue.Load(new[] { this.externalAssemblyGenerator.AssemblyOriginalPath }));
+
+            // Assert
+            output.Should().Match(@"*Warning: FakeItEasy failed to get some types from assembly 'FakeItEasy.ExtensionPoints.External, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' while scanning for extension points. Some IArgumentValueFormatters, IDummyFactories, and IFakeOptionsBuilders in that assembly might not be available.
+  System.Reflection.ReflectionTypeLoadException: *.
+  1 type(s) were not loaded for the following reasons:
+   - System.IO.FileNotFoundException: *");
         }
 
         [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Safe in this case")]


### PR DESCRIPTION
Fixes #1092 

The warning message looks like this:

```
Warning: FakeItEasy failed to get some types from assembly 'FakeItEasy.ExtensionPoints.External, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' while scanning for extension points. Some IArgumentValueFormatters, IDummyFactories, and IFakeOptionsBuilders in that assembly might not be available.
  System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
  1 type(s) were not loaded for the following reasons:
   - System.IO.FileNotFoundException: Could not load file or assembly 'FakeItEasy.ExtensionPoints.ExternalDependency, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.
```

Unfortunately it's not always possible to get the information about *which* types can't be loaded. The information is only present if the exception is a `TypeLoadException`.