### PR TITLE
Automatically attach artifacts to GitHub Release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ environment:
         secure: 9iw6ajDvltEymr75DhlRbH8X+2olJ8mbWLPqyYMmleg=
     COVERITY_TOKEN:
         secure: S9XU2JhyUK9XstLG3CN2vB5M8ce8zYZp5VECx3kvx24=
+    GITHUB_TOKEN:
+        secure: 5dFninlYVqNF98Pk9ykQwPU2pBFeQmbMOiFG2iSkg+hhcwF3UfmnDB07lvOwYtez
+    NUGET_API_KEY:
+        secure: BVzuxe9khaakJDNLAhtUM2w5G3gAkoOasCDAilstAtpLuCdFNfu3jrf0KrI5B1Bo
 
 build_script:
 - cmd: if defined APPVEYOR_SCHEDULED_BUILD (build.cmd coverity) else (build.cmd)
@@ -25,10 +29,5 @@ test: off
 artifacts:
     - path: .\artifacts\*\*
 
-deploy:
-    - provider: NuGet
-      api_key:
-          secure: BVzuxe9khaakJDNLAhtUM2w5G3gAkoOasCDAilstAtpLuCdFNfu3jrf0KrI5B1Bo
-      skip_symbols: true
-      on:
-          appveyor_repo_tag: true
+deploy_script:
+    - ps: ./deploy.ps1

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,44 @@
+if (! $env:APPVEYOR_REPO_TAG_NAME) {
+    Write-Output "No Appveyor tag name supplied. Not deploying."
+    return
+}
+
+$releaseName = $env:APPVEYOR_REPO_TAG_NAME
+$gitHubAuthToken = $env:GITHUB_TOKEN
+$nugetApiKey = $env:NUGET_API_KEY
+$repo = $env:APPVEYOR_REPO_NAME
+
+$nugetServer = nuget.org
+$artifactsPattern = "artifacts/output/*.nupkg"
+$releasesUrl = "https://api.github.com/repos/$repo/releases"
+$headers = @{
+    "Authorization" = "Bearer $gitHubAuthToken"
+    "Content-type"  = "application/json"
+}
+
+Write-Output "Deploying $releaseName"
+Write-Output "Looking for GitHub release $releaseName"
+
+$releases = Invoke-RestMethod -Uri $releasesUrl -Headers $headers -Method GET
+$release = $releases | Where-Object { $_.name -eq $releaseName }
+if (! $release) {
+    throw "Can't find release $releaseName"
+}
+
+$headers["Content-type"] = "application/octet-stream"
+$uploadsUrl = "https://uploads.github.com/repos/$repo/releases/$($release.id)/assets?name="
+
+Write-Output "Uploading artifacts to GitHub release"
+$artifacts = Get-ChildItem -Path $artifactsPattern
+$artifacts | ForEach-Object {
+    Write-Output "Uploading $($_.Name)"
+    $asset = Invoke-RestMethod -Uri ($uploadsUrl + $_.Name) -Headers $headers -Method POST -InFile $_
+    Write-Output "Uploaded  $($asset.name)"
+}
+
+Write-Output "Pushing nupkgs to nuget.org"
+$artifacts | ForEach-Object {
+    Write-Output "Pushing $($_.Name)"
+    .nuget/nuget.exe push -ApiKey $nugetApiKey -Source $nugetServer -NonInteractive -ForceEnglishOutput
+    Write-Output "Pushed  $($_.Name)"
+}


### PR DESCRIPTION
- only when building a tag
- will attach to release with same name as tag
- errors out if no such release is found
- attaches all the nupkgs

Fixes #1171.