### PR TITLE
Detect wrong-typed constraints

### DIFF
--- a/src/FakeItEasy/Core/DefaultArgumentConstraintManager.cs
+++ b/src/FakeItEasy/Core/DefaultArgumentConstraintManager.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Core
+namespace FakeItEasy.Core
 {
     using System;
 
@@ -43,7 +43,7 @@
         }
 
         private class MatchesConstraint
-            : IArgumentConstraint
+            : ITypedArgumentConstraint
         {
             private static readonly bool IsNullable = typeof(T).IsNullable();
 
@@ -55,6 +55,8 @@
                 this.predicate = predicate;
                 this.descriptionWriter = descriptionWriter;
             }
+
+            public Type Type => typeof(T);
 
             void IArgumentConstraint.WriteDescription(IOutputWriter writer)
             {

--- a/src/FakeItEasy/Core/ITypedArgumentConstraint.cs
+++ b/src/FakeItEasy/Core/ITypedArgumentConstraint.cs
@@ -1,0 +1,9 @@
+namespace FakeItEasy.Core
+{
+    using System;
+
+    internal interface ITypedArgumentConstraint : IArgumentConstraint
+    {
+        Type Type { get; }
+    }
+}

--- a/src/FakeItEasy/ExceptionMessages.cs
+++ b/src/FakeItEasy/ExceptionMessages.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy
+namespace FakeItEasy
 {
     using System;
     using FakeItEasy.Core;
@@ -36,5 +36,8 @@
             var callFormatter = ServiceLocator.Current.Resolve<IFakeObjectCallFormatter>();
             return $"Call to unconfigured method of strict fake: {callFormatter.GetDescription(call)}.";
         }
+
+        public static string ArgumentConstraintHasWrongType(Type constraintType, Type parameterType) =>
+            $"Argument constraint is of type {constraintType}, but parameter is of type {parameterType}. No call can match this constraint.";
     }
 }

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/AggregateArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/AggregateArgumentConstraint.cs
@@ -1,6 +1,5 @@
 namespace FakeItEasy.Expressions.ArgumentConstraints
 {
-    using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
@@ -9,7 +8,7 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
     internal class AggregateArgumentConstraint
         : IArgumentConstraint
     {
-        private IArgumentConstraint[] constraintsField;
+        private readonly IArgumentConstraint[] constraintsField;
 
         public AggregateArgumentConstraint(IEnumerable<IArgumentConstraint> constraints)
         {

--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -82,9 +82,7 @@ namespace FakeItEasy.Expressions
         public virtual void UsePredicateToValidateArguments(Func<ArgumentCollection, bool> predicate)
         {
             this.argumentsPredicate = predicate;
-
-            var numberOfValidators = this.argumentConstraints.Count();
-            this.argumentConstraints = Enumerable.Repeat<IArgumentConstraint>(new PredicatedArgumentConstraint(), numberOfValidators);
+            this.argumentConstraints = this.argumentConstraints.Select(a => new PredicatedArgumentConstraint()).ToArray();
         }
 
         public Func<IFakeObjectCall, ICollection<object>> GetOutAndRefParametersValueProducer()


### PR DESCRIPTION
Fixes #1237 

The 3rd commit is a simplification. I realized that only `MatchesConstraint` could be created by the argument constraint trap, so we don't need to introduce a `Type` property for other types of constraint.