### PR TITLE
switch to Bullseye and SimpleExec

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -3,6 +3,7 @@
   <package id="GitVersion.CommandLine" version="4.0.0-beta0012" />
   <package id="PdbGit" version="3.0.41" />
   <package id="Bullseye" version="1.0.0-rc.3" />
+  <package id="SimpleExec" version="2.1.0" />
   <package id="xunit.runner.console" version="2.0.0" />
   <package id="vswhere" version="1.0.62" />
   <package id="Microsoft.Net.Compilers" version="2.2.0" />

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="GitVersion.CommandLine" version="4.0.0-beta0012" />
   <package id="PdbGit" version="3.0.41" />
-  <package id="simple-targets-csx" version="6.0.0" />
+  <package id="Bullseye" version="1.0.0-rc.3" />
   <package id="xunit.runner.console" version="2.0.0" />
   <package id="vswhere" version="1.0.62" />
   <package id="Microsoft.Net.Compilers" version="2.2.0" />


### PR DESCRIPTION
- [Bullseye](https://github.com/adamralph/bullseye) replaces simple-targets-csx (it's a regular binary package instead of scripts, so can optionally be used in a [regular .NET project](https://github.com/xbehave/xbehave.net/blob/6d798877b4b891ce95ea8f2c5f9bee3d56a26bae/targets/Program.cs#L8)).
- [SimpleExec](https://github.com/adamralph/simple-exec/) wraps up command invocation, so removes the need to include local helpers