### PR TITLE
Handle exceptions in user callbacks

### DIFF
--- a/src/FakeItEasy/Configuration/AnyCallCallRule.cs
+++ b/src/FakeItEasy/Configuration/AnyCallCallRule.cs
@@ -56,7 +56,7 @@ namespace FakeItEasy.Configuration
             }
             catch (Exception ex) when (!(ex is FakeConfigurationException))
             {
-                throw new UserCallbackException("Arguments predicate threw an exception. See inner exception for details.", ex);
+                throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Arguments predicate"), ex);
             }
 
             if (this.ApplicableToMembersWithReturnType != null)

--- a/src/FakeItEasy/Configuration/AnyCallCallRule.cs
+++ b/src/FakeItEasy/Configuration/AnyCallCallRule.cs
@@ -47,9 +47,16 @@ namespace FakeItEasy.Configuration
 
         protected override bool OnIsApplicableTo(IFakeObjectCall fakeObjectCall)
         {
-            if (!this.argumentsPredicate(fakeObjectCall.Arguments))
+            try
             {
-                return false;
+                if (!this.argumentsPredicate(fakeObjectCall.Arguments))
+                {
+                    return false;
+                }
+            }
+            catch (Exception ex) when (!(ex is FakeConfigurationException))
+            {
+                throw new UserCallbackException("Arguments predicate threw an exception. See inner exception for details.", ex);
             }
 
             if (this.ApplicableToMembersWithReturnType != null)

--- a/src/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/src/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -102,7 +102,14 @@ namespace FakeItEasy.Configuration
 
             foreach (var action in this.Actions)
             {
-                action.Invoke(fakeObjectCall);
+                try
+                {
+                    action.Invoke(fakeObjectCall);
+                }
+                catch (Exception ex) when (!(ex is FakeConfigurationException))
+                {
+                    throw new UserCallbackException("Callback threw an exception. See inner exception for details.", ex);
+                }
             }
 
             this.applicator.Invoke(fakeObjectCall);

--- a/src/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/src/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -108,7 +108,7 @@ namespace FakeItEasy.Configuration
                 }
                 catch (Exception ex) when (!(ex is FakeConfigurationException))
                 {
-                    throw new UserCallbackException("Callback threw an exception. See inner exception for details.", ex);
+                    throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Callback"), ex);
                 }
             }
 
@@ -228,7 +228,7 @@ namespace FakeItEasy.Configuration
             }
             catch (Exception ex) when (!(ex is FakeConfigurationException))
             {
-                throw new UserCallbackException("Out and ref parameter value producer threw an exception. See inner exception for details.", ex);
+                throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Out and ref parameter value producer"), ex);
             }
 
             if (values.Count != indexes.Count)
@@ -261,7 +261,7 @@ namespace FakeItEasy.Configuration
                 }
                 catch (Exception ex)
                 {
-                    throw new UserCallbackException("Call filter description threw an exception. See inner exception for details.", ex);
+                    throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Call filter description"), ex);
                 }
             }
 
@@ -273,7 +273,7 @@ namespace FakeItEasy.Configuration
                 }
                 catch (Exception ex)
                 {
-                    throw new UserCallbackException($"Call filter <{this.GetDescription()}> threw an exception. See inner exception for details.", ex);
+                    throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException($"Call filter <{this.GetDescription()}>"), ex);
                 }
             }
 

--- a/src/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/src/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -214,7 +214,16 @@ namespace FakeItEasy.Configuration
             }
 
             var indexes = GetIndexesOfOutAndRefParameters(fakeObjectCall);
