### PR TITLE
Change documentation comments for IRepeatConfiguration

### DIFF
--- a/src/FakeItEasy/Configuration/IRepeatConfiguration.cs
+++ b/src/FakeItEasy/Configuration/IRepeatConfiguration.cs
@@ -9,8 +9,8 @@ namespace FakeItEasy.Configuration
         /// <summary>
         /// Specifies the number of times the configured behavior should be applied.
         /// </summary>
-        /// <param name="numberOfTimesToRepeat">The number of times the configured behavior should be applied.</param>
+        /// <param name="numberOfTimes">The number of times the configured behavior should be applied.</param>
         /// <returns>A configuration object that lets you define the subsequent behavior.</returns>
-        IThenConfiguration<TInterface> NumberOfTimes(int numberOfTimesToRepeat);
+        IThenConfiguration<TInterface> NumberOfTimes(int numberOfTimes);
     }
 }

--- a/src/FakeItEasy/Configuration/IRepeatConfiguration.cs
+++ b/src/FakeItEasy/Configuration/IRepeatConfiguration.cs
@@ -1,15 +1,15 @@
 namespace FakeItEasy.Configuration
 {
     /// <summary>
-    /// Provides configuration for method calls that has a return value.
+    /// Provides configuration to specify the number of times a configured behavior should be applied.
     /// </summary>
     /// <typeparam name="TInterface">The type of configuration interface to return.</typeparam>
     public interface IRepeatConfiguration<out TInterface> : IHideObjectMembers
     {
         /// <summary>
-        /// Specifies the number of times for the configured event.
+        /// Specifies the number of times the configured behavior should be applied.
         /// </summary>
-        /// <param name="numberOfTimes">The number of times the configured event should occur.</param>
+        /// <param name="numberOfTimesToRepeat">The number of times the configured behavior should be applied.</param>
         /// <returns>A configuration object that lets you define the subsequent behavior.</returns>
         IThenConfiguration<TInterface> NumberOfTimes(int numberOfTimesToRepeat);
     }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi40.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi40.approved.txt
@@ -493,7 +493,7 @@ namespace FakeItEasy.Configuration
     public interface IRepeatConfiguration<out TInterface> : FakeItEasy.IHideObjectMembers
     
     {
-        FakeItEasy.Configuration.IThenConfiguration<TInterface> NumberOfTimes(int numberOfTimesToRepeat);
+        FakeItEasy.Configuration.IThenConfiguration<TInterface> NumberOfTimes(int numberOfTimes);
     }
     public interface IRepeatSpecification : FakeItEasy.IHideObjectMembers
     {

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi45.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi45.approved.txt
@@ -491,7 +491,7 @@ namespace FakeItEasy.Configuration
     public interface IRepeatConfiguration<out TInterface> : FakeItEasy.IHideObjectMembers
     
     {
-        FakeItEasy.Configuration.IThenConfiguration<TInterface> NumberOfTimes(int numberOfTimesToRepeat);
+        FakeItEasy.Configuration.IThenConfiguration<TInterface> NumberOfTimes(int numberOfTimes);
     }
     public interface IRepeatSpecification : FakeItEasy.IHideObjectMembers
     {

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApiNetStd.approved.txt
@@ -412,7 +412,7 @@ namespace FakeItEasy.Configuration
     public interface IRepeatConfiguration<out TInterface> : FakeItEasy.IHideObjectMembers
     
     {
-        FakeItEasy.Configuration.IThenConfiguration<TInterface> NumberOfTimes(int numberOfTimesToRepeat);
+        FakeItEasy.Configuration.IThenConfiguration<TInterface> NumberOfTimes(int numberOfTimes);
     }
     public interface IRepeatSpecification : FakeItEasy.IHideObjectMembers
     {


### PR DESCRIPTION
As mentioned in https://github.com/FakeItEasy/FakeItEasy/pull/1293/files#r165813185

The first commit
- fixes the inconsistency in the parameter name between doc comments and actual signature
- changes the wording of the interface and method summaries

The second commits actually renames the parameter to `numberOfTimes`. I did it as a separate commit, because it's a breaking change. I think we could still do it, because the chances that it will actually impact anyone are extremely low. If you disagree, I'll remove the commit.

Contributes to #1292.