### PR TITLE
split test inputs by framework

### DIFF
--- a/tools/FakeItEasy.Build/Program.cs
+++ b/tools/FakeItEasy.Build/Program.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using static Bullseye.Targets;
     using static SimpleExec.Command;
 
@@ -80,8 +81,8 @@
                 Target(
                     testSuite.Key,
                     DependsOn("build", "testsDirectory"),
-                    forEach: testSuite.Value,
-                    action: testDirectory => RunTests(testDirectory));
+                    forEach: testSuite.Value.SelectMany(project => GetFrameworks(project).Select(framework => new { Project = project, Framework = framework })),
+                    action: tests => RunTests(tests.Project, tests.Framework));
             }
 
             Target("get-version", () => version = Read(ToolPaths.GitVersion, "/showvariable NuGetVersionV2"));
@@ -110,10 +111,16 @@
             RunTargets(args);
         }
 
-        private static void RunTests(string testDirectory)
+        private static void RunTests(string testDirectory, string framework)
         {
             var xml = Path.GetFullPath(Path.Combine(TestsDirectory, Path.GetFileName(testDirectory) + ".TestResults.xml"));
-            Run("dotnet", $"xunit -configuration Release -nologo -nobuild -noautoreporters -notrait \"explicit=yes\" -xml {xml}", testDirectory);
+            Run("dotnet", $"xunit -framework {framework} -configuration Release -nologo -nobuild -noautoreporters -notrait \"explicit=yes\" -xml {xml}", testDirectory);
         }
+
+        private static string[] GetFrameworks(string project) =>
+            File.ReadAllText($"{project}/{project.Split('/').Last()}.{(project.Contains("VB") ? "vbproj" : "csproj")}")
+                .Split("<TargetFrameworks>", 2)[1]
+                .Split("</TargetFrameworks>", 2)[0]
+                .Split(';');
     }
 }


### PR DESCRIPTION
For some reason (yet to be discovered), I get repeatable test failures when building locally. Looking at the output, I found it very difficult to tell exactly where it's happening. With this change, I can see it's when running under `netcoreapp1.0`:

![image](https://user-images.githubusercontent.com/677704/45313269-aec3f100-b52e-11e8-9ec7-deb3671f6e2b.png)

(As soon as I know why it's failing, I'll report the problem in another issue/PR.)