### PR TITLE
Output () for failed parameterless constructor signature instead of '…

### DIFF
--- a/src/FakeItEasy/Core/DefaultExceptionThrower.cs
+++ b/src/FakeItEasy/Core/DefaultExceptionThrower.cs
@@ -56,20 +56,11 @@ namespace FakeItEasy.Core
             {
                 foreach (var constructor in resolvedConstructors.Where(x => x.WasSuccessfullyResolved))
                 {
-                    if (constructor.Arguments == null)
-                    {
-                        message
-                            .AppendIndented("    ", "No constructor arguments failed:");
-                    }
-                    else
-                    {
-                        message
-                            .AppendIndented("    ", "Constructor with signature (")
-                            .Append(constructor.Arguments.ToCollectionString(x => x.ArgumentType.ToString(), ", "))
-                            .AppendLine(") failed:");
-                    }
-
-                    message.AppendIndented("      ", constructor.ReasonForFailure)
+                    message
+                        .AppendIndented("    ", "Constructor with signature (")
+                        .Append(constructor.Arguments?.ToCollectionString(x => x.ArgumentType.ToString(), ", "))
+                        .AppendLine(") failed:")
+                        .AppendIndented("      ", constructor.ReasonForFailure)
                         .AppendLine();
                 }
             }

--- a/tests/FakeItEasy.Tests/Core/DefaultExceptionThrowerTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DefaultExceptionThrowerTests.cs
@@ -21,7 +21,7 @@ namespace FakeItEasy.Tests.Core
   Failed to create fake of type System.String.
 
   Below is a list of reasons for failure per attempted constructor:
-    No constructor arguments failed:
+    Constructor with signature () failed:
       reason
 
 "
@@ -72,7 +72,7 @@ namespace FakeItEasy.Tests.Core
   Failed to create fake of type System.Int32.
 
   Below is a list of reasons for failure per attempted constructor:
-    No constructor arguments failed:
+    Constructor with signature () failed:
       reason
       on two lines
     The following constructors were not tried:
@@ -142,7 +142,7 @@ namespace FakeItEasy.Tests.Core
   Failed to create fake of type System.Int32.
 
   Below is a list of reasons for failure per attempted constructor:
-    No constructor arguments failed:
+    Constructor with signature () failed:
       reason
       on two lines
     Constructor with signature (System.String) failed:


### PR DESCRIPTION
…No constructor arguments'

Fixes #1373.