-            var values = this.OutAndRefParametersValueProducer(fakeObjectCall);
+            ICollection<object> values;
+            try
+            {
+                values = this.OutAndRefParametersValueProducer(fakeObjectCall);
+            }
+            catch (Exception ex) when (!(ex is FakeConfigurationException))
+            {
+                throw new UserCallbackException("Out and ref parameter value producer threw an exception. See inner exception for details.", ex);
+            }
+
             if (values.Count != indexes.Count)
             {
                 throw new InvalidOperationException(ExceptionMessages.NumberOfOutAndRefParametersDoesNotMatchCall);

--- a/src/FakeItEasy/Configuration/RuleBuilder.cs
+++ b/src/FakeItEasy/Configuration/RuleBuilder.cs
@@ -66,7 +66,20 @@ namespace FakeItEasy.Configuration
         public virtual IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws(Func<IFakeObjectCall, Exception> exceptionFactory)
         {
             this.AddRuleIfNeeded();
-            this.RuleBeingBuilt.UseApplicator(x => { throw exceptionFactory(x); });
+            this.RuleBeingBuilt.UseApplicator(call =>
+            {
+                Exception exceptionToThrow;
+                try
+                {
+                    exceptionToThrow = exceptionFactory(call);
+                }
+                catch (Exception ex) when (!(ex is FakeConfigurationException))
+                {
+                    throw new UserCallbackException("Exception factory threw an exception. See inner exception for details.", ex);
+                }
+
+                throw exceptionToThrow;
+            });
             return this;
         }
 

--- a/src/FakeItEasy/Configuration/RuleBuilder.cs
+++ b/src/FakeItEasy/Configuration/RuleBuilder.cs
@@ -235,7 +235,20 @@ namespace FakeItEasy.Configuration
             {
                 Guard.AgainstNull(valueProducer, nameof(valueProducer));
                 this.ParentConfiguration.AddRuleIfNeeded();
-                this.ParentConfiguration.RuleBeingBuilt.UseApplicator(x => x.SetReturnValue(valueProducer(x)));
+                this.ParentConfiguration.RuleBeingBuilt.UseApplicator(call =>
+                {
+                    TMember returnValue;
+                    try
+                    {
+                        returnValue = valueProducer(call);
+                    }
+                    catch (Exception ex) when (!(ex is FakeConfigurationException))
+                    {
+                        throw new UserCallbackException("Return value producer threw an exception. See inner exception for details.", ex);
+                    }
+
+                    call.SetReturnValue(returnValue);
+                });
                 return this;
             }
 

--- a/src/FakeItEasy/Configuration/RuleBuilder.cs
+++ b/src/FakeItEasy/Configuration/RuleBuilder.cs
@@ -75,7 +75,7 @@ namespace FakeItEasy.Configuration
                 }
                 catch (Exception ex) when (!(ex is FakeConfigurationException))
                 {
-                    throw new UserCallbackException("Exception factory threw an exception. See inner exception for details.", ex);
+                    throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Exception factory"), ex);
                 }
 
                 throw exceptionToThrow;
@@ -257,7 +257,7 @@ namespace FakeItEasy.Configuration
                     }
                     catch (Exception ex) when (!(ex is FakeConfigurationException))
                     {
-                        throw new UserCallbackException("Return value producer threw an exception. See inner exception for details.", ex);
+                        throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Return value producer"), ex);
                     }
 
                     call.SetReturnValue(returnValue);

--- a/src/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/src/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -46,7 +46,7 @@ namespace FakeItEasy.Core
             }
             catch (Exception ex) when (formatter.GetType().GetTypeInfo().Assembly != typeof(ArgumentValueFormatter).GetTypeInfo().Assembly)
             {
-                throw new UserCallbackException($"Custom argument value formatter '{formatter}' threw an exception. See inner exception for details.", ex);
+                throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException($"Custom argument value formatter '{formatter}'"), ex);
             }
         }
 

--- a/src/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/src/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -40,7 +40,14 @@ namespace FakeItEasy.Core
 
             var formatter = this.cachedFormatters.GetOrAdd(argumentType, this.ResolveTypeFormatter);
 
-            return formatter.GetArgumentValueAsString(argumentValue);
+            try
+            {
+                return formatter.GetArgumentValueAsString(argumentValue);
+            }
+            catch (Exception ex) when (formatter.GetType().GetTypeInfo().Assembly != typeof(ArgumentValueFormatter).GetTypeInfo().Assembly)
+            {
+                throw new UserCallbackException($"Custom argument value formatter '{formatter}' threw an exception. See inner exception for details.", ex);
+            }
         }
 
         private static int GetDistanceFromKnownType(Type comparedType, Type knownType)

