### PR TITLE
Generate nuspec dependencies from project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 artifacts
 packages
 src/VersionInfo.cs
+src/FakeItEasy.nuspec
 
 *.*proj.user
 *.lock.json

--- a/FakeItEasy.sln
+++ b/FakeItEasy.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A6A7B553-5359-4FB9-B19C-8A23004F49DB}"
 	ProjectSection(SolutionItems) = preProject
@@ -27,7 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{59466C4D-C40
 	ProjectSection(SolutionItems) = preProject
 		src\CommonAssemblyInfo.cs = src\CommonAssemblyInfo.cs
 		src\FakeItEasy.Analyzer.nuspec = src\FakeItEasy.Analyzer.nuspec
-		src\FakeItEasy.nuspec = src\FakeItEasy.nuspec
+		src\FakeItEasy.nuspec.template = src\FakeItEasy.nuspec.template
 		src\ILMerge.Internalize.Exclude.txt = src\ILMerge.Internalize.Exclude.txt
 	EndProjectSection
 EndProject

--- a/src/FakeItEasy.nuspec.template
+++ b/src/FakeItEasy.nuspec.template
@@ -13,16 +13,7 @@
     <licenseUrl>https://github.com/FakeItEasy/FakeItEasy/blob/master/License.txt</licenseUrl>
     <copyright>Copyright (c) FakeItEasy contributors. (fakeiteasyfx@gmail.com)</copyright>
     <tags>TDD unittesting mocks mocking fakes faking stubs stubbing spy spies doubles isolation substitutes substitution</tags>
-    <dependencies>
-      <group targetFramework=".NETFramework4.0" />
-      <group targetFramework=".NETFramework4.5" />
-      <group targetFramework=".NETStandard1.6">
-        <dependency id="Microsoft.Extensions.DependencyModel" version="1.0.0" />
-        <dependency id="System.Collections.Concurrent" version="4.0.12" />
-        <dependency id="System.Runtime.Loader" version="4.0.0" />
-        <dependency id="Castle.Core" version="4.1.0" />
-      </group>
-    </dependencies>
+    <dependencies />
   </metadata>
   <files>
     <file src="FakeItEasy\bin\Release\net40\FakeItEasy.dll" target="lib\net40" />


### PR DESCRIPTION
Fixes #1133 

- FakeItEasy.nuspec is renamed to FakeItEasy.nuspec.template, with no dependencies specified
- The build script generates FakeItEasy.nuspec from the template, using FakeItEasy.csproj to fill the dependencies
- The dependencies are located using the `Condition="'$(TargetFramework)' == '{tfm}'"` attribute. _This is a bit crude, and will break if we use more complex conditions_
- Build-only dependencies are identified by the presence of the `<PrivateAssets>` element. _This is also an oversimplification, because `<PrivateAssets>` can have values other than `all`, but it works fine with the current bits._
