### PR TITLE
Fix build when VS2015 is not installed

### DIFF
--- a/FakeItEasy.sln
+++ b/FakeItEasy.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26403.7
-MinimumVisualStudioVersion = 14.0.0.0
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A6A7B553-5359-4FB9-B19C-8A23004F49DB}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig

--- a/build.cmd
+++ b/build.cmd
@@ -5,7 +5,7 @@ pushd %~dp0
 setlocal
 
 rem options
-set NUGET_VERSION=3.5.0
+set NUGET_VERSION=4.1.0
 
 rem determine nuget cache dir
 set NUGET_CACHE_DIR=%LocalAppData%\.nuget\v%NUGET_VERSION%
@@ -19,16 +19,14 @@ if not exist %NUGET_CACHE_DIR%\NuGet.exe (
 )
 
 rem copy nuget locally
-if not exist .nuget\NuGet.exe (
-  if not exist .nuget md .nuget
-  copy %NUGET_CACHE_DIR%\NuGet.exe .nuget\NuGet.exe > nul
-)
+if not exist .nuget md .nuget
+copy /Y %NUGET_CACHE_DIR%\NuGet.exe .nuget\NuGet.exe > nul
 
 rem restore packages for build script
 .nuget\NuGet.exe restore .\packages.config -PackagesDirectory .\packages -Verbosity quiet
 
 rem run build script
-"%ProgramFiles(x86)%\MSBuild\14.0\Bin\csi.exe" .\build.csx %*
+".\packages\Microsoft.Net.Compilers.2.2.0\tools\csi.exe" .\build.csx %*
 
 rem return to original working directory
 popd

--- a/build.csx
+++ b/build.csx
@@ -127,7 +127,7 @@ targets.Add(
     "restore",
     () =>
     {
-        Cmd(nuget, $"restore {solution} -PackagesDirectory {packagesDirectory}");
+        Cmd(nuget, $"restore {solution}");
         Cmd("dotnet", $"restore");
     });
 

--- a/packages.config
+++ b/packages.config
@@ -4,4 +4,5 @@
   <package id="simple-targets-csx" version="5.2.0" />
   <package id="xunit.runner.console" version="2.0.0" />
   <package id="vswhere" version="1.0.62" />
+  <package id="Microsoft.Net.Compilers" version="2.2.0" />
 </packages>


### PR DESCRIPTION
The solution requires VS2017 anyway, so we shouldn't rely on VS2015 in any way.

Fixes #1113 