### PR TITLE
Use 3 digits in version pre-release number

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,3 @@
 ignore:
   commits-before: 2017-01-01T00:00:00
+legacy-semver-padding: 3


### PR DESCRIPTION
Otherwise the package comes out as FakeItEasy.4.0.0-beta0001.