### PR TITLE
Make CallConstraintDescriber static

### DIFF
--- a/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
+++ b/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
@@ -58,9 +58,8 @@ namespace FakeItEasy.Configuration
         {
             var writer = ServiceLocator.Current.Resolve<StringBuilderOutputWriter>();
             var constraintFactory = ServiceLocator.Current.Resolve<ExpressionArgumentConstraintFactory>();
-            var describer = ServiceLocator.Current.Resolve<CallConstraintDescriber>();
 
-            describer.DescribeCallOn(writer, parsedCallExpression.CalledMethod, parsedCallExpression.ArgumentsExpressions.Select(constraintFactory.GetArgumentConstraint));
+            CallConstraintDescriber.DescribeCallOn(writer, parsedCallExpression.CalledMethod, parsedCallExpression.ArgumentsExpressions.Select(constraintFactory.GetArgumentConstraint));
             return writer.Builder.ToString();
         }
 

--- a/src/FakeItEasy/Expressions/CallConstraintDescriber.cs
+++ b/src/FakeItEasy/Expressions/CallConstraintDescriber.cs
@@ -8,19 +8,8 @@ namespace FakeItEasy.Expressions
     /// <summary>
     /// Describes a call constraint, as defined by a method and list of argument constraints.
     /// </summary>