--- a/src/FakeItEasy/Core/CallCountConstraint.cs
+++ b/src/FakeItEasy/Core/CallCountConstraint.cs
@@ -21,7 +21,7 @@ namespace FakeItEasy.Core
             }
             catch (Exception ex)
             {
-                throw new UserCallbackException($"Call count constraint <{this.description}> threw an exception. See inner exception for details.", ex);
+                throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException($"Call count constraint <{this.description}>"), ex);
             }
         }
 

--- a/src/FakeItEasy/Core/CallCountConstraint.cs
+++ b/src/FakeItEasy/Core/CallCountConstraint.cs
@@ -15,7 +15,14 @@ namespace FakeItEasy.Core
 
         public bool Matches(int callCount)
         {
-            return this.predicate.Invoke(callCount);
+            try
+            {
+                return this.predicate.Invoke(callCount);
+            }
+            catch (Exception ex)
+            {
+                throw new UserCallbackException($"Call count constraint <{this.description}> threw an exception. See inner exception for details.", ex);
+            }
         }
 
         public override string ToString()

--- a/src/FakeItEasy/Core/DefaultArgumentConstraintManager.cs
+++ b/src/FakeItEasy/Core/DefaultArgumentConstraintManager.cs
@@ -61,7 +61,15 @@ namespace FakeItEasy.Core
             void IArgumentConstraint.WriteDescription(IOutputWriter writer)
             {
                 writer.Write("<");
-                this.descriptionWriter.Invoke(writer);
+                try
+                {
+                    this.descriptionWriter.Invoke(writer);
+                }
+                catch (Exception ex)
+                {
+                    throw new UserCallbackException($"Argument matcher description threw an exception. See inner exception for details.", ex);
+                }
+
                 writer.Write(">");
             }
 

--- a/src/FakeItEasy/Core/DefaultArgumentConstraintManager.cs
+++ b/src/FakeItEasy/Core/DefaultArgumentConstraintManager.cs
@@ -67,7 +67,7 @@ namespace FakeItEasy.Core
                 }
                 catch (Exception ex)
                 {
-                    throw new UserCallbackException($"Argument matcher description threw an exception. See inner exception for details.", ex);
+                    throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Argument matcher description"), ex);
                 }
 
                 writer.Write(">");
@@ -86,7 +86,7 @@ namespace FakeItEasy.Core
                 }
                 catch (Exception ex)
                 {
-                    throw new UserCallbackException($"Argument matcher {this.GetDescription()} threw an exception. See inner exception for details.", ex);
+                    throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException($"Argument matcher {this.GetDescription()}"), ex);
                 }
             }
 

--- a/src/FakeItEasy/Core/DefaultArgumentConstraintManager.cs
+++ b/src/FakeItEasy/Core/DefaultArgumentConstraintManager.cs
@@ -67,7 +67,19 @@ namespace FakeItEasy.Core
 
             bool IArgumentConstraint.IsValid(object argument)
             {
-                return IsValueValidForType(argument) && this.predicate.Invoke((T)argument);
+                if (!IsValueValidForType(argument))
+                {
+                    return false;
+                }
+
+                try
+                {
+                    return this.predicate.Invoke((T)argument);
+                }
+                catch (Exception ex)
+                {
+                    throw new UserCallbackException($"Argument matcher {this.GetDescription()} threw an exception. See inner exception for details.", ex);
+                }
             }
 
             private static bool IsValueValidForType(object argument)
@@ -78,6 +90,13 @@ namespace FakeItEasy.Core
                 }
 
                 return argument is T;
+            }
+
+            private string GetDescription()
+            {
+                var writer = ServiceLocator.Current.Resolve<StringBuilderOutputWriter>();
+                ((IArgumentConstraint)this).WriteDescription(writer);
+                return writer.Builder.ToString();
             }
         }
     }

