### PR TITLE
Document that WhenArgumentsMatch ignores inline argument constraints

### DIFF
--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -135,8 +135,11 @@ Sometimes individually constraining arguments isn't sufficient. In
 such a case, other methods may be used to determine which calls match
 the fake's configuration.
 
-`WithAnyArguments` ensures that no argument constraints will be applied when matching calls:
+_When using the following methods, any inline argument constraints are ignored, and only the
+special method is used to match the call._ Some arguments have to be supplied in order to satisfy the compiler,
+but the values will not be used, so you can supply whatever values make the code easiest for you to read.
 
+`WithAnyArguments` ensures that no argument constraints will be applied when matching calls:
 
 ```csharp
 A.CallTo(() => foo.Bar(null, 7)).WithAnyArguments().MustHaveHappened();

--- a/src/FakeItEasy/Configuration/IArgumentValidationConfiguration.cs
+++ b/src/FakeItEasy/Configuration/IArgumentValidationConfiguration.cs
@@ -10,6 +10,9 @@ namespace FakeItEasy.Configuration
     {
         /// <summary>
         /// Configures the call to be accepted when the specified predicate returns true.
+        /// This method overrides any inline argument constraints (such as <see cref="A{T}.Ignored"/>,
+        /// implicit equality matchers, or anything else); only <paramref name="argumentsPredicate"/>
+        /// is considered when matching the call.
         /// </summary>
         /// <param name="argumentsPredicate">The argument predicate.</param>
         /// <returns>A configuration object.</returns>


### PR DESCRIPTION
Fixes #1200.