### PR TITLE
Don't always use ExpressionCallMatcher to describe call constraints

### DIFF
--- a/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
+++ b/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
@@ -4,7 +4,6 @@ namespace FakeItEasy.Configuration
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using FakeItEasy.Core;
     using FakeItEasy.Expressions;
 
     internal class PropertyExpressionHelper
@@ -56,13 +55,10 @@ namespace FakeItEasy.Configuration
 
         private static string GetExpressionDescription(ParsedCallExpression parsedCallExpression)
         {
-            var matcher = new ExpressionCallMatcher(
-                parsedCallExpression,
-                ServiceLocator.Current.Resolve<ExpressionArgumentConstraintFactory>(),
-                ServiceLocator.Current.Resolve<MethodInfoManager>(),
-                ServiceLocator.Current.Resolve<StringBuilderOutputWriter.Factory>());
+            var constraintFactory = ServiceLocator.Current.Resolve<ExpressionArgumentConstraintFactory>();
+            var describer = ServiceLocator.Current.Resolve<CallConstraintDescriber>();
 
-            return matcher.DescriptionOfMatchingCall;
+            return describer.GetDescriptionOfMatchingCall(parsedCallExpression.CalledMethod, parsedCallExpression.ArgumentsExpressions.Select(constraintFactory.GetArgumentConstraint));
         }
 
         private static string GetPropertyName(ParsedCallExpression parsedCallExpression)

--- a/src/FakeItEasy/Expressions/CallConstraintDescriber.cs
+++ b/src/FakeItEasy/Expressions/CallConstraintDescriber.cs
@@ -1,0 +1,102 @@
+namespace FakeItEasy.Expressions
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using FakeItEasy.Core;
+
+    /// <summary>
+    /// Describes a call constraint, as defined by a method and list of argument constraints.
+    /// </summary>
+    internal class CallConstraintDescriber
+    {
+        private readonly StringBuilderOutputWriter.Factory outputWriterFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallConstraintDescriber" /> class.
+        /// </summary>
+        /// <param name="outputWriterFactory">The output writer factory to use.</param>
+        public CallConstraintDescriber(StringBuilderOutputWriter.Factory outputWriterFactory)
+        {
+            this.outputWriterFactory = outputWriterFactory;
+        }
+
+        /// <summary>
+        /// Gets a human readable description of the call constraint
+        /// matcher.
+        /// </summary>
+        /// <param name="method">The method to describe.</param>
+        /// <param name="argumentConstraints">The argument constraints applied to the method.</param>
+        /// <returns>A human readable description of the call constraint.</returns>
+        public string GetDescriptionOfMatchingCall(MethodInfo method, IEnumerable<IArgumentConstraint> argumentConstraints)
+        {
+            var result = new StringBuilder();
+
+            result.Append(method.DeclaringType);
+            result.Append(".");
+            AppendMethodName(result, method);
+
+            this.AppendArgumentsListString(result, method, argumentConstraints);
+
+            return result.ToString();
+        }
+
+        private static void AppendMethodName(StringBuilder result, MethodInfo method)
+        {
+            result.Append(method.IsPropertyGetterOrSetter() ? method.Name.Substring(4) : method.Name);
+            result.Append(method.GetGenericArgumentsString());
+        }
+
+        private static IList<IArgumentConstraint> GetArgumentConstraintsForArgumentsList(MethodInfo method, IEnumerable<IArgumentConstraint> argumentConstraints)
+        {
+            var list = argumentConstraints.ToList();
+            if (method.IsPropertySetter())
+            {
+                list.RemoveAt(list.Count - 1);
+            }
+
+            return list;
+        }
+
+        private static void AppendArgumentListPrefix(StringBuilder builder, MethodInfo method) =>
+            builder.Append(method.IsPropertyGetterOrSetter() ? '[' : '(');
+
+        private static void AppendArgumentListSuffix(StringBuilder builder, MethodInfo method) =>
+            builder.Append(method.IsPropertyGetterOrSetter() ? ']' : ')');
+
+        private void AppendArgumentsListString(StringBuilder result, MethodInfo method, IEnumerable<IArgumentConstraint> argumentConstraints)
+        {
+            var constraints = GetArgumentConstraintsForArgumentsList(method, argumentConstraints);
+            var stringBuilderOutputWriter = this.outputWriterFactory(result);
+            if (constraints.Any() || !method.IsPropertyGetterOrSetter())
+            {
+                AppendArgumentListPrefix(result, method);
+                int index = 0;
+                var parameters = method.GetParameters();
+
+                foreach (var constraint in constraints)
+                {
+                    if (index > 0)
+                    {
+                        result.Append(", ");
+                    }
+
+                    var parameter = parameters[index];
+                    result.Append(parameter.Name + ": ");
+                    constraint.WriteDescription(stringBuilderOutputWriter);
+                    index++;
+                }
+
+                AppendArgumentListSuffix(result, method);
+            }
+
+            if (method.IsPropertySetter())
+            {
+                result.Append(" = ");
+                var valueConstraint = argumentConstraints.Last();
+                valueConstraint.WriteDescription(stringBuilderOutputWriter);
+            }
+        }
+    }
+}

