### PR TITLE
Squelch SA0001 warning for Analyzer

### DIFF
--- a/src/FakeItEasy.Analyzer/Directory.Build.props
+++ b/src/FakeItEasy.Analyzer/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <PackageTags>FakeItEasy;analyzer</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)FakeItEasy.Analyzer.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FakeItEasy.Analyzer/FakeItEasy.Analyzer.ruleset
+++ b/src/FakeItEasy.Analyzer/FakeItEasy.Analyzer.ruleset
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="FakeItEasy Tests" ToolsVersion="14.0">
+  <Include Path="..\fakeiteasy.ruleset" Action="Default" />
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" />
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
I missed these warnings when I suppressed SA0001 for tests and samples.