### PR TITLE
Write call constraint to writer instead of converting to string

### DIFF
--- a/src/FakeItEasy/Configuration/AnyCallCallRule.cs
+++ b/src/FakeItEasy/Configuration/AnyCallCallRule.cs
@@ -17,28 +17,26 @@ namespace FakeItEasy.Configuration
 
         public bool ApplicableToAllNonVoidReturnTypes { get; set; }
 
-        public override string DescriptionOfValidCall
+        public override void DescribeCallOn(IOutputWriter writer)
         {
-            get
+            if (this.ApplicableToMembersWithReturnType != null)
             {
-                if (this.ApplicableToMembersWithReturnType != null)
+                if (this.ApplicableToMembersWithReturnType == typeof(void))
                 {
-                    if (this.ApplicableToMembersWithReturnType == typeof(void))
-                    {
-                        return "Any call with void return type to the fake object.";
-                    }
-                    else
-                    {
-                        return $"Any call with return type {this.ApplicableToMembersWithReturnType} to the fake object.";
-                    }
+                    writer.Write("Any call with void return type to the fake object.");
                 }
-
-                if (this.ApplicableToAllNonVoidReturnTypes)
+                else
                 {
-                    return "Any call with non-void return type to the fake object.";
+                    writer.Write("Any call with return type ").Write(this.ApplicableToMembersWithReturnType).Write(" to the fake object.");
                 }
-
-                return "Any call made to the fake object.";
+            }
+            else if (this.ApplicableToAllNonVoidReturnTypes)
+            {
+                writer.Write("Any call with non-void return type to the fake object.");
+            }
+            else
+            {
+                writer.Write("Any call made to the fake object.");
             }
         }
 

--- a/src/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/src/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -66,9 +66,10 @@ namespace FakeItEasy.Configuration
         public virtual int? NumberOfTimesToCall { get; set; }
 
         /// <summary>
-        /// Gets a description of calls the rule is applicable to.
+        /// Writes a description of calls the rule is applicable to.
         /// </summary>
-        public abstract string DescriptionOfValidCall { get; }
+        /// <param name="writer">The writer on which to describe the call.</param>
+        public abstract void DescribeCallOn(IOutputWriter writer);
 
         /// <summary>
         /// Sets an action that is called by the <see cref="Apply"/> method to apply this
