### PR TITLE
Support in parameters in non-generic classes under .NET Core

### DIFF
--- a/docs/what-can-be-faked.md
+++ b/docs/what-can-be-faked.md
@@ -20,11 +20,8 @@ Note that special steps will need to be taken to
 
 ### Types whose methods have `in` parameters
 
-Currently, types that contain methods having a parameter modified by the `in` keyword cannot be faked by the .NET Standard version of the FakeItEasy library.
-
-If the type is a generic type, no FakeItEasy library can fake it.
-
-These limitations are tracked as [issue 1338](https://github.com/FakeItEasy/FakeItEasy/issues/1338).
+Generic types that contain methods having a parameter modified by the `in` keyword cannot be faked by FakeItEasy.
+This limitation is tracked as [issue 1382](https://github.com/FakeItEasy/FakeItEasy/issues/1382).
 
 ### Where do the constructor arguments come from?
   

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="Castle.Core" Version="4.2.1" />
+    <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -10,10 +10,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_NETCORE_REFLECTION</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
-    <DefineConstants>$(DefineConstants);FEATURE_IN_PARAM</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/tests/FakeItEasy.Specs/InParametersSpecs.cs
+++ b/tests/FakeItEasy.Specs/InParametersSpecs.cs
@@ -19,7 +19,6 @@ namespace FakeItEasy.Specs
             int Foo(in int x);
         }
 
-#if FEATURE_IN_PARAM
         [Scenario]
         public void FakingInParam(IInParam fake, int argument, int result)
         {
@@ -36,25 +35,10 @@ namespace FakeItEasy.Specs
                 .x(() => result.Should().Be(42));
         }
 
-// Below are characterization tests, representing the current capabilities of the code, not the desired state.
-// If these tests start failing, update them and fix the "What can be faked" documentation page.
-//
-// See https://github.com/castleproject/Core/issues/339 for more details about the limitation.
-#else
-        [Scenario]
-        public void FakingInParam(Exception exception)
-        {
-            "Given an interface with a method that takes an 'in' parameter"
-                .See<IInParam>();
-
-            "When I create a fake of the interface"
-                .x(() => exception = Record.Exception(() => A.Fake<IInParam>()));
-
-            "Then it throws"
-                .x(() => exception.Should().BeAnExceptionOfType<FakeCreationException>());
-        }
-#endif
-
+        // A characterization test, representing the current capabilities of the code, not the desired state.
+        // If it start failing, update it and fix the "What can be faked" documentation page.
+        //
+        // https://github.com/FakeItEasy/FakeItEasy/issues/1382 tracks this failing.
         [Scenario]
         public void FakingGenericInParam(Exception exception)
         {


### PR DESCRIPTION
Fixes #1338.