-    internal class CallConstraintDescriber
+    internal static class CallConstraintDescriber
     {
-        private readonly StringBuilderOutputWriter.Factory outputWriterFactory;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CallConstraintDescriber" /> class.
-        /// </summary>
-        /// <param name="outputWriterFactory">The output writer factory to use.</param>
-        public CallConstraintDescriber(StringBuilderOutputWriter.Factory outputWriterFactory)
-        {
-            this.outputWriterFactory = outputWriterFactory;
-        }
-
         /// <summary>
         /// Writes a human readable description of the call constraint
         /// matcher to the supplied writer.
@@ -28,13 +17,13 @@ namespace FakeItEasy.Expressions
         /// <param name="writer">The writer on which to describe the call.</param>
         /// <param name="method">The method to describe.</param>
         /// <param name="argumentConstraints">The argument constraints applied to the method.</param>
-        public void DescribeCallOn(IOutputWriter writer, MethodInfo method, IEnumerable<IArgumentConstraint> argumentConstraints)
+        public static void DescribeCallOn(IOutputWriter writer, MethodInfo method, IEnumerable<IArgumentConstraint> argumentConstraints)
         {
             writer.Write(method.DeclaringType);
             writer.Write(".");
             WriteMethodName(writer, method);
 
-            this.WriteArgumentsListString(writer, method, argumentConstraints);
+            WriteArgumentsListString(writer, method, argumentConstraints);
         }
 
         private static void WriteMethodName(IOutputWriter writer, MethodInfo method)
@@ -60,7 +49,7 @@ namespace FakeItEasy.Expressions
         private static void WriteArgumentListSuffix(IOutputWriter writer, MethodInfo method) =>
             writer.Write(method.IsPropertyGetterOrSetter() ? ']' : ')');
 
-        private void WriteArgumentsListString(IOutputWriter writer, MethodInfo method, IEnumerable<IArgumentConstraint> argumentConstraints)
+        private static void WriteArgumentsListString(IOutputWriter writer, MethodInfo method, IEnumerable<IArgumentConstraint> argumentConstraints)
         {
             var constraints = GetArgumentConstraintsForArgumentsList(method, argumentConstraints);
             if (constraints.Any() || !method.IsPropertyGetterOrSetter())

--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -15,7 +15,6 @@ namespace FakeItEasy.Expressions
         : ICallMatcher
     {
         private readonly MethodInfoManager methodInfoManager;
-        private readonly CallConstraintDescriber callConstraintConstraintDescriber;
         private IEnumerable<IArgumentConstraint> argumentConstraints;
         private Func<ArgumentCollection, bool> argumentsPredicate;
 
@@ -25,11 +24,9 @@ namespace FakeItEasy.Expressions
         /// <param name="parsedExpression">The parsed call specification.</param>
         /// <param name="constraintFactory">The constraint factory.</param>
         /// <param name="methodInfoManager">The method info manager to use.</param>
-        /// <param name="callConstraintConstraintDescriber">The call constraint describer to use.</param>
-        public ExpressionCallMatcher(ParsedCallExpression parsedExpression, ExpressionArgumentConstraintFactory constraintFactory, MethodInfoManager methodInfoManager, CallConstraintDescriber callConstraintConstraintDescriber)
+        public ExpressionCallMatcher(ParsedCallExpression parsedExpression, ExpressionArgumentConstraintFactory constraintFactory, MethodInfoManager methodInfoManager)
         {
             this.methodInfoManager = methodInfoManager;
-            this.callConstraintConstraintDescriber = callConstraintConstraintDescriber;
             this.Method = parsedExpression.CalledMethod;
 
             this.argumentConstraints = GetArgumentConstraints(parsedExpression.ArgumentsExpressions, constraintFactory).ToArray();
@@ -42,7 +39,7 @@ namespace FakeItEasy.Expressions
         /// Writes a description of calls the rule is applicable to.
         /// </summary>
         /// <param name="writer">The writer on which to describe the call.</param>
-        public virtual void DescribeCallOn(IOutputWriter writer) => this.callConstraintConstraintDescriber.DescribeCallOn(writer, this.Method, this.argumentConstraints);
+        public virtual void DescribeCallOn(IOutputWriter writer) => CallConstraintDescriber.DescribeCallOn(writer, this.Method, this.argumentConstraints);
 
         /// <summary>
         /// Matches the specified call against the expression.

--- a/src/FakeItEasy/RootModule.cs
+++ b/src/FakeItEasy/RootModule.cs
@@ -33,13 +33,11 @@ namespace FakeItEasy
 
             container.RegisterSingleton<IExpressionCallMatcherFactory>(c => new ExpressionCallMatcherFactory(c));
 
-            container.RegisterSingleton(c => new CallConstraintDescriber(c.Resolve<StringBuilderOutputWriter.Factory>()));
-
             container.RegisterSingleton(c =>
                 new ExpressionArgumentConstraintFactory(c.Resolve<IArgumentConstraintTrapper>()));
 
             container.RegisterSingleton<ExpressionCallRule.Factory>(c =>
-                callSpecification => new ExpressionCallRule(new ExpressionCallMatcher(callSpecification, c.Resolve<ExpressionArgumentConstraintFactory>(), c.Resolve<MethodInfoManager>(), c.Resolve<CallConstraintDescriber>())));
+                callSpecification => new ExpressionCallRule(new ExpressionCallMatcher(callSpecification, c.Resolve<ExpressionArgumentConstraintFactory>(), c.Resolve<MethodInfoManager>())));
 
             container.RegisterSingleton(c =>
                 new MethodInfoManager());
@@ -127,14 +125,10 @@ namespace FakeItEasy
                 this.serviceLocator = serviceLocator;
             }
 
-            public ICallMatcher CreateCallMatcher(ParsedCallExpression callSpecification)
-            {
-                return new ExpressionCallMatcher(
+            public ICallMatcher CreateCallMatcher(ParsedCallExpression callSpecification) => new ExpressionCallMatcher(
                     callSpecification,
                     this.serviceLocator.Resolve<ExpressionArgumentConstraintFactory>(),
-                    this.serviceLocator.Resolve<MethodInfoManager>(),
-                    this.serviceLocator.Resolve<CallConstraintDescriber>());
-            }
+                    this.serviceLocator.Resolve<MethodInfoManager>());
         }
 
         private class ResolverFakeObjectCreator

--- a/tests/FakeItEasy.Tests/Expressions/ExpressionCallMatcherTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ExpressionCallMatcherTests.cs
@@ -234,7 +234,7 @@ namespace FakeItEasy.Tests.Expressions
 
         private ExpressionCallMatcher CreateMatcher(ParsedCallExpression callSpecification)
         {
-            return new ExpressionCallMatcher(callSpecification, this.constraintFactory, this.methodInfoManager, new CallConstraintDescriber(this.outputWriterFactory));
+            return new ExpressionCallMatcher(callSpecification, this.constraintFactory, this.methodInfoManager);
         }
 
         private void StubMethodInfoManagerToReturn(bool returnValue)


### PR DESCRIPTION
This is embarrassing. After #1313, CAllConstraintDescriber no longer needed to have instances.
Why not make it static?