### PR TITLE
Fix race condition in call assertion

### DIFF
--- a/src/FakeItEasy/Core/FakeAsserter.cs
+++ b/src/FakeItEasy/Core/FakeAsserter.cs
@@ -7,9 +7,9 @@ namespace FakeItEasy.Core
     internal class FakeAsserter : IFakeAsserter
     {
         private readonly CallWriter callWriter;
-        private readonly IEnumerable<IFakeObjectCall> calls;
+        private readonly IEnumerable<ICompletedFakeObjectCall> calls;
 
-        public FakeAsserter(IEnumerable<IFakeObjectCall> calls, CallWriter callWriter)
+        public FakeAsserter(IEnumerable<ICompletedFakeObjectCall> calls, CallWriter callWriter)
         {
             Guard.AgainstNull(calls, nameof(calls));
             Guard.AgainstNull(callWriter, nameof(callWriter));
@@ -18,10 +18,10 @@ namespace FakeItEasy.Core
             this.callWriter = callWriter;
         }
 
-        public delegate IFakeAsserter Factory(IEnumerable<IFakeObjectCall> calls);
+        public delegate IFakeAsserter Factory(IEnumerable<ICompletedFakeObjectCall> calls);
 
         public virtual void AssertWasCalled(
-            Func<IFakeObjectCall, bool> callPredicate, Action<IOutputWriter> callDescriber, Repeated repeatConstraint)
+            Func<ICompletedFakeObjectCall, bool> callPredicate, Action<IOutputWriter> callDescriber, Repeated repeatConstraint)
         {
             var matchedCallCount = this.calls.Count(callPredicate);
             if (!repeatConstraint.Matches(matchedCallCount))

--- a/src/FakeItEasy/Core/IFakeAsserter.cs
+++ b/src/FakeItEasy/Core/IFakeAsserter.cs
@@ -4,6 +4,6 @@ namespace FakeItEasy.Core
 
     internal interface IFakeAsserter
     {
-        void AssertWasCalled(Func<IFakeObjectCall, bool> callPredicate, Action<IOutputWriter> callDescriber, Repeated repeatConstraint);
+        void AssertWasCalled(Func<ICompletedFakeObjectCall, bool> callPredicate, Action<IOutputWriter> callDescriber, Repeated repeatConstraint);
     }
 }

--- a/tests/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
@@ -229,7 +229,7 @@ namespace FakeItEasy.Tests.Configuration
 
             // Assert
             A.CallTo(() => this.asserter.AssertWasCalled(
-                A<Func<IFakeObjectCall, bool>>._,
+                A<Func<ICompletedFakeObjectCall, bool>>._,
                 this.ruleProducedByFactory.WriteDescriptionOfValidCall,
                 repeatedConstraint))
                 .MustHaveHappened();
@@ -247,7 +247,7 @@ namespace FakeItEasy.Tests.Configuration
 
             // Assert
             A.CallTo(() => this.asserter.AssertWasCalled(
-                A<Func<IFakeObjectCall, bool>>._,
+                A<Func<ICompletedFakeObjectCall, bool>>._,
                 this.ruleProducedByFactory.WriteDescriptionOfValidCall,
                 repeatedConstraint))
                 .MustHaveHappened();

--- a/tests/FakeItEasy.Tests/Core/FakeAsserterTests.cs
+++ b/tests/FakeItEasy.Tests/Core/FakeAsserterTests.cs
@@ -9,12 +9,12 @@ namespace FakeItEasy.Tests.Core
 
     public class FakeAsserterTests
     {
-        private readonly List<IFakeObjectCall> calls;
+        private readonly List<ICompletedFakeObjectCall> calls;
         private readonly CallWriter callWriter;
 
         public FakeAsserterTests()
         {
-            this.calls = new List<IFakeObjectCall>();
+            this.calls = new List<ICompletedFakeObjectCall>();
             this.callWriter = A.Fake<CallWriter>();
         }
 
@@ -170,7 +170,9 @@ namespace FakeItEasy.Tests.Core
         {
             for (int i = 0; i < numberOfCalls; i++)
             {
-                this.calls.Add(A.Fake<IFakeObjectCall>());
+                var call = A.Fake<ICompletedFakeObjectCall>();
+                SequenceNumberManager.RecordSequenceNumber(call);
+                this.calls.Add(call);
             }
         }
     }

--- a/tests/FakeItEasy.Tests/Core/FakeAsserterTests.cs
+++ b/tests/FakeItEasy.Tests/Core/FakeAsserterTests.cs
@@ -142,6 +142,25 @@ namespace FakeItEasy.Tests.Core
                 .And.Message.Should().StartWith(Environment.NewLine);
         }
 
+        [Fact]
+        public void Exception_message_should_not_contain_matching_call_when_call_is_recorded_after_checking_count()
+        {
+            var asserter = this.CreateAsserter();
+
+            var repeatConstraint = A.Fake<Repeated>();
+
+            // This will cause the call to be recorded after checking the count
+            A.CallTo(() => repeatConstraint.Matches(A<int>._))
+                .Invokes(() => this.StubCalls(1))
+                .Returns(false);
+
+            var exception = Record.Exception(() =>
+                asserter.AssertWasCalled(x => true, outputWriter => { }, repeatConstraint));
+
+            exception.Should().BeAnExceptionOfType<ExpectationException>()
+                .And.Message.Should().Contain("no calls were made to the fake object.");
+        }
+
         private FakeAsserter CreateAsserter()
         {
             return new FakeAsserter(this.calls, this.callWriter);


### PR DESCRIPTION
Fixes #1159

A simpler fix would have been to just call `.ToList()` on the calls in the `FakeAsserter` constructor, but it would have created unnecessary copies of the call list, which could possibly be large.