### PR TITLE
Enable code analysis

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" PrivateAssets="all" />
     <CodeAnalysisDictionary Include="$(MSBuildThisFileDirectory)src/FakeItEasy.Dictionary.xml">
       <Link>Properties\FakeItEasy.Dictionary.xml</Link>
     </CodeAnalysisDictionary>

--- a/src/FakeItEasy.Analyzer/ArgumentConstraintTypeMismatchAnalyzer.cs
+++ b/src/FakeItEasy.Analyzer/ArgumentConstraintTypeMismatchAnalyzer.cs
@@ -20,7 +20,7 @@ namespace FakeItEasy.Analyzer
 #endif
     public class ArgumentConstraintTypeMismatchAnalyzer : ArgumentConstraintAnalyzerBase
     {
-        internal static readonly string ParameterTypeKey = "parameterType";
+        internal const string ParameterTypeKey = "parameterType";
 
         private static readonly ImmutableHashSet<string> SupportedArgumentConstraintProperties =
             ImmutableHashSet.Create(

--- a/src/FakeItEasy.Analyzer/ArgumentConstraintTypeMismatchCodeFixProvider.cs
+++ b/src/FakeItEasy.Analyzer/ArgumentConstraintTypeMismatchCodeFixProvider.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy.Analyzer
 {
     using System.Collections.Immutable;
+    using System.Globalization;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,13 +30,13 @@ namespace FakeItEasy.Analyzer
             ImmutableArray.Create(DiagnosticDefinitions.ArgumentConstraintNullabilityMismatch.Id, DiagnosticDefinitions.ArgumentConstraintTypeMismatch.Id);
 
         private static string MakeConstraintNullableCodeFixTitle =>
-            DiagnosticDefinitions.ResourceManager.GetString(nameof(MakeConstraintNullableCodeFixTitle));
+            DiagnosticDefinitions.ResourceManager.GetString(nameof(MakeConstraintNullableCodeFixTitle), CultureInfo.CurrentUICulture);
 
         private static string MakeNotNullConstraintCodeFixTitle =>
-            DiagnosticDefinitions.ResourceManager.GetString(nameof(MakeNotNullConstraintCodeFixTitle));
+            DiagnosticDefinitions.ResourceManager.GetString(nameof(MakeNotNullConstraintCodeFixTitle), CultureInfo.CurrentUICulture);
 
         private static string ChangeConstraintTypeCodeFixTitle =>
-            DiagnosticDefinitions.ResourceManager.GetString(nameof(ChangeConstraintTypeCodeFixTitle));
+            DiagnosticDefinitions.ResourceManager.GetString(nameof(ChangeConstraintTypeCodeFixTitle), CultureInfo.CurrentUICulture);
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -81,7 +82,7 @@ namespace FakeItEasy.Analyzer
 
         private static async Task<Document> MakeConstraintNullableAsync(CodeFixContext context, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
-            var root = await context.Document.GetSyntaxRootAsync(cancellationToken);
+            var root = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var constraintNode = GetConstraintNode(diagnostic, root);
 
@@ -105,7 +106,7 @@ namespace FakeItEasy.Analyzer
 
         private static async Task<Document> MakeNotNullConstraintAsync(CodeFixContext context, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
-            var root = await context.Document.GetSyntaxRootAsync(cancellationToken);
+            var root = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var constraintNode = GetConstraintNode(diagnostic, root);
 
@@ -146,7 +147,7 @@ namespace FakeItEasy.Analyzer
 
         private static async Task<Document> ChangeConstraintTypeAsync(CodeFixContext context, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
-            var root = await context.Document.GetSyntaxRootAsync(cancellationToken);
+            var root = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             // The T type
             var constraintType = GetConstraintType(diagnostic, root);

--- a/src/FakeItEasy.ruleset
+++ b/src/FakeItEasy.ruleset
@@ -1,8 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="FakeItEasy" ToolsVersion="11.0">
   <Include Path="allrules.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1020" Action="None" />
+    <Rule Id="CA1200" Action="None" />
     <Rule Id="CA1305" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">

--- a/src/FakeItEasy/Compatibility/ArrayHelper.cs
+++ b/src/FakeItEasy/Compatibility/ArrayHelper.cs
@@ -1,0 +1,16 @@
+namespace FakeItEasy.Compatibility
+{
+    internal static class ArrayHelper
+    {
+#if FEATURE_ARRAY_EMPTY
+        public static T[] Empty<T>() => System.Array.Empty<T>();
+#else
+        public static T[] Empty<T>() => EmptyArrayCache<T>.EmptyArray;
+
+        private static class EmptyArrayCache<T>
+        {
+            public static readonly T[] EmptyArray = new T[0];
+        }
+#endif
+    }
+}

--- a/src/FakeItEasy/Configuration/ArgumentCollection.cs
+++ b/src/FakeItEasy/Configuration/ArgumentCollection.cs
@@ -21,7 +21,9 @@ namespace FakeItEasy.Configuration
         /// <summary>
         ///   The arguments this collection contains.
         /// </summary>
+#pragma warning disable CA2235 // Mark all non-serializable fields
         private readonly object[] arguments;
+#pragma warning restore CA2235 // Mark all non-serializable fields
 
         /// <summary>
         ///   Initializes a new instance of the <see cref = "ArgumentCollection" /> class.
@@ -60,7 +62,9 @@ namespace FakeItEasy.Configuration
         /// </summary>
         public IEnumerable<string> ArgumentNames { get; }
 
+#pragma warning disable CA2235 // Mark all non-serializable fields
         internal MethodInfo Method { get; }
+#pragma warning restore CA2235 // Mark all non-serializable fields
 
         /// <summary>
         ///   Gets the argument at the specified index.

--- a/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
+++ b/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
@@ -4,6 +4,7 @@ namespace FakeItEasy.Configuration
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
+    using FakeItEasy.Compatibility;
     using FakeItEasy.Expressions;
 
     internal class PropertyExpressionHelper
@@ -19,7 +20,7 @@ namespace FakeItEasy.Configuration
                                             "' must refer to a property or indexer getter, but doesn't.");
             }
 
-            var parsedArgumentExpressions = parsedCallExpression.ArgumentsExpressions ?? new ParsedArgumentExpression[0];
+            var parsedArgumentExpressions = parsedCallExpression.ArgumentsExpressions ?? ArrayHelper.Empty<ParsedArgumentExpression>();
             var parameterTypes = parsedArgumentExpressions
                 .Select(p => p.ArgumentInformation.ParameterType)
                 .Concat(new[] { parsedCallExpression.CalledMethod.ReturnType })

--- a/src/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
+++ b/src/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Core
+namespace FakeItEasy.Core
 {
     using System;
     using System.Runtime.CompilerServices;
@@ -12,7 +12,9 @@
     internal class DefaultFakeManagerAccessor
         : IFakeManagerAccessor
     {
+#pragma warning disable CA2235 // Mark all non-serializable fields
         private static readonly ConditionalWeakTable<object, FakeManager> FakeManagers = new ConditionalWeakTable<object, FakeManager>();
+#pragma warning restore CA2235 // Mark all non-serializable fields
 
         /// <summary>
         /// Gets the fake manager associated with the proxy.

--- a/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Core
+namespace FakeItEasy.Core
 {
     using System;
     using System.Collections.Generic;
@@ -14,12 +14,14 @@
         private class ObjectMemberRule
             : IFakeObjectCallRule
         {
+#pragma warning disable CA2235 // Mark all non-serializable fields
             private static readonly List<MethodInfo> ObjectMethods =
+#pragma warning restore CA2235 // Mark all non-serializable fields
                 new List<MethodInfo>
                     {
                         typeof(object).GetMethod("Equals", new[] { typeof(object) }),
-                        typeof(object).GetMethod("ToString", new Type[] { }),
-                        typeof(object).GetMethod("GetHashCode", new Type[] { })
+                        typeof(object).GetMethod("ToString", Type.EmptyTypes),
+                        typeof(object).GetMethod("GetHashCode", Type.EmptyTypes)
                     };
 
             private readonly FakeManager fakeManager;

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Core
+namespace FakeItEasy.Core
 {
     using System;
     using System.Collections.Concurrent;
@@ -18,10 +18,12 @@
     {
         private readonly CallRuleMetadata[] postUserRules;
         private readonly CallRuleMetadata[] preUserRules;
+#pragma warning disable CA2235 // Mark all non-serializable fields
         private readonly LinkedList<IInterceptionListener> interceptionListeners;
         private readonly WeakReference objectReference;
 
         private ConcurrentQueue<ICompletedFakeObjectCall> recordedCalls;
+#pragma warning restore CA2235 // Mark all non-serializable fields
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FakeManager"/> class.
@@ -66,13 +68,16 @@
         /// <summary>
         /// Gets the faked proxy object.
         /// </summary>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Object", Justification = "Renaming this property would be a breaking change.")]
+#pragma warning disable CA1716, CA1720 // Identifier contains keyword, Identifier contains type name
         public virtual object Object => this.objectReference.Target;
+#pragma warning restore CA1716, CA1720 // Identifier contains keyword, Identifier contains type name
 
         /// <summary>
         /// Gets the faked type.
         /// </summary>
+#pragma warning disable CA2235 // Mark all non-serializable fields
         public virtual Type FakeObjectType { get; }
+#pragma warning restore CA2235 // Mark all non-serializable fields
 
         /// <summary>
         /// Gets the interceptions that are currently registered with the fake object.
@@ -82,7 +87,9 @@
             get { return this.AllUserRules.Select(x => x.Rule); }
         }
 
+#pragma warning disable CA2235 // Mark all non-serializable fields
         internal LinkedList<CallRuleMetadata> AllUserRules { get; }
+#pragma warning restore CA2235 // Mark all non-serializable fields
 
         private IEnumerable<CallRuleMetadata> AllRules =>
             this.preUserRules.Concat(this.AllUserRules.Concat(this.postUserRules));

--- a/src/FakeItEasy/Core/FakeManagerProvider.cs
+++ b/src/FakeItEasy/Core/FakeManagerProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Core
+namespace FakeItEasy.Core
 {
     using System;
     using FakeItEasy.Creation;
@@ -35,7 +35,9 @@
         private readonly IProxyOptions proxyOptions;
 
         // We want to lock accesses to initializedFakeManager to guarantee thread-safety (see IFakeCallProcessorProvider documentation):
+#pragma warning disable CA2235 // Mark all non-serializable fields
         private readonly object initializedFakeManagerLock = new object();
+#pragma warning restore CA2235 // Mark all non-serializable fields
 
         private FakeManager initializedFakeManager;
 

--- a/src/FakeItEasy/Core/MethodInfoManager.cs
+++ b/src/FakeItEasy/Core/MethodInfoManager.cs
@@ -160,7 +160,7 @@ namespace FakeItEasy.Core
             return type.GetInterfaces().Any(x => x.Equals(interfaceType));
         }
 
-        private struct TypeMethodInfoPair
+        private struct TypeMethodInfoPair : IEquatable<TypeMethodInfoPair>
         {
             public TypeMethodInfoPair(Type type, MethodInfo methodInfo)
                 : this()
@@ -186,6 +186,11 @@ namespace FakeItEasy.Core
             {
                 var other = (TypeMethodInfoPair)obj;
 
+                return this.Equals(other);
+            }
+
+            public bool Equals(TypeMethodInfoPair other)
+            {
                 return this.Type == other.Type && this.MethodInfo == other.MethodInfo;
             }
         }

--- a/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
+++ b/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
@@ -71,7 +71,9 @@ namespace FakeItEasy.Core
             return new[] { this.hasSender ? this.eventSender : fake, this.eventArguments };
         }
 
+#pragma warning disable CA1822 // Mark members as static
         private void Now(object sender, TEventArgs e)
+#pragma warning restore CA1822 // Mark members as static
         {
             throw new NotSupportedException(ExceptionMessages.NowCalledDirectly);
         }

--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleInvocationCallAdapter.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleInvocationCallAdapter.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Creation.CastleDynamicProxy
+namespace FakeItEasy.Creation.CastleDynamicProxy
 {
     using System;
     using System.Diagnostics;
@@ -18,7 +18,9 @@
         : IInterceptedFakeObjectCall
     {
         private readonly IInvocation invocation;
+#pragma warning disable CA2235 // Mark all non-serializable fields
         private readonly object[] originalArguments;
+#pragma warning restore CA2235 // Mark all non-serializable fields
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CastleInvocationCallAdapter"/> class.
@@ -36,7 +38,9 @@
         /// <summary>
         /// Gets the method that's called.
         /// </summary>
+#pragma warning disable CA2235 // Mark all non-serializable fields
         public MethodInfo Method { get; }
+#pragma warning restore CA2235 // Mark all non-serializable fields
 
         /// <summary>
         /// Gets the arguments used in the call.

--- a/src/FakeItEasy/FakeFacade.cs
+++ b/src/FakeItEasy/FakeFacade.cs
@@ -51,7 +51,9 @@ namespace FakeItEasy
             manager.ClearRecordedCalls();
         }
 
+#pragma warning disable CA1822 // Mark members as static
         public void InitializeFixture(object fixture)
+#pragma warning restore CA1822 // Mark members as static
         {
             Guard.AgainstNull(fixture, nameof(fixture));
 

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -35,7 +35,7 @@
   <!-- .NET Standard 1.6 -->
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <DefineConstants>$(DefineConstants);FEATURE_NETCORE_REFLECTION;FEATURE_EXCEPTION_DISPATCH_INFO</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_NETCORE_REFLECTION;FEATURE_EXCEPTION_DISPATCH_INFO;FEATURE_ARRAY_EMPTY</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">

--- a/src/FakeItEasy/Guard.cs
+++ b/src/FakeItEasy/Guard.cs
@@ -26,6 +26,7 @@ namespace FakeItEasy
         /// <summary>
         /// When applied to a parameter, this attribute provides an indication to code analysis that the argument has been null checked.
         /// </summary>
+        [AttributeUsage(AttributeTargets.Parameter)]
         private sealed class ValidatedNotNullAttribute : Attribute
         {
         }

--- a/src/FakeItEasy/Raise.cs
+++ b/src/FakeItEasy/Raise.cs
@@ -77,7 +77,9 @@ namespace FakeItEasy
         /// with all CLR languages (for example Visual Basic).
         /// To raise non-standard events from other languages, use <see cref="Raise.FreeForm{TEventHandler}"/>.
         /// </summary>
+#pragma warning disable CA1034 // Do not nest type
         public static class FreeForm
+#pragma warning restore CA1034 // Do not nest type
         {
             /// <summary>
             /// Raises an event with non-standard signature, resolving the actual delegate type dynamically.
@@ -97,14 +99,18 @@ namespace FakeItEasy
         /// Otherwise, prefer <see cref="Raise.FreeForm" />.
         /// </summary>
         /// <typeparam name="TEventHandler">The type of the event handler. Should be a <see cref="Delegate"/>.</typeparam>
+#pragma warning disable CA1034 // Do not nest type
         public static class FreeForm<TEventHandler>
+#pragma warning restore CA1034 // Do not nest type
         {
             /// <summary>
             /// Raises an event with non-standard signature.
             /// </summary>
             /// <param name="arguments">The arguments to send to the event handlers.</param>
             /// <returns>A new object that knows how to raise events.</returns>
+#pragma warning disable CA1000 // Do not declare static members on generic types
             public static TEventHandler With(params object[] arguments)
+#pragma warning restore CA1000 // Do not declare static members on generic types
             {
                 return new DelegateRaiser<TEventHandler>(arguments, ArgumentProviderMap);
             }

--- a/src/FakeItEasy/StringBuilderExtensions.cs
+++ b/src/FakeItEasy/StringBuilderExtensions.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy
 {
     using System.Text;
+    using FakeItEasy.Compatibility;
 
     /// <summary>
     /// Provides extension methods for <see cref="StringBuilder"/>.
@@ -9,7 +10,7 @@ namespace FakeItEasy
     {
         public static StringBuilder AppendIndented(this StringBuilder builder, string indentString, string value)
         {
-            var lines = value == null ? new string[] { } : value.Split('\n');
+            var lines = value?.Split('\n') ?? ArrayHelper.Empty<string>();
 
             for (var i = 0; i < lines.Length; i++)
             {

--- a/src/FakeItEasy/TaskHelper.cs
+++ b/src/FakeItEasy/TaskHelper.cs
@@ -4,6 +4,7 @@ namespace FakeItEasy
     using System.Collections.Concurrent;
     using System.Reflection;
     using System.Threading.Tasks;
+    using FakeItEasy.Compatibility;
 
     internal static class TaskHelper
     {
@@ -50,7 +51,7 @@ namespace FakeItEasy
                 type =>
                 {
                     var method = CreateGenericCanceledTaskGenericDefinition.MakeGenericMethod(type);
-                    return (Task)method.Invoke(null, new object[0]);
+                    return (Task)method.Invoke(null, ArrayHelper.Empty<object>());
                 });
         }
 

--- a/tests/FakeItEasy.Analyzer.Tests.Shared/Helpers/DiagnosticResult.cs
+++ b/tests/FakeItEasy.Analyzer.Tests.Shared/Helpers/DiagnosticResult.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Analyzer.Tests.Helpers
+namespace FakeItEasy.Analyzer.Tests.Helpers
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
@@ -49,7 +49,7 @@
             {
                 if (this.locations == null)
                 {
-                    this.locations = new DiagnosticResultLocation[] { };
+                    this.locations = Array.Empty<DiagnosticResultLocation>();
                 }
 
                 return this.locations;

--- a/tests/FakeItEasy.IntegrationTests/DummyTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/DummyTests.cs
@@ -55,8 +55,8 @@ namespace FakeItEasy.IntegrationTests
             // the other is still being created.
             // Guards against the concurrent creations being detected as a
             // circular dependency and throwing an exception.
-            var makeOne = Task.Factory.StartNew(A.Dummy<ConcurrentCreationDummy>);
-            var makeTwo = Task.Factory.StartNew(() =>
+            var makeOne = Task.Run(() => A.Dummy<ConcurrentCreationDummy>());
+            var makeTwo = Task.Run(() =>
             {
                 ConcurrentCreationDummy.CreatingFirstInstance.Wait();
                 try

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -422,8 +422,7 @@ namespace FakeItEasy.Specs
         [Scenario]
         public static void IgnoredArgumentConstraintForDifferentValueTypeWithNonNullArgument(
             IHaveANullableParameter subject,
-            Exception exception,
-            int result)
+            Exception exception)
         {
             "Given a fake with a method that accepts a nullable value type parameter"
                 .x(() => subject = A.Fake<IHaveANullableParameter>());

--- a/tests/FakeItEasy.Specs/FixtureInitializationSpecs.cs
+++ b/tests/FakeItEasy.Specs/FixtureInitializationSpecs.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Specs
+namespace FakeItEasy.Specs
 {
     using System;
     using System.Reflection;
@@ -91,9 +91,9 @@
             public IFoo UnattributedFooField;
 
             [Fake]
-#pragma warning disable CS0169 // it's used by reflection
+#pragma warning disable CS0169, CA1823 // it's used by reflection
             private IFoo privateFoo;
-#pragma warning restore CS0169
+#pragma warning restore CS0169, CA1823
         }
 
         public class SutExample

--- a/tests/FakeItEasy.Tests.ruleset
+++ b/tests/FakeItEasy.Tests.ruleset
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="FakeItEasy Tests" ToolsVersion="14.0">
   <Include Path="..\src\fakeiteasy.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
@@ -12,7 +12,9 @@
     <Rule Id="CA1025" Action="None" />
     <Rule Id="CA1034" Action="None" />
     <Rule Id="CA1045" Action="None" />
+    <Rule Id="CA1051" Action="None" />
     <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1068" Action="None" />
     <Rule Id="CA1303" Action="None" />
     <Rule Id="CA1305" Action="None" />
     <Rule Id="CA1402" Action="None" />
@@ -23,6 +25,7 @@
     <Rule Id="CA1709" Action="None" />
     <Rule Id="CA1716" Action="None" />
     <Rule Id="CA1720" Action="None" />
+    <Rule Id="CA1724" Action="None" />
     <Rule Id="CA1822" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2204" Action="None" />

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CollectionContainsTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CollectionContainsTests.cs
@@ -1,5 +1,6 @@
 namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
 {
+    using System;
     using System.Collections.Generic;
     using Xunit;
 
@@ -12,7 +13,7 @@ namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
         {
             return TestCases.FromObject(
                 null,
-                new object[] { },
+                Array.Empty<object>(),
                 new object[] { null },
                 new object[] { 1, 2, 3, "foo", "bar" });
         }

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CollectionIsEmptyTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/CollectionIsEmptyTests.cs
@@ -1,5 +1,6 @@
 namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Xunit;
@@ -23,7 +24,7 @@ namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
             return TestCases.FromObject(
                 new List<object>(),
                 Enumerable.Empty<object>(),
-                new object[0]);
+                Array.Empty<object>());
         }
 
         [Theory]

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/IsSameSequenceAsTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/IsSameSequenceAsTests.cs
@@ -1,5 +1,6 @@
 namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
 {
+    using System;
     using System.Collections.Generic;
     using Xunit;
 
@@ -12,7 +13,7 @@ namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
         {
             return TestCases.FromObject(
                 new[] { "1", "2", "x", "y" },
-                new string[] { },
+                Array.Empty<string>(),
                 null,
                 new[] { "a", "b", null, "z", "x" },
                 new[] { "a", "b" });

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/IsSameSequenceAsWithLongSequenceTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/IsSameSequenceAsWithLongSequenceTests.cs
@@ -1,5 +1,6 @@
 namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Xunit;
@@ -13,7 +14,7 @@ namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
         {
             return TestCases.FromObject(
                 new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 },
-                new int[] { },
+                Array.Empty<int>(),
                 null,
                 new[] { 1, 2, 3, 4 },
                 new[] { 9, 8 });

--- a/tests/FakeItEasy.Tests/Configuration/ArgumentCollectionTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/ArgumentCollectionTests.cs
@@ -20,7 +20,9 @@ namespace FakeItEasy.Tests.Configuration
         public void Constructor_is_properly_guarded()
         {
             var method = typeof(IFoo).GetMethod("Bar", new[] { typeof(object), typeof(object) });
+#pragma warning disable CA1806 // Do not ignore method results
             Expression<Action> call = () => new ArgumentCollection(new object[] { "foo", 1 }, method);
+#pragma warning restore CA1806 // Do not ignore method results
             call.Should().BeNullGuarded();
         }
 

--- a/tests/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
@@ -278,7 +278,7 @@ namespace FakeItEasy.Tests.Configuration
         [Fact]
         public void OutAndRefParameterProducer_should_not_be_settable_more_than_once()
         {
-            this.rule.OutAndRefParametersValueProducer = x => new object[0];
+            this.rule.OutAndRefParametersValueProducer = x => Array.Empty<object>();
 
             var exception = Record.Exception(() => this.rule.OutAndRefParametersValueProducer = x => new object[] { "test" });
             exception.Should().BeAnExceptionOfType<InvalidOperationException>();

--- a/tests/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
@@ -34,7 +34,7 @@ namespace FakeItEasy.Tests.Configuration
                 configuration => configuration.DoesNothing(),
                 configuration => configuration.Throws<Exception>(),
                 configuration => configuration.Invokes(DoNothing),
-                configuration => configuration.AssignsOutAndRefParametersLazily(_ => new object[0]));
+                configuration => configuration.AssignsOutAndRefParametersLazily(_ => Array.Empty<object>()));
 
         public static IEnumerable<object[]> BehaviorDefinitionActionsForNonVoid =>
             TestCases.FromObject<Action<IAnyCallConfigurationWithReturnTypeSpecified<int>>>(

--- a/tests/FakeItEasy.Tests/Core/ArgumentConstraintTrapTests.cs
+++ b/tests/FakeItEasy.Tests/Core/ArgumentConstraintTrapTests.cs
@@ -87,7 +87,7 @@ namespace FakeItEasy.Tests.Core
             IArgumentConstraint lateStartingResult = null;
 
             // Act
-            var earlyStartingTask = Task.Factory.StartNew(() =>
+            var earlyStartingTask = Task.Run(() =>
             {
                 earlyStartingResult = this.trap.TrapConstraints(() =>
                 {
@@ -98,7 +98,7 @@ namespace FakeItEasy.Tests.Core
                 }).SingleOrDefault();
             });
 
-            var lateStartingTask = Task.Factory.StartNew(() =>
+            var lateStartingTask = Task.Run(() =>
             {
                 lateStartingLock.Wait();
 

--- a/tests/FakeItEasy.Tests/Core/DefaultExceptionThrowerTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DefaultExceptionThrowerTests.cs
@@ -17,7 +17,7 @@ namespace FakeItEasy.Tests.Core
                 {
                     TypeOfFake = typeof(string),
                     ReasonForFailureOfDefaultConstructor = "reason",
-                    ResolvedConstructors = new ResolvedConstructor[] { },
+                    ResolvedConstructors = Array.Empty<ResolvedConstructor>(),
                     ExpectedMessage = @"
   Failed to create fake of type System.String.
 

--- a/tests/FakeItEasy.Tests/Core/DefaultFakeObjectCallFormatterTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DefaultFakeObjectCallFormatterTests.cs
@@ -45,7 +45,7 @@ namespace FakeItEasy.Tests.Core
         public void Should_write_empty_argument_list()
         {
             // Arrange
-            var call = this.CreateFakeCall(typeof(object).GetMethod("ToString", new Type[] { }));
+            var call = this.CreateFakeCall(typeof(object).GetMethod("ToString", Type.EmptyTypes));
 
             // Act
             var description = this.formatter.GetDescription(call);

--- a/tests/FakeItEasy.Tests/Core/FakeCallEqualityComparerTests.cs
+++ b/tests/FakeItEasy.Tests/Core/FakeCallEqualityComparerTests.cs
@@ -9,7 +9,7 @@ namespace FakeItEasy.Tests.Core
 
     public class FakeCallEqualityComparerTests
     {
-        private static readonly MethodInfo ToStringMethod = typeof(object).GetMethod("ToString", new Type[] { });
+        private static readonly MethodInfo ToStringMethod = typeof(object).GetMethod("ToString", Type.EmptyTypes);
         private static readonly MethodInfo EqualsMethod = typeof(object).GetMethod("Equals", new[] { typeof(object) });
 
         private readonly FakeCallEqualityComparer comparer;
@@ -119,7 +119,7 @@ namespace FakeItEasy.Tests.Core
             var call = A.Fake<IFakeObjectCall>();
 
             A.CallTo(() => call.Method).Returns(ToStringMethod);
-            A.CallTo(() => call.Arguments).Returns(new ArgumentCollection(new object[] { }, A.Fake<MethodInfo>()));
+            A.CallTo(() => call.Arguments).Returns(new ArgumentCollection(Array.Empty<object>(), A.Fake<MethodInfo>()));
 
             return call;
         }

--- a/tests/FakeItEasy.Tests/Core/MethodInfoManagerTests.cs
+++ b/tests/FakeItEasy.Tests/Core/MethodInfoManagerTests.cs
@@ -211,16 +211,14 @@ namespace FakeItEasy.Tests.Core
             {
             }
 
-            public T GetDefault<T>()
-            {
-                return default(T);
-            }
+            public T GetDefault<T>() => default(T);
 
             [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "other", Justification = "Required for testing.")]
-            public bool Equals(Base other)
-            {
-                return true;
-            }
+            public bool Equals(Base other) => true;
+
+            public override bool Equals(object other) => true;
+
+            public override int GetHashCode() => 0;
         }
 
         public class Derived : Base

--- a/tests/FakeItEasy.Tests/Core/WrappedObjectRuleTests.cs
+++ b/tests/FakeItEasy.Tests/Core/WrappedObjectRuleTests.cs
@@ -45,7 +45,7 @@ namespace FakeItEasy.Tests.Core
             var wrapped = A.Fake<IFoo>();
             A.CallTo(() => wrapped.Baz()).Returns(returnValue);
 
-            var call = FakeCall.Create<IFoo>("Baz", new Type[] { }, new object[] { });
+            var call = FakeCall.Create<IFoo>("Baz", Type.EmptyTypes, Array.Empty<object>());
 
             var rule = this.CreateRule(wrapped);
             rule.Apply(call);

--- a/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyGeneratorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
+namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
 {
     using System;
     using System.Collections.Generic;
@@ -148,7 +148,7 @@
             // Arrange
             // Here we can't use A.Dummy<IFakeCallProcessorProvider>() because the EnsureInitialized() call within GenerateProxy()
             // triggers the Castle issue #65 (https://github.com/castleproject/Core/issues/65)
-            var result = this.generator.GenerateProxy(typeOfProxy, new Type[] { }, null, new SerializableFakeCallProcessorProvider());
+            var result = this.generator.GenerateProxy(typeOfProxy, Type.EmptyTypes, null, new SerializableFakeCallProcessorProvider());
             var proxy = result.GeneratedProxy;
 
             // Act

--- a/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleInvocationCallAdapterTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleInvocationCallAdapterTests.cs
@@ -15,8 +15,8 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
         {
             var invocation = A.Fake<IInvocation>();
 
-            A.CallTo(() => invocation.Arguments).Returns(new object[] { });
-            A.CallTo(() => invocation.Method).Returns(typeof(IFoo).GetMethod("Bar", new Type[] { }));
+            A.CallTo(() => invocation.Arguments).Returns(Array.Empty<object>());
+            A.CallTo(() => invocation.Method).Returns(typeof(IFoo).GetMethod("Bar", Type.EmptyTypes));
 
             var adapter = new CastleInvocationCallAdapter(invocation);
 
@@ -29,8 +29,8 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
         public void SetArgumentValue_sets_the_argument_value_of_the_invocation()
         {
             var invocation = A.Fake<IInvocation>();
-            A.CallTo(() => invocation.Arguments).Returns(new object[] { });
-            A.CallTo(() => invocation.Method).Returns(typeof(IFoo).GetMethod("Bar", new Type[] { }));
+            A.CallTo(() => invocation.Arguments).Returns(Array.Empty<object>());
+            A.CallTo(() => invocation.Method).Returns(typeof(IFoo).GetMethod("Bar", Type.EmptyTypes));
 
             var adapter = new CastleInvocationCallAdapter(invocation);
 

--- a/tests/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/DefaultFakeObjectCreatorTests.cs
@@ -324,7 +324,7 @@ namespace FakeItEasy.Tests.Creation
 
                     foreach (var constructorPair in x.Zip(constructors, (constructor1, constructor2) => new { Constructor1 = constructor1, Constructor2 = constructor2 }))
                     {
-                        if (!string.Equals(constructorPair.Constructor1.ReasonForFailure, constructorPair.Constructor2.ReasonForFailure))
+                        if (constructorPair.Constructor1.ReasonForFailure != constructorPair.Constructor2.ReasonForFailure)
                         {
                             return false;
                         }

--- a/tests/FakeItEasy.Tests/Creation/DummyValueResolverTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/DummyValueResolverTests.cs
@@ -256,7 +256,7 @@ namespace FakeItEasy.Tests.Creation
 
         private DynamicDummyFactory CreateDummyFactoryThatMakesNoDummy()
         {
-            return new DynamicDummyFactory(new IDummyFactory[0]);
+            return new DynamicDummyFactory(Array.Empty<IDummyFactory>());
         }
 
         public class ClassWithDefaultConstructor

--- a/tests/FakeItEasy.Tests/Creation/ProxyGeneratorResultTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/ProxyGeneratorResultTests.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Tests.Creation
+namespace FakeItEasy.Tests.Creation
 {
     using System;
     using System.Linq.Expressions;
@@ -145,7 +145,9 @@
             // Act
 
             // Assert
+#pragma warning disable CA1806 // Do not ignore method results
             Expression<Action> call = () => new ProxyGeneratorResult("reason");
+#pragma warning restore CA1806 // Do not ignore method results
             call.Should().BeNullGuarded();
         }
 
@@ -157,7 +159,9 @@
             // Act
 
             // Assert
+#pragma warning disable CA1806 // Do not ignore method results
             Expression<Action> call = () => new ProxyGeneratorResult(new object());
+#pragma warning restore CA1806 // Do not ignore method results
             call.Should().BeNullGuarded();
         }
     }

--- a/tests/FakeItEasy.Tests/Creation/ProxyGeneratorSelectorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/ProxyGeneratorSelectorTests.cs
@@ -29,8 +29,8 @@ namespace FakeItEasy.Tests.Creation
         public void Should_delegate_calls_to_delegate_generator_when_generating_delegate_proxy()
         {
             // Arrange
-            var additionalInterfaces = new Type[] { };
-            var argumentsForConstructor = new object[] { };
+            var additionalInterfaces = Type.EmptyTypes;
+            var argumentsForConstructor = Array.Empty<object>();
             var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
 
             var expected = A.Dummy<ProxyGeneratorResult>();
@@ -48,8 +48,8 @@ namespace FakeItEasy.Tests.Creation
         public void Should_delegate_calls_to_default_generator_when_generating_non_delegate_proxy()
         {
             // Arrange
-            var additionalInterfaces = new Type[] { };
-            var argumentsForConstructor = new object[] { };
+            var additionalInterfaces = Type.EmptyTypes;
+            var argumentsForConstructor = Array.Empty<object>();
             var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
 
             var expected = A.Dummy<ProxyGeneratorResult>();

--- a/tests/FakeItEasy.Tests/ExceptionContractTests.cs
+++ b/tests/FakeItEasy.Tests/ExceptionContractTests.cs
@@ -99,7 +99,7 @@ namespace FakeItEasy.Tests
             // Arrange
 
             // Act
-            var constructor = typeof(T).GetConstructor(new Type[] { });
+            var constructor = typeof(T).GetConstructor(Type.EmptyTypes);
 
             // Assert
             constructor.Should().NotBeNull("exception classes should provide a public default constructor.");

--- a/tests/FakeItEasy.Tests/Expressions/CallExpressionParserTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/CallExpressionParserTests.cs
@@ -26,13 +26,13 @@ namespace FakeItEasy.Tests.Expressions
         public void Should_return_parsed_expression_with_instance_method_set()
         {
             // Arrange
-            var call = Call(() => string.Empty.Equals(null));
+            var call = Call(() => string.Empty.Equals(null, StringComparison.CurrentCulture));
 
             // Act
             var result = this.parser.Parse(call);
 
             // Assert
-            result.CalledMethod.Should().BeSameAs(GetMethod<string>("Equals", typeof(string)));
+            result.CalledMethod.Should().BeSameAs(GetMethod<string>("Equals", typeof(string), typeof(StringComparison)));
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace FakeItEasy.Tests.Expressions
         {
             return typeof(T)
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-                .Where(x => x.Name.Equals(propertyName))
+                .Where(x => x.Name == propertyName)
                 .Select(x => x.GetGetMethod(true))
                 .Single();
         }

--- a/tests/FakeItEasy.Tests/Expressions/ExpressionArgumentConstraintFactoryTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ExpressionArgumentConstraintFactoryTests.cs
@@ -184,7 +184,7 @@ namespace FakeItEasy.Tests.Expressions
             {
                 Guard.AgainstNull(call, nameof(call));
 
-                if (call.Method.Name.Equals("TrapConstraints"))
+                if (call.Method.Name == "TrapConstraints")
                 {
                     this.realTrap.TrapConstraints(call.GetArgument<Action>(0));
                 }

--- a/tests/FakeItEasy.Tests/Expressions/ExpressionCallRuleTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ExpressionCallRuleTests.cs
@@ -50,7 +50,9 @@ namespace FakeItEasy.Tests.Expressions
         [Fact]
         public void Constructor_should_be_null_guarded()
         {
+#pragma warning disable CA1806 // Do not ignore method results
             Expression<Action> call = () => new ExpressionCallRule(this.callMatcher);
+#pragma warning restore CA1806 // Do not ignore method results
             call.Should().BeNullGuarded();
         }
 

--- a/tests/FakeItEasy.Tests/FacadedTestBase.cs
+++ b/tests/FakeItEasy.Tests/FacadedTestBase.cs
@@ -30,14 +30,14 @@ namespace FakeItEasy.Tests
 
         private bool IsExcluedMethod(MethodInfo facadedMethod)
         {
-            return facadedMethod.Name.Equals("ReferenceEquals") || facadedMethod.Name.Equals("Equals");
+            return facadedMethod.Name == "ReferenceEquals" || facadedMethod.Name == "Equals";
         }
 
         private bool NameSignatureAndReturnTypeEquals(MethodInfo method1, MethodInfo method2)
         {
             return
                 object.Equals(method1.ReturnType, method2.ReturnType)
-                && string.Equals(method1.Name, method2.Name)
+                && method1.Name == method2.Name
                 && this.AllArgumentsEquals(method1, method2);
         }
 
@@ -59,7 +59,7 @@ namespace FakeItEasy.Tests
                         }))
             {
                 if (!object.Equals(argument.Method1Parameter.ParameterType, argument.Method2Parameter.ParameterType) ||
-                    !string.Equals(argument.Method1Parameter.Name, argument.Method2Parameter.Name))
+                    argument.Method1Parameter.Name != argument.Method2Parameter.Name)
                 {
                     return false;
                 }

--- a/tests/FakeItEasy.Tests/Fake.of.T.Tests.cs
+++ b/tests/FakeItEasy.Tests/Fake.of.T.Tests.cs
@@ -22,8 +22,9 @@ namespace FakeItEasy.Tests
         {
             Action<IFakeOptions<Foo>> optionsBuilder = x => { };
 
-            Expression<Action> call = () =>
-                new Fake<Foo>(optionsBuilder);
+#pragma warning disable CA1806 // Do not ignore method results
+            Expression<Action> call = () => new Fake<Foo>(optionsBuilder);
+#pragma warning restore CA1806 // Do not ignore method results
             call.Should().BeNullGuarded();
         }
 

--- a/tests/FakeItEasy.Tests/FakeCall.cs
+++ b/tests/FakeItEasy.Tests/FakeCall.cs
@@ -19,7 +19,9 @@ namespace FakeItEasy.Tests
 
         public ArgumentCollection Arguments { get; private set; }
 
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
         public ArgumentCollection ArgumentsAfterCall => throw new NotImplementedException();
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
 
         public object ReturnValue { get; private set; }
 
@@ -44,7 +46,7 @@ namespace FakeItEasy.Tests
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "By design.")]
         public static FakeCall Create<T>(string methodName) where T : class
         {
-            return Create<T>(methodName, new Type[] { }, new object[] { });
+            return Create<T>(methodName, Type.EmptyTypes, Array.Empty<object>());
         }
 
         public void SetReturnValue(object value)

--- a/tests/FakeItEasy.Tests/NullGuardedAssertion.cs
+++ b/tests/FakeItEasy.Tests/NullGuardedAssertion.cs
@@ -200,7 +200,7 @@ namespace FakeItEasy.Tests
 
                             var nullException = ex.InnerException as ArgumentNullException;
                             if (nullException == null ||
-                                !callThatShouldThrow.ArgumentName.Equals(nullException.ParamName))
+                                callThatShouldThrow.ArgumentName != nullException.ParamName)
                             {
                                 result.Add(callThatShouldThrow);
                             }

--- a/tests/FakeItEasy.Tests/NullGuardedAssertionTests.cs
+++ b/tests/FakeItEasy.Tests/NullGuardedAssertionTests.cs
@@ -45,7 +45,9 @@ namespace FakeItEasy.Tests
         [Fact]
         public void Assert_should_pass_when_call_is_properly_guarded_constructor()
         {
+#pragma warning disable CA1806 // Do not ignore method results
             AssertShouldPass(() => new ClassWithProperlyGuardedConstructor("foo"));
+#pragma warning restore CA1806 // Do not ignore method results
         }
 
         [Fact]
@@ -63,7 +65,9 @@ namespace FakeItEasy.Tests
         [Fact]
         public void Assert_should_include_method_signature_in_error_message_when_call_is_non_guarded_constructor()
         {
+#pragma warning disable CA1806 // Do not ignore method results
             AssertShouldFail(() => new ClassWithNonProperlyGuardedConstructor("foo", "bar")).And
+#pragma warning restore CA1806 // Do not ignore method results
                 .Message.Should().Contain("Expected calls to FakeItEasy.Tests.NullGuardedAssertionTests+ClassWithNonProperlyGuardedConstructor.ctor([String] a, [String] b) to be null guarded.");
         }
 

--- a/tests/FakeItEasy.Tests/TestHelpers/BinarySerializationHelper.cs
+++ b/tests/FakeItEasy.Tests/TestHelpers/BinarySerializationHelper.cs
@@ -8,7 +8,9 @@ namespace FakeItEasy.Tests.TestHelpers
 
     public static class BinarySerializationHelper
     {
+#pragma warning disable CA1801 // parameter not used
         public static T SerializeAndDeserialize<T>(T value)
+#pragma warning restore CA1801 // parameter not used
         {
 #if FEATURE_BINARY_SERIALIZATION
             T result;

--- a/tests/FakeItEasy.Tests/TestHelpers/ExpressionHelper.cs
+++ b/tests/FakeItEasy.Tests/TestHelpers/ExpressionHelper.cs
@@ -97,7 +97,7 @@ namespace FakeItEasy.Tests.TestHelpers
                 var property = (PropertyInfo)propertyCall.Member;
 
                 method = property.GetGetMethod(true);
-                arguments = new object[] { };
+                arguments = Array.Empty<object>();
             }
 
             return new ArgumentCollection(arguments, method);

--- a/tests/FakeItEasy.Tests/TestHelpers/MethodInfoDummyFactory.cs
+++ b/tests/FakeItEasy.Tests/TestHelpers/MethodInfoDummyFactory.cs
@@ -7,7 +7,7 @@ namespace FakeItEasy.Tests.TestHelpers
     {
         protected override MethodInfo Create()
         {
-            return typeof(object).GetMethod("ToString", new Type[] { });
+            return typeof(object).GetMethod("ToString", Type.EmptyTypes);
         }
     }
 }


### PR DESCRIPTION
Fixes #1144

The `Microsoft.CodeAnalysis.FxCopAnalyzers` package now seems sufficiently stable.

There are many warnings that weren't previously reported by FxCop, so I had to fix or suppress many of them. I tried to make commits easy to follow, hopefully it won't be to painful to review...