### PR TITLE
Better description for IsSameSequenceAs constraint

### DIFF
--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy
+namespace FakeItEasy
 {
     using System;
     using System.Collections;
@@ -145,14 +145,15 @@
         /// as the specified collection.
         /// </summary>
         /// <param name="manager">The constraint manager to match the constraint.</param>
-        /// <param name="value">The sequence to test against.</param>
+        /// <param name="values">The sequence to test against.</param>
         /// <typeparam name="T">The type of argument to constrain.</typeparam>
         /// <returns>A dummy argument value.</returns>
-        public static T IsSameSequenceAs<T>(this IArgumentConstraintManager<T> manager, IEnumerable value) where T : IEnumerable
+        public static T IsSameSequenceAs<T>(this IArgumentConstraintManager<T> manager, IEnumerable values) where T : IEnumerable
         {
+            var list = values.AsList();
             return manager.NullCheckedMatches(
-                x => x.Cast<object>().SequenceEqual(value.Cast<object>()),
-                x => x.Write("specified sequence"));
+                x => x.Cast<object>().SequenceEqual(list),
+                x => x.WriteArgumentValues(list));
         }
 
         /// <summary>

--- a/src/FakeItEasy/EnumerableExtensions.cs
+++ b/src/FakeItEasy/EnumerableExtensions.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
@@ -8,7 +9,7 @@ namespace FakeItEasy
     /// <summary>
     /// Provides extension methods for generic usage of <see cref="IEnumerable{T}"/>.
     /// </summary>
-    internal static partial class EnumerableExtensions
+    internal static class EnumerableExtensions
     {
         /// <summary>
         /// Joins the collection to a string.
@@ -38,6 +39,27 @@ namespace FakeItEasy
         public static IEnumerable<T> Concat<T>(this IEnumerable<T> source, T item)
         {
             return source.Concat(new[] { item });
+        }
+
+        /// <summary>
+        /// Returns the sequence as a list in order to avoid multiple enumerations of the original sequence.
+        /// </summary>
+        /// <typeparam name="T">The type of items in the sequence.</typeparam>
+        /// <param name="source">The sequence to return as a list.</param>
+        /// <returns>The sequence cast as a list if it's actually a list; otherwise, a new list with the elements from the sequence.</returns>
+        public static IList<T> AsList<T>(this IEnumerable<T> source)
+        {
+            return source as IList<T> ?? source.ToList();
+        }
+
+        /// <summary>
+        /// Returns the sequence as a list in order to avoid multiple enumerations of the original sequence.
+        /// </summary>
+        /// <param name="source">The sequence to return as a list.</param>
+        /// <returns>The sequence cast as a list if it's actually a list; otherwise, a new list with the elements from the sequence.</returns>
+        public static IList<object> AsList(this IEnumerable source)
+        {
+            return source as IList<object> ?? source.Cast<object>().ToList();
         }
     }
 }

--- a/src/FakeItEasy/OutputWriterExtensions.cs
+++ b/src/FakeItEasy/OutputWriterExtensions.cs
@@ -1,6 +1,8 @@
 namespace FakeItEasy
 {
     using System;
+    using System.Collections;
+    using System.Linq;
 
     /// <summary>
     /// Provides extensions for <see cref="IOutputWriter"/>.
@@ -47,6 +49,66 @@ namespace FakeItEasy
             Guard.AgainstNull(value, nameof(value));
 
             writer.Write(value.ToString());
+            return writer;
+        }
+
+        /// <summary>
+        /// Formats the specified argument values as strings and writes them to the output.
+        /// </summary>
+        /// <param name="writer">The writer to write to.</param>
+        /// <param name="values">The values to write to the writer.</param>
+        /// <param name="skipFormatting">Specify that argument values should not be formatted.</param>
+        /// <returns>The writer.</returns>
+        internal static IOutputWriter WriteArgumentValues(this IOutputWriter writer, IEnumerable values, bool skipFormatting = false)
+        {
+            Guard.AgainstNull(writer, nameof(writer));
+            Guard.AgainstNull(values, nameof(values));
+
+            var list = values.AsList();
+            if (list.Count <= 5)
+            {
+                writer.WriteArgumentValuesImpl(list, skipFormatting);
+            }
+            else
+            {
+                writer.WriteArgumentValuesImpl(list.Take(2), skipFormatting);
+                int remainingCount = list.Count - 4;
+                writer.Write($", … ({remainingCount} more elements) …, ");
+                writer.WriteArgumentValuesImpl(list.Skip(list.Count - 2), skipFormatting);
+            }
+
+            return writer;
+        }
+
+        /// <summary>
+        /// Formats the specified argument values as strings and writes them to the output.
+        /// </summary>
+        /// <param name="writer">The writer to write to.</param>
+        /// <param name="values">The values to write to the writer.</param>
+        /// <param name="skipFormatting">Specify that argument values should not be formatted.</param>
+        /// <returns>The writer.</returns>
+        private static IOutputWriter WriteArgumentValuesImpl(this IOutputWriter writer, IEnumerable values, bool skipFormatting = false)
+        {
+            bool first = true;
+            foreach (var value in values)
+            {
+                if (!first)
+                {
+                    writer.Write(", ");
+                }
+
+                if (skipFormatting)
+                {
+                    writer.Write(value);
+                }
+                else
+                {
+                    writer.WriteArgumentValue(value);
+                }
+
+                first = false;
+            }
+
             return writer;
         }
     }

