### PR TITLE
Use the same wording (never, once, twice, n times) when reporting actual amount of found calls

### DIFF
--- a/docs/formatting-argument-values.md
+++ b/docs/formatting-argument-values.md
@@ -23,7 +23,7 @@ This would help FakeItEasy display this error message:
 <pre>
 Assertion failed for the following call:
   SampleTests.ILibrary.Checkout(<Ignored>)
-Expected to find it never but found it #1 times among the calls:
+Expected to find it never but found it once among the calls:
   1: SampleTests.ILibrary.Checkout(<b>book: 'The Ocean at the End of the Lane', published on 2013-06-18</b>)
 </pre>
 which could make tracking down any failures a little easier.
@@ -32,7 +32,7 @@ Compare to the original behavior:
 <pre>
 Assertion failed for the following call:
   SampleTests.ILibrary.Checkout(<Ignored>)
-Expected to find it never but found it #1 times among the calls:
+Expected to find it never but found it once among the calls:
   1: SampleTests.ILibrary.Checkout(<b>book: SampleTests.Book</b>)
 </pre>
 

--- a/src/FakeItEasy/Core/FakeAsserter.cs
+++ b/src/FakeItEasy/Core/FakeAsserter.cs
@@ -61,7 +61,21 @@ namespace FakeItEasy.Core
 
             if (calls.Any())
             {
-                writer.Write("but found it #{0} times among the calls:", matchedCallCount);
+                switch (matchedCallCount)
+                {
+                    case 0:
+                        writer.Write("but didn't find it among the calls:");
+                        break;
+                    case 1:
+                        writer.Write("but found it once among the calls:");
+                        break;
+                    case 2:
+                        writer.Write("but found it twice among the calls:");
+                        break;
+                    default:
+                        writer.Write("but found it {0} times among the calls:", matchedCallCount);
+                        break;
+                }
             }
             else
             {

--- a/tests/FakeItEasy.IntegrationTests/Assertions/ExceptionMessagesTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/Assertions/ExceptionMessagesTests.cs
@@ -30,7 +30,7 @@ namespace FakeItEasy.IntegrationTests.Assertions
 
   Assertion failed for the following call:
     FakeItEasy.Tests.IFoo.Bar(argument: """")
-  Expected to find it at least twice but found it #0 times among the calls:
+  Expected to find it at least twice but didn't find it among the calls:
     1: FakeItEasy.Tests.IFoo.Bar() repeated 2 times
     ...
     3: FakeItEasy.Tests.IFoo.Bar(argument: ""test"")
@@ -61,7 +61,7 @@ namespace FakeItEasy.IntegrationTests.Assertions
 
   Assertion failed for the following call:
     FakeItEasy.Tests.IFoo.Bar(argument: """")
-  Expected to find it at least twice but found it #0 times among the calls:
+  Expected to find it at least twice but didn't find it among the calls:
     1: FakeItEasy.Tests.IFoo.Bar(
           argument1: 1,
           argument2: 2,
@@ -93,7 +93,7 @@ namespace FakeItEasy.IntegrationTests.Assertions
 
   Assertion failed for the following call:
     FakeItEasy.Tests.IFoo.Bar(argument: <Ignored>, argument2: <Starts with ""lorem"">)
-  Expected to find it at least twice but found it #1 times among the calls:
+  Expected to find it at least twice but found it once among the calls:
     1: FakeItEasy.Tests.IFoo.Bar(argument: System.Object, argument2: ""lorem ipsum"")
 
 ";
@@ -118,7 +118,7 @@ namespace FakeItEasy.IntegrationTests.Assertions
 
   Assertion failed for the following call:
     FakeItEasy.Tests.IFoo.Baz(argument: <Ignored>, argument2: <Starts with ""lorem"">)
-  Expected to find it at least twice but found it #1 times among the calls:
+  Expected to find it at least twice but found it once among the calls:
     1: FakeItEasy.Tests.IFoo.Baz(argument: System.Object, argument2: ""lorem ipsum"")
 
 ";

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -105,7 +105,7 @@ namespace FakeItEasy.Specs
 
   Assertion failed for the following call:
     FakeItEasy.Specs.CallMatchingSpecs+IHaveNoGenericParameters.Bar(baz: 3)
-  Expected to find it at least once but found it #0 times among the calls:
+  Expected to find it at least once but didn't find it among the calls:
     1: FakeItEasy.Specs.CallMatchingSpecs+IHaveNoGenericParameters.Bar(baz: 1)
     2: FakeItEasy.Specs.CallMatchingSpecs+IHaveNoGenericParameters.Bar(baz: 2)
 
@@ -137,7 +137,7 @@ namespace FakeItEasy.Specs
 
   Assertion failed for the following call:
     FakeItEasy.Specs.CallMatchingSpecs+IHaveTwoGenericParameters.Bar`2[System.String,System.String](baz1: <Ignored>, baz2: <Ignored>)
-  Expected to find it at least once but found it #0 times among the calls:
+  Expected to find it at least once but didn't find it among the calls:
     1: FakeItEasy.Specs.CallMatchingSpecs+IHaveTwoGenericParameters.Bar`2[System.Int32,System.Double](baz1: 1, baz2: 2)
     2: FakeItEasy.Specs.CallMatchingSpecs+IHaveTwoGenericParameters.Bar`2[FakeItEasy.Specs.CallMatchingSpecs+Generic`2[System.Boolean,System.Int64],System.Int32](baz1: FakeItEasy.Specs.CallMatchingSpecs+Generic`2[System.Boolean,System.Int64], baz2: 3)
 
@@ -172,7 +172,7 @@ namespace FakeItEasy.Specs
 
   Assertion failed for the following call:
     FakeItEasy.Specs.CallMatchingSpecs+IIHaveACollectionParameter.Bar(args: <NULL, 42, ""hello"">)
-  Expected to find it at least once but found it #0 times among the calls:
+  Expected to find it at least once but didn't find it among the calls:
     1: FakeItEasy.Specs.CallMatchingSpecs+IIHaveACollectionParameter.Bar(args: [1, ""hello"", … (2 more elements) …, ""foo"", ""bar""])
     2: FakeItEasy.Specs.CallMatchingSpecs+IIHaveACollectionParameter.Bar(args: [NULL, 42])
 

--- a/tests/FakeItEasy.Specs/OrderedCallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/OrderedCallMatchingSpecs.cs
@@ -273,7 +273,7 @@ namespace FakeItEasy.Specs
 
   Assertion failed for the following call:
     FakeItEasy.Specs.OrderedCallMatchingSpecs+IFoo.Bar(baz: 1)
-  Expected to find it exactly once but found it #2 times among the calls:
+  Expected to find it exactly once but found it twice among the calls:
     1: FakeItEasy.Specs.OrderedCallMatchingSpecs+IFoo.Bar(baz: 1)
     2: FakeItEasy.Specs.OrderedCallMatchingSpecs+IFoo.Bar(baz: 2)
     3: FakeItEasy.Specs.OrderedCallMatchingSpecs+IFoo.Bar(baz: 1)

--- a/tests/FakeItEasy.Tests/Core/FakeAsserterTests.cs
+++ b/tests/FakeItEasy.Tests/Core/FakeAsserterTests.cs
@@ -84,7 +84,67 @@ namespace FakeItEasy.Tests.Core
 
             var expectedMessage =
 @"
-  Expected to find it exactly twice but found it #0 times among the calls:";
+  Expected to find it exactly twice but didn't find it among the calls:";
+
+            exception.Should().BeAnExceptionOfType<ExpectationException>()
+                .And.Message.Should().Contain(expectedMessage);
+        }
+
+        [Fact]
+        public void Exception_message_should_write_no_call_was_made()
+        {
+            this.StubCalls(1);
+
+            var asserter = this.CreateAsserter();
+            var exception = Record.Exception(() =>
+                asserter.AssertWasCalled(x => false, outputWriter => { }, Repeated.Exactly.Twice));
+
+            var expectedMessage = @"Expected to find it exactly twice but didn't find it among the calls:";
+
+            exception.Should().BeAnExceptionOfType<ExpectationException>()
+                .And.Message.Should().Contain(expectedMessage);
+        }
+
+        [Fact]
+        public void Exception_message_should_write_one_call_was_made()
+        {
+            this.StubCalls(1);
+
+            var asserter = this.CreateAsserter();
+            var exception = Record.Exception(() =>
+                asserter.AssertWasCalled(x => true, outputWriter => { }, Repeated.Exactly.Twice));
+
+            var expectedMessage = @"Expected to find it exactly twice but found it once among the calls:";
+
+            exception.Should().BeAnExceptionOfType<ExpectationException>()
+                .And.Message.Should().Contain(expectedMessage);
+        }
+
+        [Fact]
+        public void Exception_message_should_write_two_calls_were_made()
+        {
+            this.StubCalls(2);
+
+            var asserter = this.CreateAsserter();
+            var exception = Record.Exception(() =>
+                asserter.AssertWasCalled(x => true, outputWriter => { }, Repeated.Exactly.Once));
+
+            var expectedMessage = @"Expected to find it exactly once but found it twice among the calls:";
+
+            exception.Should().BeAnExceptionOfType<ExpectationException>()
+                .And.Message.Should().Contain(expectedMessage);
+        }
+
+        [Fact]
+        public void Exception_message_should_write_many_calls_were_made()
+        {
+            this.StubCalls(3);
+
+            var asserter = this.CreateAsserter();
+            var exception = Record.Exception(() =>
+                asserter.AssertWasCalled(x => true, outputWriter => { }, Repeated.Exactly.Twice));
+
+            var expectedMessage = @"Expected to find it exactly twice but found it 3 times among the calls:";
 
             exception.Should().BeAnExceptionOfType<ExpectationException>()
                 .And.Message.Should().Contain(expectedMessage);


### PR DESCRIPTION
Fixes #1278 