### PR TITLE
Fix nuget server name

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -8,7 +8,7 @@ $gitHubAuthToken = $env:GITHUB_TOKEN
 $nugetApiKey = $env:NUGET_API_KEY
 $repo = $env:APPVEYOR_REPO_NAME
 
-$nugetServer = nuget.org
+$nugetServer = "nuget.org"
 $artifactsPattern = "artifacts/output/*.nupkg"
 $releasesUrl = "https://api.github.com/repos/$repo/releases"
 $headers = @{


### PR DESCRIPTION
Supports #1171.

You can see the failure in [AppVeyor build 390](https://ci.appveyor.com/project/FakeItEasy/fakeiteasy/build/390#L666).