--- a/src/FakeItEasy/Core/DynamicDummyFactory.cs
+++ b/src/FakeItEasy/Core/DynamicDummyFactory.cs
@@ -41,7 +41,15 @@ namespace FakeItEasy.Core
                 return false;
             }
 
-            fakeObject = dummyFactory.Create(typeOfDummy);
+            try
+            {
+                fakeObject = dummyFactory.Create(typeOfDummy);
+            }
+            catch (Exception ex)
+            {
+                throw new UserCallbackException($"Dummy factory '{dummyFactory.GetType()}' threw an exception. See inner exception for details.", ex);
+            }
+
             return true;
         }
     }

--- a/src/FakeItEasy/Core/DynamicDummyFactory.cs
+++ b/src/FakeItEasy/Core/DynamicDummyFactory.cs
@@ -47,7 +47,7 @@ namespace FakeItEasy.Core
             }
             catch (Exception ex)
             {
-                throw new UserCallbackException($"Dummy factory '{dummyFactory.GetType()}' threw an exception. See inner exception for details.", ex);
+                throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException($"Dummy factory '{dummyFactory.GetType()}'"), ex);
             }
 
             return true;

--- a/src/FakeItEasy/Core/DynamicOptionsBuilder.cs
+++ b/src/FakeItEasy/Core/DynamicOptionsBuilder.cs
@@ -43,7 +43,7 @@ namespace FakeItEasy.Core
                 }
                 catch (Exception ex)
                 {
-                    throw new UserCallbackException($"Fake options builder '{fakeOptionsBuilder.GetType()}' threw an exception. See inner exception for details.", ex);
+                    throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException($"Fake options builder '{fakeOptionsBuilder.GetType()}'"), ex);
                 }
             }
         }

--- a/src/FakeItEasy/Core/DynamicOptionsBuilder.cs
+++ b/src/FakeItEasy/Core/DynamicOptionsBuilder.cs
@@ -37,7 +37,14 @@ namespace FakeItEasy.Core
 
             if (fakeOptionsBuilder != null)
             {
-                fakeOptionsBuilder.BuildOptions(typeOfFake, fakeOptions);
+                try
+                {
+                    fakeOptionsBuilder.BuildOptions(typeOfFake, fakeOptions);
+                }
+                catch (Exception ex)
+                {
+                    throw new UserCallbackException($"Fake options builder '{fakeOptionsBuilder.GetType()}' threw an exception. See inner exception for details.", ex);
+                }
             }
         }
     }

--- a/src/FakeItEasy/ExceptionMessages.cs
+++ b/src/FakeItEasy/ExceptionMessages.cs
@@ -39,5 +39,8 @@ namespace FakeItEasy
 
         public static string ArgumentConstraintHasWrongType(Type constraintType, Type parameterType) =>
             $"Argument constraint is of type {constraintType}, but parameter is of type {parameterType}. No call can match this constraint.";
+
+        public static string UserCallbackThrewAnException(string callbackDescription) =>
+            $"{callbackDescription} threw an exception. See inner exception for details.";
     }
 }

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
@@ -30,7 +30,7 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
                 writer.WriteArgumentValue(this.ExpectedValue);
                 return writer.Builder.ToString();
             }
-            catch (Exception)
+            catch (Exception ex) when (!(ex is UserCallbackException))
             {
                 FakeManager manager = Fake.TryGetFakeManager(this.ExpectedValue);
                 return manager != null

--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -93,7 +93,7 @@ namespace FakeItEasy.Expressions
             }
             catch (Exception ex) when (this.useExplicitArgumentsPredicate && !(ex is FakeConfigurationException))
             {
-                throw new UserCallbackException("Arguments predicate threw an exception. See inner exception for details.", ex);
+                throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Arguments predicate"), ex);
             }
         }
 

--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -17,6 +17,7 @@ namespace FakeItEasy.Expressions
         private readonly MethodInfoManager methodInfoManager;
         private IEnumerable<IArgumentConstraint> argumentConstraints;
         private Func<ArgumentCollection, bool> argumentsPredicate;