--- a/src/FakeItEasy/Expressions/CallExpressionParser.cs
+++ b/src/FakeItEasy/Expressions/CallExpressionParser.cs
@@ -72,7 +72,7 @@ namespace FakeItEasy.Expressions
             return new ParsedCallExpression(
                 calledMethod: property.GetGetMethod(true),
                 callTargetExpression: expression.Expression,
-                argumentsExpressions: null);
+                argumentsExpressions: Enumerable.Empty<ParsedArgumentExpression>());
         }
 
         private static LambdaExpression ReplaceParameterWithFake(LambdaExpression callExpression, object fake)

--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -4,7 +4,6 @@ namespace FakeItEasy.Expressions
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-    using System.Text;
     using FakeItEasy.Configuration;
     using FakeItEasy.Core;
     using FakeItEasy.Expressions.ArgumentConstraints;
@@ -16,7 +15,7 @@ namespace FakeItEasy.Expressions
         : ICallMatcher
     {
         private readonly MethodInfoManager methodInfoManager;
-        private readonly StringBuilderOutputWriter.Factory outputWriterFactory;
+        private readonly CallConstraintDescriber callConstraintConstraintDescriber;
         private IEnumerable<IArgumentConstraint> argumentConstraints;
         private Func<ArgumentCollection, bool> argumentsPredicate;
 
@@ -26,25 +25,22 @@ namespace FakeItEasy.Expressions
         /// <param name="parsedExpression">The parsed call specification.</param>
         /// <param name="constraintFactory">The constraint factory.</param>
         /// <param name="methodInfoManager">The method info manager to use.</param>
-        /// <param name="outputWriterFactory">The output writer factory to use.</param>
-        public ExpressionCallMatcher(ParsedCallExpression parsedExpression, ExpressionArgumentConstraintFactory constraintFactory, MethodInfoManager methodInfoManager, StringBuilderOutputWriter.Factory outputWriterFactory)
+        /// <param name="callConstraintConstraintDescriber">The call constraint describer to use.</param>
+        public ExpressionCallMatcher(ParsedCallExpression parsedExpression, ExpressionArgumentConstraintFactory constraintFactory, MethodInfoManager methodInfoManager, CallConstraintDescriber callConstraintConstraintDescriber)
         {
             this.methodInfoManager = methodInfoManager;
-            this.outputWriterFactory = outputWriterFactory;
-
+            this.callConstraintConstraintDescriber = callConstraintConstraintDescriber;
             this.Method = parsedExpression.CalledMethod;
 
             this.argumentConstraints = GetArgumentConstraints(parsedExpression.ArgumentsExpressions, constraintFactory).ToArray();
             this.argumentsPredicate = this.ArgumentsMatchesArgumentConstraints;
         }
 
-        public delegate ExpressionCallMatcher Factory(ParsedCallExpression parsedExpression);
-
         /// <summary>
         /// Gets a human readable description of calls that will be matched by this
         /// matcher.
         /// </summary>
-        public virtual string DescriptionOfMatchingCall => this.ToString();
+        public virtual string DescriptionOfMatchingCall => this.callConstraintConstraintDescriber.GetDescriptionOfMatchingCall(this.Method, this.argumentConstraints);
 
         private MethodInfo Method { get; }
 
@@ -59,23 +55,6 @@ namespace FakeItEasy.Expressions
 
             return this.InvokesSameMethodOnTarget(call.FakedObject.GetType(), call.Method, this.Method)
                 && this.ArgumentsMatches(call.Arguments);
-        }
-
-        /// <summary>
-        /// Gets a description of the call.
-        /// </summary>
-        /// <returns>Description of the call.</returns>
-        public override string ToString()
-        {
-            var result = new StringBuilder();
-
-            result.Append(this.Method.DeclaringType);
-            result.Append(".");
-            this.AppendMethodName(result);
-
-            this.AppendArgumentsListString(result);
-
-            return result.ToString();
         }
 
         public virtual void UsePredicateToValidateArguments(Func<ArgumentCollection, bool> predicate)
