### PR TITLE
remove xunit console

### DIFF
--- a/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
+++ b/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="SimpleExec" Version="$(SimpleExecVersion)" />
     <PackageReference Include="GitVersion.CommandLine" Version="4.0.0-beta0012" ToolName="GitVersion" ToolExe="GitVersion.exe" />
     <PackageReference Include="PdbGit" Version="3.0.41" ToolName="PdbGit" ToolExe="PdbGit.exe" />
-    <PackageReference Include="xunit.runner.console" Version="2.0.0" ToolName="XUnit" ToolExe="xunit.console.exe" />
     <PackageReference Include="NuGet.CommandLine" Version="$(NuGetVersion)" ToolName="NuGet" ToolExe="nuget.exe" />
   </ItemGroup>
 


### PR DESCRIPTION
So this is actually the thing I was trying to fix which, when checking it didn't break anything, led me to raise https://github.com/FakeItEasy/FakeItEasy/pull/1442.

I guess this package reference became redundant some time ago.