### PR TITLE
fix GetVSLocation

### DIFF
--- a/tools/build.csx
+++ b/tools/build.csx
@@ -157,7 +157,7 @@ public void RunTestsInDirectory(string testDirectory)
 public string GetVSLocation()
 {
     var installationPath = Read($"\"{vswhere}\"", "-nologo -latest -property installationPath -requires Microsoft.Component.MSBuild -version [15,16)", ".");
-    if (string.IsNullOrEmpty(installationPath))
+    if (string.IsNullOrWhiteSpace(installationPath))
     {
         throw new InvalidOperationException("Visual Studio 2017 was not found");
     }


### PR DESCRIPTION
If vswhere returns an empty line, the method returns an empty string instead of throwing the exception.