### PR TITLE
Publish artifacts even when the build fails

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,9 @@ build_script:
         & .\build.cmd
     }
 
+on_failure:
+  - ps: $root = (Resolve-Path artifacts); [IO.Directory]::GetFiles($root.Path, '*.*', 'AllDirectories') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1) -DeploymentName failed-build }
+
 nuget:
     disable_publish_on_pr: true
 


### PR DESCRIPTION
Because if we don't, it's sometimes hard to find out why the build fails.