### PR TITLE
Drop MSBuild, use dotnet build instead

### DIFF
--- a/how_to_build.md
+++ b/how_to_build.md
@@ -16,9 +16,7 @@ Ensure that the following are installed:
 
 1. .NET 3.5, required by ILMerge
 
-1. .NET framework 4.6.1 or later
-
-1. a very recent version of Visual Studio 2017 or MSBuild (currently this means 15.7 or later)
+1. a very recent version of Visual Studio 2017 (currently this means 15.7 or later) or the Build Tools for Visual Studio 2017
 
 1. a very recent version of the .NET Core SDK (currently this means 2.1.3 or later)
 

--- a/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
+++ b/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="GitVersion.CommandLine" Version="4.0.0-beta0012" ToolName="GitVersion" ToolExe="GitVersion.exe" />
     <PackageReference Include="PdbGit" Version="3.0.41" ToolName="PdbGit" ToolExe="PdbGit.exe" />
     <PackageReference Include="xunit.runner.console" Version="2.0.0" ToolName="XUnit" ToolExe="xunit.console.exe" />
-    <PackageReference Include="vswhere" Version="1.0.62" ToolName="VSWhere" ToolExe="vswhere.exe" />
     <PackageReference Include="NuGet.CommandLine" Version="$(NuGetVersion)" ToolName="NuGet" ToolExe="nuget.exe" />
   </ItemGroup>
 


### PR DESCRIPTION
As discussed with @adamralph, not sure where/when it was.
We no longer need to call MSBuild explicitly, so we don't need VSWhere anymore.