### PR TITLE
Use StyleCop.Analyzers 1.1.0-beta006

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
     <CodeAnalysisDictionary Include="$(MSBuildThisFileDirectory)src/FakeItEasy.Dictionary.xml">
       <Link>Properties\FakeItEasy.Dictionary.xml</Link>
     </CodeAnalysisDictionary>

--- a/samples/FakeItEasy.Examples.ruleset
+++ b/samples/FakeItEasy.Examples.ruleset
@@ -13,5 +13,6 @@
     <Rule Id="CA1824" Action="None" />
     <Rule Id="CA2201" Action="None" />
     <Rule Id="CA2210" Action="None" />
+    <Rule Id="SA0001" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/FakeItEasy.Analyzer/ArgumentConstraintTypeMismatchAnalyzer.cs
+++ b/src/FakeItEasy.Analyzer/ArgumentConstraintTypeMismatchAnalyzer.cs
@@ -158,17 +158,17 @@ namespace FakeItEasy.Analyzer
                     }
 #if CSHARP
                 case ElementAccessExpressionSyntax elementAccess:
-                {
-                    var indexer = SymbolHelpers.GetAccessedIndexerSymbol(elementAccess, context);
-                    if (indexer == null)
                     {
-                        return false;
-                    }
+                        var indexer = SymbolHelpers.GetAccessedIndexerSymbol(elementAccess, context);
+                        if (indexer == null)
+                        {
+                            return false;
+                        }
 
-                    methodOrIndexerName = indexer.Name;
-                    parameters = indexer.Parameters;
-                    return true;
-                }
+                        methodOrIndexerName = indexer.Name;
+                        parameters = indexer.Parameters;
+                        return true;
+                    }
 #endif
                 default:
                     return false;

--- a/src/FakeItEasy.ruleset
+++ b/src/FakeItEasy.ruleset
@@ -11,6 +11,7 @@
     <Rule Id="SA1124" Action="Warning" />
     <Rule Id="SA1127" Action="None" />
     <Rule Id="SA1128" Action="None" />
+    <Rule Id="SA1413" Action="None" />
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1628" Action="Warning" />
     <Rule Id="SA1629" Action="Warning" />

--- a/tests/FakeItEasy.Analyzer.CSharp.Tests/NonVirtualSetupAnalyzerTests.cs
+++ b/tests/FakeItEasy.Analyzer.CSharp.Tests/NonVirtualSetupAnalyzerTests.cs
@@ -148,7 +148,7 @@ namespace FakeItEasy.Analyzer.Tests
 
 ";
 
-           this.VerifyCSharpDiagnostic(
+            this.VerifyCSharpDiagnostic(
                 Test,
                 new DiagnosticResult
                 {
@@ -227,16 +227,16 @@ namespace AnalyzerPrototypeSubjectStatic
 }
 ";
 
-    this.VerifyCSharpDiagnostic(
-    Test,
-    new DiagnosticResult
-    {
-        Id = "FakeItEasy0002",
-        Message =
-            "Member Bar can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted.",
-        Severity = DiagnosticSeverity.Error,
-        Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 26) }
-            });
+            this.VerifyCSharpDiagnostic(
+                Test,
+                new DiagnosticResult
+                {
+                    Id = "FakeItEasy0002",
+                    Message =
+                        "Member Bar can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted.",
+                    Severity = DiagnosticSeverity.Error,
+                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 26) }
+                });
         }
 
         [Fact]

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -281,7 +281,7 @@
             "When I start to configure a non-virtual non-void method on the object"
                 .x(() => exception = Record.Exception(() => A.CallTo(() => notAFake.ReturnSomethingNonVirtual())));
 
-             "Then it throws an argument exception"
+            "Then it throws an argument exception"
                 .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
                     .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+BaseClass' of type FakeItEasy.Specs.ConfigurationSpecs+BaseClass is not recognized as a fake object."));
         }
@@ -313,7 +313,7 @@
             "When I start to configure a sealed non-void method on the object"
                 .x(() => exception = Record.Exception(() => A.CallTo(() => notAFake.ReturnSomething())));
 
-             "Then it throws an argument exception"
+            "Then it throws an argument exception"
                 .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
                     .And.Message.Should().Contain("Object 'FakeItEasy.Specs.ConfigurationSpecs+DerivedClass' of type FakeItEasy.Specs.ConfigurationSpecs+DerivedClass is not recognized as a fake object."));
         }
@@ -329,7 +329,7 @@
             "When I start to configure a sealed non-void method on the fake"
                 .x(() => exception = Record.Exception(() => A.CallTo(() => fake.ReturnSomething())));
 
-             "Then it throws a fake configuration exception"
+            "Then it throws a fake configuration exception"
                 .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
                     .And.Message.Should().Contain("Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
         }

--- a/tests/FakeItEasy.Tests.ruleset
+++ b/tests/FakeItEasy.Tests.ruleset
@@ -30,6 +30,7 @@
   </Rules>
 
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" />
     <Rule Id="SA1107" Action="None" />
     <Rule Id="SA1201" Action="None" />
     <Rule Id="SA1401" Action="None" />


### PR DESCRIPTION
I wanted to use a `!` with pattern matching as part of my work on #1297.
StyleCop.Analyzers couldn't handle it, thinking that 
```c#
if (!(context.Node is InvocationExpressionSyntax call))
```

had too many parentheses. I noticed the bug was fixed in 1.1.0-beta006, so thought, "why not upgrade?".