### PR TITLE
update to Bullseye 1.0.0-rc.5

### DIFF
--- a/tools/build.csx
+++ b/tools/build.csx
@@ -1,4 +1,4 @@
-#r "packages/Bullseye.1.0.0-rc.4/lib/netstandard2.0/Bullseye.dll"
+#r "packages/Bullseye.1.0.0-rc.5/lib/netstandard2.0/Bullseye.dll"
 #r "packages/SimpleExec.2.1.0/lib/netstandard1.3/SimpleExec.dll"
 
 using System.Runtime.CompilerServices;

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="GitVersion.CommandLine" version="4.0.0-beta0012" />
   <package id="PdbGit" version="3.0.41" />
-  <package id="Bullseye" version="1.0.0-rc.4" />
+  <package id="Bullseye" version="1.0.0-rc.5" />
   <package id="SimpleExec" version="2.1.0" />
   <package id="xunit.runner.console" version="2.0.0" />
   <package id="vswhere" version="1.0.62" />


### PR DESCRIPTION
Contains a minor fix concerning console output for targets with a `null` action (an unusual thing to do). You shouldn't notice any difference.