@@ -98,103 +77,13 @@ namespace FakeItEasy.Expressions
             return null;
         }
 
-        private static IEnumerable<IArgumentConstraint> GetArgumentConstraints(IEnumerable<ParsedArgumentExpression> argumentExpressions, ExpressionArgumentConstraintFactory constraintFactory)
-        {
-            if (argumentExpressions == null)
-            {
-                return Enumerable.Empty<IArgumentConstraint>();
-            }
-
-            return
-                from argument in argumentExpressions
-                select constraintFactory.GetArgumentConstraint(argument);
-        }
+        private static IEnumerable<IArgumentConstraint> GetArgumentConstraints(IEnumerable<ParsedArgumentExpression> argumentExpressions, ExpressionArgumentConstraintFactory constraintFactory) =>
+            from argument in argumentExpressions
+            select constraintFactory.GetArgumentConstraint(argument);
 
         private bool InvokesSameMethodOnTarget(Type type, MethodInfo first, MethodInfo second)
         {
             return this.methodInfoManager.WillInvokeSameMethodOnTarget(type, first, second);
-        }
-
-        private void AppendMethodName(StringBuilder result)
-        {
-            if (this.Method.IsPropertyGetterOrSetter())
-            {
-                result.Append(this.Method.Name.Substring(4));
-            }
-            else
-            {
-                result.Append(this.Method.Name);
-            }
-
-            result.Append(this.Method.GetGenericArgumentsString());
-        }
-
-        private void AppendArgumentsListString(StringBuilder result)
-        {
-            var constraints = this.GetArgumentConstraintsForArgumentsList();
-            if (constraints.Any() || !this.Method.IsPropertyGetterOrSetter())
-            {
-                this.AppendArgumentListPrefix(result);
-                int index = 0;
-                var parameters = this.Method.GetParameters();
-
-                foreach (var constraint in constraints)
-                {
-                    if (index > 0)
-                    {
-                        result.Append(", ");
-                    }
-
-                    var parameter = parameters[index];
-                    result.Append(parameter.Name + ": ");
-                    constraint.WriteDescription(this.outputWriterFactory(result));
-                    index++;
-                }
-
-                this.AppendArgumentListSuffix(result);
-            }
-
-            if (this.Method.IsPropertySetter())
-            {
-                result.Append(" = ");
-                var valueConstraint = this.argumentConstraints.Last();
-                valueConstraint.WriteDescription(this.outputWriterFactory(result));
-            }
-        }
-
-        private IList<IArgumentConstraint> GetArgumentConstraintsForArgumentsList()
-        {
-            var list = this.argumentConstraints.ToList();
-            if (this.Method.IsPropertySetter())
-            {
-                list.RemoveAt(list.Count - 1);
-            }
-
-            return list;
-        }
-
-        private void AppendArgumentListPrefix(StringBuilder builder)
-        {
-            if (this.Method.IsPropertyGetterOrSetter())
-            {
-                builder.Append("[");
-            }
-            else
-            {
-                builder.Append("(");
-            }
-        }
-
-        private void AppendArgumentListSuffix(StringBuilder builder)
-        {
-            if (this.Method.IsPropertyGetterOrSetter())
-            {
-                builder.Append("]");
-            }
-            else
-            {
-                builder.Append(")");
-            }
         }
 
         private bool ArgumentsMatches(ArgumentCollection argumentCollection)

--- a/src/FakeItEasy/RootModule.cs
+++ b/src/FakeItEasy/RootModule.cs
@@ -34,11 +34,13 @@ namespace FakeItEasy
 
             container.RegisterSingleton<IExpressionCallMatcherFactory>(c => new ExpressionCallMatcherFactory(c));
 