+        private bool useExplicitArgumentsPredicate;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExpressionCallMatcher" /> class.
@@ -58,6 +59,7 @@ namespace FakeItEasy.Expressions
         {
             this.argumentsPredicate = predicate;
             this.argumentConstraints = this.argumentConstraints.Select(a => new PredicatedArgumentConstraint()).ToArray();
+            this.useExplicitArgumentsPredicate = true;
         }
 
         public Func<IFakeObjectCall, ICollection<object>> GetOutAndRefParametersValueProducer()
@@ -85,7 +87,14 @@ namespace FakeItEasy.Expressions
 
         private bool ArgumentsMatches(ArgumentCollection argumentCollection)
         {
-            return this.argumentsPredicate(argumentCollection);
+            try
+            {
+                return this.argumentsPredicate(argumentCollection);
+            }
+            catch (Exception ex) when (this.useExplicitArgumentsPredicate && !(ex is FakeConfigurationException))
+            {
+                throw new UserCallbackException("Arguments predicate threw an exception. See inner exception for details.", ex);
+            }
         }
 
         private bool ArgumentsMatchesArgumentConstraints(ArgumentCollection argumentCollection)

--- a/src/FakeItEasy/UserCallbackException.cs
+++ b/src/FakeItEasy/UserCallbackException.cs
@@ -1,0 +1,60 @@
+namespace FakeItEasy
+{
+    using System;
+#if FEATURE_BINARY_SERIALIZATION
+    using System.Runtime.Serialization;
+#endif
+
+    /// <summary>
+    /// An exception thrown when a user-provided callback throws an exception.
+    /// </summary>
+#if FEATURE_BINARY_SERIALIZATION
+    [Serializable]
+#endif
+    public class UserCallbackException
+        : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCallbackException"/> class.
+        /// </summary>
+        public UserCallbackException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCallbackException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public UserCallbackException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCallbackException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public UserCallbackException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if FEATURE_BINARY_SERIALIZATION
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCallbackException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        /// The <paramref name="info"/> parameter is null.
+        /// </exception>
+        /// <exception cref="T:System.Runtime.Serialization.SerializationException">
+        /// The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).
+        /// </exception>
+        protected UserCallbackException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.ruleset
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.ruleset
@@ -1,8 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="FakeItEasy Specs" ToolsVersion="12.0">
   <Include Path="..\fakeiteasy.tests.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1003" Action="None" />
     <Rule Id="CA1009" Action="None" />
+    <Rule Id="CA1032" Action="None" />
   </Rules>
 </RuleSet>

--- a/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Specs
+namespace FakeItEasy.Specs
 {
     using System;
     using System.Linq;
@@ -85,7 +85,8 @@
                 .x(() => exception = Record.Exception(() => A.Fake<WrapsNull>()));
 
             "Then an argument null exception is thrown"
-                .x(() => exception.Should().BeAnExceptionOfType<ArgumentNullException>());
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>()
+                    .WithInnerException<ArgumentException>());
         }
 
         [Scenario]
@@ -187,8 +188,9 @@
                 .x(() => exception = Record.Exception(() => A.Fake<ConstructorArgumentsSetByConstructorForWrongType>()));
 
             "Then an exception is thrown"
-                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
-                    .WithMessage("Supplied constructor is for type FakeItEasy.Specs.ConstructorArgumentsSetByConstructorForWrongType, but must be for FakeItEasy.Specs.ConstructorArgumentsSetByConstructor."));
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>()
+                    .WithInnerException<ArgumentException>()
+                    .WithInnerMessage("Supplied constructor is for type FakeItEasy.Specs.ConstructorArgumentsSetByConstructorForWrongType, but must be for FakeItEasy.Specs.ConstructorArgumentsSetByConstructor."));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -284,6 +284,32 @@ namespace FakeItEasy.Specs
                 .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
         }
 