@@ -132,7 +133,7 @@ namespace FakeItEasy.Configuration
         {
             Guard.AgainstNull(writer, nameof(writer));
 
-            writer.Write(this.DescriptionOfValidCall);
+            this.DescribeCallOn(writer);
 
             Func<string> wherePrefix = () =>
             {

--- a/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
+++ b/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
@@ -56,10 +56,12 @@ namespace FakeItEasy.Configuration
 
         private static string GetExpressionDescription(ParsedCallExpression parsedCallExpression)
         {
+            var writer = ServiceLocator.Current.Resolve<StringBuilderOutputWriter>();
             var constraintFactory = ServiceLocator.Current.Resolve<ExpressionArgumentConstraintFactory>();
             var describer = ServiceLocator.Current.Resolve<CallConstraintDescriber>();
 
-            return describer.GetDescriptionOfMatchingCall(parsedCallExpression.CalledMethod, parsedCallExpression.ArgumentsExpressions.Select(constraintFactory.GetArgumentConstraint));
+            describer.DescribeCallOn(writer, parsedCallExpression.CalledMethod, parsedCallExpression.ArgumentsExpressions.Select(constraintFactory.GetArgumentConstraint));
+            return writer.Builder.ToString();
         }
 
         private static string GetPropertyName(ParsedCallExpression parsedCallExpression)

--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -36,13 +36,13 @@ namespace FakeItEasy.Expressions
             this.argumentsPredicate = this.ArgumentsMatchesArgumentConstraints;
         }
 
-        /// <summary>
-        /// Gets a human readable description of calls that will be matched by this
-        /// matcher.
-        /// </summary>
-        public virtual string DescriptionOfMatchingCall => this.callConstraintConstraintDescriber.GetDescriptionOfMatchingCall(this.Method, this.argumentConstraints);
-
         private MethodInfo Method { get; }
+
+        /// <summary>
+        /// Writes a description of calls the rule is applicable to.
+        /// </summary>
+        /// <param name="writer">The writer on which to describe the call.</param>
+        public virtual void DescribeCallOn(IOutputWriter writer) => this.callConstraintConstraintDescriber.DescribeCallOn(writer, this.Method, this.argumentConstraints);
 
         /// <summary>
         /// Matches the specified call against the expression.

--- a/src/FakeItEasy/Expressions/ExpressionCallRule.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallRule.cs
@@ -30,17 +30,9 @@ namespace FakeItEasy.Expressions
         /// <returns>A rule instance.</returns>
         public delegate ExpressionCallRule Factory(ParsedCallExpression callSpecification);
 
-        public override string DescriptionOfValidCall => this.ExpressionMatcher.DescriptionOfMatchingCall;
-
         private ExpressionCallMatcher ExpressionMatcher { get; }
 
-        /// <summary>
-        /// Returns a <see cref="System.String"/> that represents this instance.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="System.String"/> that represents this instance.
-        /// </returns>
-        public override string ToString() => this.DescriptionOfValidCall;
+        public override void DescribeCallOn(IOutputWriter writer) => this.ExpressionMatcher.DescribeCallOn(writer);
 
         public override void UsePredicateToValidateArguments(Func<ArgumentCollection, bool> argumentsPredicate)
         {

--- a/tests/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
@@ -314,7 +314,7 @@ namespace FakeItEasy.Tests.Configuration
 
             public bool OnIsApplicableToWasCalled { get; private set; }
 
-            public override string DescriptionOfValidCall => this.DescriptionOfValidCallReturnValue;
+            public override void DescribeCallOn(IOutputWriter writer) => writer.Write(this.DescriptionOfValidCallReturnValue);
 
             public override void UsePredicateToValidateArguments(Func<ArgumentCollection, bool> argumentsPredicate)
             {

--- a/tests/FakeItEasy.Tests/Expressions/ExpressionCallMatcherTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ExpressionCallMatcherTests.cs
@@ -154,8 +154,10 @@ namespace FakeItEasy.Tests.Expressions
 
             var matcher = this.CreateMatcher<IFoo>(x => x.Bar(1, 2));
 
-            matcher.DescriptionOfMatchingCall.Should().Be("FakeItEasy.Tests.IFoo.Bar(argument: <FOO>, argument2: <FOO>)");
+            var writer = ServiceLocator.Current.Resolve<StringBuilderOutputWriter>();
+            matcher.DescribeCallOn(writer);
 
+            writer.Builder.ToString().Should().Be("FakeItEasy.Tests.IFoo.Bar(argument: <FOO>, argument2: <FOO>)");
             A.CallTo(() => this.constraintFactory.GetArgumentConstraint(A<ParsedArgumentExpression>._)).MustHaveHappenedTwiceExactly();
         }
 
@@ -201,7 +203,10 @@ namespace FakeItEasy.Tests.Expressions
 
             matcher.UsePredicateToValidateArguments(x => true);
 
-            matcher.DescriptionOfMatchingCall.Should().Be("FakeItEasy.Tests.IFoo.Bar(argument: <Predicated>, argument2: <Predicated>)");
+            var writer = ServiceLocator.Current.Resolve<StringBuilderOutputWriter>();
+            matcher.DescribeCallOn(writer);
+
+            writer.Builder.ToString().Should().Be("FakeItEasy.Tests.IFoo.Bar(argument: <Predicated>, argument2: <Predicated>)");
         }
 
         [Fact]

--- a/tests/FakeItEasy.Tests/Expressions/ExpressionCallRuleTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ExpressionCallRuleTests.cs
@@ -80,13 +80,15 @@ namespace FakeItEasy.Tests.Expressions
         }
 
         [Fact]
-        public void DescriptionOfValidCall_should_return_expressionMatcher_ToString()
+        public void DescribeCallOn_should_write_expressionMatcher_description()
         {
-            A.CallTo(() => this.callMatcher.DescriptionOfMatchingCall).Returns("foo");
+            var fakeWriter = ServiceLocator.Current.Resolve<StringBuilderOutputWriter>();
+            A.CallTo(() => this.callMatcher.DescribeCallOn(A<IOutputWriter>._)).Invokes((IOutputWriter w) => w.Write("foo"));
 
             var rule = this.CreateRule();
 
-            rule.DescriptionOfValidCall.Should().Be("foo");
+            rule.WriteDescriptionOfValidCall(fakeWriter);
+            fakeWriter.Builder.ToString().Should().Be("foo");
         }
 
         [Fact]


### PR DESCRIPTION
When fixing #684, I noticed that we use output writers to make strings that we pass to output writers that we use to make strings…

This will take out at least one place where we go writer → string → writer.
It's just a peeve of mine, and if we don't want to bother, I understand.