--- a/src/FakeItEasy/StringBuilderOutputWriter.cs
+++ b/src/FakeItEasy/StringBuilderOutputWriter.cs
@@ -16,10 +16,6 @@ namespace FakeItEasy
         {
         }
 
-        public StringBuilder Builder
-        {
-            get;
-            private set;
-        }
+        public StringBuilder Builder { get; }
     }
 }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi40.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi40.approved.txt
@@ -130,7 +130,7 @@ namespace FakeItEasy
             where T :  struct { }
         public static string IsNullOrEmpty(this FakeItEasy.IArgumentConstraintManager<string> manager) { }
         public static T IsSameAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
-        public static T IsSameSequenceAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.IEnumerable value)
+        public static T IsSameSequenceAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.IEnumerable values)
             where T : System.Collections.IEnumerable { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> scope, System.Func<T, bool> predicate, string description) { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Func<T, bool> predicate, string descriptionFormat, params object[] args) { }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi45.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi45.approved.txt
@@ -130,7 +130,7 @@ namespace FakeItEasy
             where T :  struct { }
         public static string IsNullOrEmpty(this FakeItEasy.IArgumentConstraintManager<string> manager) { }
         public static T IsSameAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
-        public static T IsSameSequenceAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.IEnumerable value)
+        public static T IsSameSequenceAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.IEnumerable values)
             where T : System.Collections.IEnumerable { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> scope, System.Func<T, bool> predicate, string description) { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Func<T, bool> predicate, string descriptionFormat, params object[] args) { }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApiNetStd.approved.txt
@@ -54,7 +54,7 @@ namespace FakeItEasy
             where T :  struct { }
         public static string IsNullOrEmpty(this FakeItEasy.IArgumentConstraintManager<string> manager) { }
         public static T IsSameAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
-        public static T IsSameSequenceAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.IEnumerable value)
+        public static T IsSameSequenceAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.IEnumerable values)
             where T : System.Collections.IEnumerable { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> scope, System.Func<T, bool> predicate, string description) { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Func<T, bool> predicate, string descriptionFormat, params object[] args) { }

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/IsSameSequenceAsWithLongSequenceTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/IsSameSequenceAsWithLongSequenceTests.cs
@@ -1,28 +1,30 @@
 namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
 {
     using System.Collections.Generic;
+    using System.Linq;
     using Xunit;
 
-    public class IsSameSequenceAsTests
-        : ArgumentConstraintTestBase<IEnumerable<string>>
+    public class IsSameSequenceAsWithLongSequenceTests
+        : ArgumentConstraintTestBase<IEnumerable<int>>
     {
-        protected override string ExpectedDescription => "\"a\", \"b\", NULL, \"y\", \"z\"";
+        protected override string ExpectedDescription => "1, 2, … (6 more elements) …, 9, 10";
 
         public static IEnumerable<object[]> InvalidValues()
         {
             return TestCases.FromObject(
-                new[] { "1", "2", "x", "y" },
-                new string[] { },
+                new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 },
+                new int[] { },
                 null,
-                new[] { "a", "b", null, "z", "x" },
-                new[] { "a", "b" });
+                new[] { 1, 2, 3, 4 },
+                new[] { 9, 8 });
         }
 
         public static IEnumerable<object[]> ValidValues()
         {
             return TestCases.FromObject(
-                new[] { "a", "b", null, "y", "z" },
-                new List<string> { "a", "b", null, "y", "z" });
+                new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+                new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+                Enumerable.Range(1, 10));
         }
 
         [Theory]
@@ -39,9 +41,9 @@ namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
             base.IsValid_should_return_true_for_valid_values(validValue);
         }
 
-        protected override void CreateConstraint(INegatableArgumentConstraintManager<IEnumerable<string>> scope)
+        protected override void CreateConstraint(INegatableArgumentConstraintManager<IEnumerable<int>> scope)
         {
-            scope.IsSameSequenceAs(new[] { "a", "b", null, "y", "z" });
+            scope.IsSameSequenceAs(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
         }
     }
 }

--- a/tests/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
+++ b/tests/FakeItEasy.Tests/Core/ArgumentValueFormatterTests.cs
@@ -5,7 +5,6 @@ namespace FakeItEasy.Tests.Core
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
     using FakeItEasy.Core;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
@@ -153,7 +152,7 @@ namespace FakeItEasy.Tests.Core
             // Arrange
             var allArgumentValueFormatters = typeof(A).GetTypeInformation().Assembly.GetTypes()
                 .Where(t => t.CanBeInstantiatedAs(typeof(IArgumentValueFormatter)))
-                .Select(Activator.CreateInstance)
+                .Select(Sdk.Create.Dummy)
                 .Cast<IArgumentValueFormatter>();
 
             // Act


### PR DESCRIPTION
Fixes #1193 

It seems to work pretty well, but I'm worried about one thing: when formatting argument values in the list of calls, what should happen for nested collections? My current implementation will recursively format the collections, but it will probably hurt the readability of the output...

Also, I noticed a few inconsistencies:
- When we write constraint descriptions, we use `IOutputWriter.WriteArgumentValue` to format values, but when we write the list of calls, we use `ArgumentValueFormatter`.
- Anyway, shouldn't `DefaultOutputWriter.WriteArgumentValue` use `ArgumentValueFormatter`, in order to take custom argument value formatters into account?
- Null values are formatted inconsistently between `DefaultOutputWriter` (`NULL`) and `ArgumentValueFormatter` (`<NULL>`).