+        [Scenario]
+        public void ExceptionInExceptionFactory(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call to the fake is configured with an exception factory that throws an exception"
+                .x(() => A.CallTo(() => fake.Bar(0)).Throws(call =>
+                {
+                    ThrowException();
+                    return new Exception("test");
+                }));
+
+            "When the configured method is called"
+                .x(() => exception = Record.Exception(() => fake.Bar(0)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Exception factory threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
         private static bool ThrowException()
         {
             throw new MyException("Oops");

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -35,6 +35,50 @@ namespace FakeItEasy.Specs
                 .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
         }
 
+        [Scenario]
+        public void ExceptionInArgumentMatcherDescription(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And no call to the fake is made"
+                .x(() => { });
+
+            "When an assertion is made with a custom argument matcher whose description throws an exception"
+                .x(() => exception = Record.Exception(() => A.CallTo(() => fake.Bar(A<int>.That.Matches(i => i % 2 == 0, o => o.Write(ThrowException())))).MustHaveHappened()));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Argument matcher description threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
+        [Scenario]
+        public void ExceptionInArgumentMatcherAndInDescription(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call to the fake is configured with a custom argument matcher that throws an exception and whose description also throws an exception"
+                .x(() => A.CallTo(() => fake.Bar(A<int>.That.Matches(i => ThrowException(), o => o.Write(ThrowException())))).Returns(42));
+
+            "When the configured method is called"
+                .x(() => exception = Record.Exception(() => fake.Bar(0)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Argument matcher description threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
         private static bool ThrowException()
         {
             throw new MyException("Oops");

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -128,6 +128,50 @@ namespace FakeItEasy.Specs
                 .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
         }
 
+        [Scenario]
+        public void ExceptionInWhenArgumentsMatchPredicateForExpressionCallSpec(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a method configured on this fake with a WhenArgumentsMatch predicate that throws an exception"
+                .x(() => A.CallTo(() => fake.Bar(0)).WhenArgumentsMatch(args => ThrowException()).Returns(0));
+
+            "When a call to the configured method is made"
+                .x(() => exception = Record.Exception(() => fake.Bar(0)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Arguments predicate threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
+        [Scenario]
+        public void ExceptionInWhenArgumentsMatchPredicateForAnyCallSpec(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And calls configured on this fake with a WhenArgumentsMatch predicate that throws an exception"
+                .x(() => A.CallTo(fake).WhenArgumentsMatch(args => ThrowException()).DoesNothing());
+
+            "When a call to any method of the fake is made"
+                .x(() => exception = Record.Exception(() => fake.Bar(0)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Arguments predicate threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
         private static bool ThrowException()
         {
             throw new MyException("Oops");

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -13,6 +13,8 @@ namespace FakeItEasy.Specs
             int Bar(int x);
 
             int Baz(HasCustomValueFormatter d);
+
+            void OutAndRef(ref int x, out string s);
         }
 
         [Scenario]
@@ -255,6 +257,28 @@ namespace FakeItEasy.Specs
 
             "And its message should describe where the exception was thrown from"
                 .x(() => exception.Message.Should().Be("Return value producer threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
+        [Scenario]
+        public void ExceptionInOutAndRefValueProducer(IFoo fake, Exception exception, int x, string s)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call to the fake is configured with an out and ref value producer that throws an exception"
+                .x(() => A.CallTo(() => fake.OutAndRef(ref x, out s)).AssignsOutAndRefParametersLazily(call => new object[] { ThrowException() }));
+
+            "When the configured method is called"
+                .x(() => exception = Record.Exception(() => fake.OutAndRef(ref x, out s)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Out and ref parameter value producer threw an exception. See inner exception for details."));
 
             "And the inner exception should be the original exception"
                 .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -238,6 +238,28 @@ namespace FakeItEasy.Specs
                 .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
         }
 
+        [Scenario]
+        public void ExceptionInReturnValueProducer(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call to the fake is configured with a return value producer that throws an exception"
+                .x(() => A.CallTo(() => fake.Bar(0)).ReturnsLazily(() => ThrowException().GetHashCode()));
+
+            "When the configured method is called"
+                .x(() => exception = Record.Exception(() => fake.Bar(0)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Return value producer threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
         private static bool ThrowException()
         {
             throw new MyException("Oops");

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -310,6 +310,28 @@ namespace FakeItEasy.Specs
                 .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
         }
 
+        [Scenario]
+        public void ExceptionInCallback(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call to the fake is configured with a callback that throws an exception"
+                .x(() => A.CallTo(() => fake.Bar(0)).Invokes(() => ThrowException()));
+
+            "When the configured method is called"
+                .x(() => exception = Record.Exception(() => fake.Bar(0)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Callback threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
         private static bool ThrowException()
         {
             throw new MyException("Oops");

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -79,6 +79,28 @@ namespace FakeItEasy.Specs
                 .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
         }
 
+        [Scenario]
+        public void ExceptionInCallCountSpecification(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And no call to the fake is made"
+                .x(() => { });
+
+            "When an assertion is made with a call count constraint that throws an exception"
+                .x(() => exception = Record.Exception(() => A.CallTo(() => fake.Bar(0)).MustHaveHappenedANumberOfTimesMatching(n => ThrowException())));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Call count constraint <a number of times matching the predicate 'n => ThrowException()'> threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
         private static bool ThrowException()
         {
             throw new MyException("Oops");

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -131,6 +131,28 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
+        public void ExceptionInDummyFactory(MyDummy dummy, Exception exception)
+        {
+            "Given a type"
+                .See<MyDummy>();
+
+            "And a dummy factory for this type that throws"
+                .See<MyDummyFactory>();
+
+            "When I try to create a dummy for this type"
+                .x(() => exception = Record.Exception(() => dummy = A.Dummy<MyDummy>()));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Dummy factory 'FakeItEasy.Specs.UserCallbackExceptionSpecs+MyDummyFactory' threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
+        [Scenario]
         public void ExceptionInWhenArgumentsMatchPredicateForExpressionCallSpec(IFoo fake, Exception exception)
         {
             "Given a fake"
@@ -354,6 +376,19 @@ namespace FakeItEasy.Specs
             protected override string GetStringValue(HasCustomValueFormatter argumentValue)
             {
                 throw new MyException("Oops");
+            }
+        }
+
+        public class MyDummy
+        {
+        }
+
+        public class MyDummyFactory : DummyFactory<MyDummy>
+        {
+            protected override MyDummy Create()
+            {
+                ThrowException();
+                return default;
             }
         }
     }

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -1,0 +1,51 @@
+namespace FakeItEasy.Specs
+{
+    using System;
+    using FakeItEasy.Tests.TestHelpers;
+    using FluentAssertions;
+    using Xbehave;
+    using Xunit;
+
+    public class UserCallbackExceptionSpecs
+    {
+        public interface IFoo
+        {
+            int Bar(int x);
+        }
+
+        [Scenario]
+        public void ExceptionInArgumentMatcher(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a call to the fake is configured with a custom argument matcher that throws an exception"
+                .x(() => A.CallTo(() => fake.Bar(A<int>.That.Matches(i => ThrowException()))).Returns(42));
+
+            "When the configured method is called"
+                .x(() => exception = Record.Exception(() => fake.Bar(0)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Argument matcher <i => ThrowException()> threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
+        private static bool ThrowException()
+        {
+            throw new MyException("Oops");
+        }
+
+        public class MyException : Exception
+        {
+            public MyException(string message, Exception inner = null)
+                : base(message, inner)
+            {
+            }
+        }
+    }
+}

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -172,6 +172,72 @@ namespace FakeItEasy.Specs
                 .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
         }
 
+        [Scenario]
+        public void ExceptionInWherePredicate(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And calls configured on this fake with a call filter predicate that throws an exception"
+                .x(() => A.CallTo(fake).Where(call => ThrowException()).DoesNothing());
+
+            "When a call to any method of the fake is made"
+                .x(() => exception = Record.Exception(() => fake.Bar(0)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Call filter <call => ThrowException()> threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
+        [Scenario]
+        public void ExceptionInWhereDescription(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And no call to the fake is made"
+                .x(() => { });
+
+            "When an assertion is made with a call filter whose description throws an exception"
+                .x(() => exception = Record.Exception(() => A.CallTo(fake).Where(call => true, o => o.Write(ThrowException())).MustHaveHappened()));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Call filter description threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
+        [Scenario]
+        public void ExceptionInWherePredicateAndInDescription(IFoo fake, Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And calls configured on this fake with a call filter predicate that throws an exception and whose description also throws an exception"
+                .x(() => A.CallTo(fake).Where(call => ThrowException(), o => o.Write(ThrowException())).DoesNothing());
+
+            "When a call to any method of the fake is made"
+                .x(() => exception = Record.Exception(() => fake.Bar(0)));
+
+            "Then a UserCallbackException should be thrown"
+                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
+
+            "And its message should describe where the exception was thrown from"
+                .x(() => exception.Message.Should().Be("Call filter description threw an exception. See inner exception for details."));
+
+            "And the inner exception should be the original exception"
+                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
+        }
+
         private static bool ThrowException()
         {
             throw new MyException("Oops");

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi40.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi40.approved.txt
@@ -399,6 +399,13 @@ namespace FakeItEasy
     {
         public UnderTestAttribute() { }
     }
+    public class UserCallbackException : System.Exception
+    {
+        public UserCallbackException() { }
+        public UserCallbackException(string message) { }
+        public UserCallbackException(string message, System.Exception innerException) { }
+        protected UserCallbackException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
     public class static WhereConfigurationExtensions
     {
         public static T Where<T>(this FakeItEasy.Configuration.IWhereConfiguration<T> configuration, System.Linq.Expressions.Expression<System.Func<FakeItEasy.Core.IFakeObjectCall, bool>> predicate) { }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi45.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApi45.approved.txt
@@ -397,6 +397,13 @@ namespace FakeItEasy
     {
         public UnderTestAttribute() { }
     }
+    public class UserCallbackException : System.Exception
+    {
+        public UserCallbackException() { }
+        public UserCallbackException(string message) { }
+        public UserCallbackException(string message, System.Exception innerException) { }
+        protected UserCallbackException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
     public class static WhereConfigurationExtensions
     {
         public static T Where<T>(this FakeItEasy.Configuration.IWhereConfiguration<T> configuration, System.Linq.Expressions.Expression<System.Func<FakeItEasy.Core.IFakeObjectCall, bool>> predicate) { }

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApiNetStd.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.ApproveApiNetStd.approved.txt
@@ -319,6 +319,12 @@ namespace FakeItEasy
     {
         public UnderTestAttribute() { }
     }
+    public class UserCallbackException : System.Exception
+    {
+        public UserCallbackException() { }
+        public UserCallbackException(string message) { }
+        public UserCallbackException(string message, System.Exception innerException) { }
+    }
     public class static WhereConfigurationExtensions
     {
         public static T Where<T>(this FakeItEasy.Configuration.IWhereConfiguration<T> configuration, System.Linq.Expressions.Expression<System.Func<FakeItEasy.Core.IFakeObjectCall, bool>> predicate) { }


### PR DESCRIPTION
Fixes #1341

Here's a (hopefully) complete list of APIs where we execute user-provided callbacks:

- Fake creation APIs
    - [ ] ~Fake creation options builder (`A.Fake`, `Create.Fake`)~
    - [ ] ~Fake configuration callback (`IFakeOptions.ConfigureFake`)~
- Call specification APIs
    - [x] Argument matcher predicate (`A<T>.That.Matches`)
    - [x] Argument matcher description writer (`A<T>.That.Matches`)
    - [x] Arguments predicate (`WhenArgumentsMatch`)
    - [x] Call filter (`Where`)
    - [x] Call filter description (`Where`)
- Call configuration APIs
    - [x] Return value producer (`ReturnsLazily`)
    - [x] Out and ref parameters producer (`AssignsOutAndRefParametersLazily`)
    - [x] Exception factory (`Throws`, `ThrowsAsync`)
    - [x] Callback (`Invokes`)
- Call assertion APIs
    - [x] Call count constraint (`MustHaveHappenedANumberOfTimesMatching`, `Repeated.Like`)
- Extension points
    - [x] Custom argument value formatter
    - [x] Dummy factory
    - [x] Fake options builder