+            container.RegisterSingleton(c => new CallConstraintDescriber(c.Resolve<StringBuilderOutputWriter.Factory>()));
+
             container.RegisterSingleton(c =>
                 new ExpressionArgumentConstraintFactory(c.Resolve<IArgumentConstraintTrapper>()));
 
             container.RegisterSingleton<ExpressionCallRule.Factory>(c =>
-                callSpecification => new ExpressionCallRule(new ExpressionCallMatcher(callSpecification, c.Resolve<ExpressionArgumentConstraintFactory>(), c.Resolve<MethodInfoManager>(), c.Resolve<StringBuilderOutputWriter.Factory>())));
+                callSpecification => new ExpressionCallRule(new ExpressionCallMatcher(callSpecification, c.Resolve<ExpressionArgumentConstraintFactory>(), c.Resolve<MethodInfoManager>(), c.Resolve<CallConstraintDescriber>())));
 
             container.RegisterSingleton(c =>
                 new MethodInfoManager());
@@ -132,7 +134,7 @@ namespace FakeItEasy
                     callSpecification,
                     this.serviceLocator.Resolve<ExpressionArgumentConstraintFactory>(),
                     this.serviceLocator.Resolve<MethodInfoManager>(),
-                    this.serviceLocator.Resolve<StringBuilderOutputWriter.Factory>());
+                    this.serviceLocator.Resolve<CallConstraintDescriber>());
             }
         }
 

--- a/tests/FakeItEasy.Tests/Expressions/ExpressionCallMatcherTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ExpressionCallMatcherTests.cs
@@ -144,7 +144,7 @@ namespace FakeItEasy.Tests.Expressions
         }
 
         [Fact]
-        public void ToString_should_write_full_method_name_with_type_name_and_arguments_list()
+        public void DescriptionOfMatchingCall_should_write_full_method_name_with_type_name_and_arguments_list()
         {
             var constraint = A.Fake<IArgumentConstraint>();
             A.CallTo(() => constraint.WriteDescription(A<IOutputWriter>._))
@@ -154,7 +154,7 @@ namespace FakeItEasy.Tests.Expressions
 
             var matcher = this.CreateMatcher<IFoo>(x => x.Bar(1, 2));
 
-            matcher.ToString().Should().Be("FakeItEasy.Tests.IFoo.Bar(argument: <FOO>, argument2: <FOO>)");
+            matcher.DescriptionOfMatchingCall.Should().Be("FakeItEasy.Tests.IFoo.Bar(argument: <FOO>, argument2: <FOO>)");
 
             A.CallTo(() => this.constraintFactory.GetArgumentConstraint(A<ParsedArgumentExpression>._)).MustHaveHappenedTwiceExactly();
         }
@@ -195,13 +195,13 @@ namespace FakeItEasy.Tests.Expressions
         }
 
         [Fact]
-        public void ToString_should_write_predicate_when_predicate_is_used_to_validate_arguments()
+        public void DescriptionOfMatchingCall_should_write_predicate_when_predicate_is_used_to_validate_arguments()
         {
             var matcher = this.CreateMatcher<IFoo>(x => x.Bar(null, null));
 
             matcher.UsePredicateToValidateArguments(x => true);
 
-            matcher.ToString().Should().Be("FakeItEasy.Tests.IFoo.Bar(argument: <Predicated>, argument2: <Predicated>)");
+            matcher.DescriptionOfMatchingCall.Should().Be("FakeItEasy.Tests.IFoo.Bar(argument: <Predicated>, argument2: <Predicated>)");
         }
 
         [Fact]
@@ -229,7 +229,7 @@ namespace FakeItEasy.Tests.Expressions
 
         private ExpressionCallMatcher CreateMatcher(ParsedCallExpression callSpecification)
         {
-            return new ExpressionCallMatcher(callSpecification, this.constraintFactory, this.methodInfoManager, this.outputWriterFactory);
+            return new ExpressionCallMatcher(callSpecification, this.constraintFactory, this.methodInfoManager, new CallConstraintDescriber(this.outputWriterFactory));
         }
 
         private void StubMethodInfoManagerToReturn(bool returnValue)


### PR DESCRIPTION
Fixes #684.