### PR TITLE
Update links to use https in README.md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-﻿# EditorConfig is awesome: http://EditorConfig.org
+﻿# EditorConfig is awesome: https://editorconfig.org
 
 # Top-most EditorConfig file
 root = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The coordinators will usually assign a priority to each issue from 1 (highest) t
 
 ## Tests
 
-Changes in functionality (new features, changed behavior, or bug fixes) should be described by [xBehave.net](http://xbehave.github.io/) acceptance tests in the `FakeItEasy.Specs` project. Doing so ensures that tests are written in language familiar to FakeItEasy's end users and are resilient to refactoring.
+Changes in functionality (new features, changed behavior, or bug fixes) should be described by [xBehave.net](https://xbehave.github.io/) acceptance tests in the `FakeItEasy.Specs` project. Doing so ensures that tests are written in language familiar to FakeItEasy's end users and are resilient to refactoring.
 
 There should be a high level of test coverage. When achieving proper coverage is impractical via acceptance tests, then integration tests or unit tests should be added.
 
@@ -44,11 +44,11 @@ Pull requests containing tabs will not be accepted. Make sure you set your edito
 
 ## Line Endings
 
-The repository is configured to preserve line endings both on checkout and commit (the equivalent of `autocrlf` set to `false`). This means *you* are responsible for line endings. We recommend that you configure your diff viewer so that it does not ignore line endings. Any [wall of pink](http://www.hanselman.com/blog/YoureJustAnotherCarriageReturnLineFeedInTheWall.aspx) pull requests will not be accepted.
+The repository is configured to preserve line endings both on checkout and commit (the equivalent of `autocrlf` set to `false`). This means *you* are responsible for line endings. We recommend that you configure your diff viewer so that it does not ignore line endings. Any [wall of pink](https://www.hanselman.com/blog/YoureJustAnotherCarriageReturnLineFeedInTheWall.aspx) pull requests will not be accepted.
 
 ## Line Width
 
-Try to keep lines of code no longer than 160 characters wide. This isn't a strict rule. Occasionally a line of code can be more readable if allowed to spill over slightly. A good way to remember this rule is to use the 'Column Guides' feature of the [Productivity Power Tools 2012](http://visualstudiogallery.msdn.microsoft.com/3a96a4dc-ba9c-4589-92c5-640e07332afd) extension for Visual Studio.
+Try to keep lines of code no longer than 160 characters wide. This isn't a strict rule. Occasionally a line of code can be more readable if allowed to spill over slightly. A good way to remember this rule is to use the 'Column Guides' feature of the [Productivity Power Tools 2012](https://visualstudiogallery.msdn.microsoft.com/3a96a4dc-ba9c-4589-92c5-640e07332afd) extension for Visual Studio.
 
 ## Coding Style
 
@@ -76,9 +76,9 @@ You should pick either the "personal" or "this computer" option.
 
 ## Making Changes
 
-FakeItEasy uses the git branching model known as [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/). As such, all development must be performed on a ["feature branch"](https://martinfowler.com/bliki/FeatureBranch.html) created from the main development branch, which is called `develop`. To submit a change:
+FakeItEasy uses the git branching model known as [GitFlow](https://nvie.com/posts/a-successful-git-branching-model/). As such, all development must be performed on a ["feature branch"](https://martinfowler.com/bliki/FeatureBranch.html) created from the main development branch, which is called `develop`. To submit a change:
 
-1. [Fork](http://help.github.com/forking/) the  [FakeItEasy repository](https://github.com/FakeItEasy/FakeItEasy/) on GitHub
+1. [Fork](https://help.github.com/forking/) the  [FakeItEasy repository](https://github.com/FakeItEasy/FakeItEasy/) on GitHub
 1. Clone your fork locally
 1. Configure the upstream repo (`git remote add upstream git://github.com/FakeItEasy/FakeItEasy.git`)
 1. Create a local branch (`git checkout -b my-branch develop`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Are you mocking me?](http://fakeiteasy.github.io/img/fakeiteasy_logo_256.png)
+![Are you mocking me?](https://fakeiteasy.github.io/img/fakeiteasy_logo_256.png)
 
 [![NuGet version](https://img.shields.io/nuget/v/FakeItEasy.svg?style=flat)](https://www.nuget.org/packages/FakeItEasy)
 [![Build status](https://ci.appveyor.com/api/projects/status/tmxobysgprwpecsb/branch/develop?svg=true)](https://ci.appveyor.com/project/FakeItEasy/fakeiteasy/branch/develop)
@@ -13,9 +13,9 @@ A .Net dynamic fake framework for creating all types of fake objects, mocks, stu
 
 ## It's faking amazing!
 
-* [Website](http://fakeiteasy.github.io/)
-* [Quickstart](http://fakeiteasy.readthedocs.io/en/stable/quickstart/)
-* [Documentation](http://fakeiteasy.readthedocs.io/en/stable/)
+* [Website](https://fakeiteasy.github.io/)
+* [Quickstart](https://fakeiteasy.readthedocs.io/en/stable/quickstart/)
+* [Documentation](https://fakeiteasy.readthedocs.io/en/stable/)
 * [Chat](https://gitter.im/FakeItEasy/FakeItEasy)
 * NuGet packages:
     * [Official releases on NuGet.org](https://www.nuget.org/profiles/FakeItEasy "FakeItEasy's packages on NuGet.org"), targeting:

--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -93,7 +93,7 @@ supply your own as well), but you must supply a description when using
 a `Func`.
 
 For another example of using `That.Matches`, see Jonathan Channon's
-[Comparing object instances with FakeItEasy](http://blog.jonathanchannon.com/2013/09/11/comparing-object-instances-with-fakeiteasy).
+[Comparing object instances with FakeItEasy](https://blog.jonathanchannon.com/2013/09/11/comparing-object-instances-with-fakeiteasy).
 
 ## Always place `Ignored` and `That` inside `A.CallTo`
 

--- a/docs/creating-fakes.md
+++ b/docs/creating-fakes.md
@@ -74,7 +74,7 @@ mentioned above.
 
 ##Unnatural fakes
 
-For those accustomed to [Moq](http://www.moqthis.com/) there is an
+For those accustomed to [Moq](https://www.moqthis.com/) there is an
 alternative way of creating fakes through the `new Fake<T>`
 syntax. The fake provides a fluent interface for configuring the faked
 object:
@@ -86,4 +86,4 @@ fake.CallsTo(x => x.Bar("some argument")).Returns("some return value");
 var foo = fake.FakeObject;
 ```
 
-For an alternative look at migrating from Moq to FakeItEasy, see Daniel Marbach's blog post that talks about [Migration from Moq to FakeItEasy with Resharper Search Patterns](http://www.planetgeek.ch/2013/07/18/migration-from-moq-to-fakeiteasy-with-resharper-search-patterns/).
+For an alternative look at migrating from Moq to FakeItEasy, see Daniel Marbach's blog post that talks about [Migration from Moq to FakeItEasy with Resharper Search Patterns](https://www.planetgeek.ch/2013/07/18/migration-from-moq-to-fakeiteasy-with-resharper-search-patterns/).

--- a/docs/external-resources.md
+++ b/docs/external-resources.md
@@ -1,6 +1,6 @@
 # External Resources
 
-* [FakeItEasy courses on Pluralsight](http://www.pluralsight.com/tag/fakeiteasy)
-* [The "fakeiteasy" tag on StackOverflow](http://stackoverflow.com/questions/tagged/fakeiteasy)
-* [Mocking HttpContext with FakeItEasy](http://blog.jonathanchannon.com/2013/04/30/mocking-httpcontext-with-fake-it-easy/)
-* [Migration from Moq to FakeItEasy with Resharper Search Patterns](http://www.planetgeek.ch/2013/07/18/migration-from-moq-to-fakeiteasy-with-resharper-search-patterns/)
+* [FakeItEasy courses on Pluralsight](https://www.pluralsight.com/tag/fakeiteasy)
+* [The "fakeiteasy" tag on StackOverflow](https://stackoverflow.com/questions/tagged/fakeiteasy)
+* [Mocking HttpContext with FakeItEasy](https://blog.jonathanchannon.com/2013/04/30/mocking-httpcontext-with-fake-it-easy/)
+* [Migration from Moq to FakeItEasy with Resharper Search Patterns](https://www.planetgeek.ch/2013/07/18/migration-from-moq-to-fakeiteasy-with-resharper-search-patterns/)

--- a/docs/what-can-be-faked.md
+++ b/docs/what-can-be-faked.md
@@ -3,7 +3,7 @@
 ## What types can be faked?
 
 FakeItEasy uses
-[Castle DynamicProxy](http://www.castleproject.org/projects/dynamicproxy/)
+[Castle DynamicProxy](https://www.castleproject.org/projects/dynamicproxy/)
 to create fakes. Thus, it can fake just about anything that could
 normally be overridden, extended, or implemented.  This means that the
 following entities can be faked:

--- a/docs/why-was-fakeiteasy-created.md
+++ b/docs/why-was-fakeiteasy-created.md
@@ -10,7 +10,7 @@ constructs referenced (such as `DummyDefinitions`) have changed or
 been renamed in newer versions of FakeItEasy.
 
 The question on Stack Overflow:
-"[Are fakes better than Mocks?](http://stackoverflow.com/questions/4001101/are-fakes-better-than-mocks)"
+"[Are fakes better than Mocks?](https://stackoverflow.com/questions/4001101/are-fakes-better-than-mocks)"
 
 #Patrik H&auml;gne's answer
 

--- a/src/FakeItEasy.Analyzer.nuspec
+++ b/src/FakeItEasy.Analyzer.nuspec
@@ -8,8 +8,8 @@
     <description>A convenience package that installs the FakeItEasy Analyzer for both C# and Visual Basic. Clients using FakeItEasy from only one of the two languages should prefer FakeItEasy.Analyzer.CSharp or FakeItEasy.Analyzer.VisualBasic. Provides diagnostic analyzers to warn about incorrect usage of FakeItEasy. Works in Visual Studio 2015 Update 1 or later.</description>
     <releaseNotes>https://github.com/FakeItEasy/FakeItEasy/releases</releaseNotes>
     <language>en-US</language>
-    <projectUrl>http://fakeiteasy.github.io/</projectUrl>
-    <iconUrl>http://fakeiteasy.github.io/img/fakeiteasy_logo_256_square_white.png</iconUrl>
+    <projectUrl>https://fakeiteasy.github.io/</projectUrl>
+    <iconUrl>https://fakeiteasy.github.io/img/fakeiteasy_logo_256_square_white.png</iconUrl>
     <licenseUrl>https://raw.githubusercontent.com/FakeItEasy/FakeItEasy/master/License.txt</licenseUrl>
     <copyright>Copyright (c) FakeItEasy contributors. (fakeiteasyfx@gmail.com)</copyright>
     <tags>FakeItEasy analyzer</tags>

--- a/src/FakeItEasy.Dictionary.xml
+++ b/src/FakeItEasy.Dictionary.xml
@@ -1,4 +1,4 @@
-<!-- NOTE (adamralph): For more info see: http://msdn.microsoft.com/en-us/library/bb514188.aspx -->
+<!-- NOTE (adamralph): For more info see: https://docs.microsoft.com/en-us/visualstudio/code-quality/how-to-customize-the-code-analysis-dictionary -->
 <Dictionary>
   <Words>
     <Recognized>

--- a/src/FakeItEasy/Core/FakeCallEqualityComparer.cs
+++ b/src/FakeItEasy/Core/FakeCallEqualityComparer.cs
@@ -16,7 +16,7 @@ namespace FakeItEasy.Core
                     && x.Arguments.SequenceEqual(y.Arguments);
         }
 
-        // NOTE (adamralph): based on http://stackoverflow.com/a/263416/49241
+        // NOTE (adamralph): based on https://stackoverflow.com/a/263416/49241
         public int GetHashCode(IFakeObjectCall obj)
         {
             Guard.AgainstNull(obj, nameof(obj));

--- a/src/FakeItEasy/IHideObjectMembers.cs
+++ b/src/FakeItEasy/IHideObjectMembers.cs
@@ -6,9 +6,9 @@ namespace FakeItEasy
 
     /// <summary>
     /// Hides standard Object members to make fluent interfaces
-    /// easier to read. Found in the source of Autofac: <see cref="!:http://code.google.com/p/autofac/"/>
+    /// easier to read. Found in the source of Autofac: <see cref="!:https://code.google.com/p/autofac/"/>
     /// Based on blog post here:
-    /// <see cref="!:http://www.clariusconsulting.net/blogs/kzu/archive/2008/03/10/58301.aspx"/>
+    /// <see cref="!:http://blogs.clariusconsulting.net/kzu/how-to-hide-system-object-members-from-your-interfaces/"/>
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public interface IHideObjectMembers

--- a/tests/FakeItEasy.Dictionary.Tests.xml
+++ b/tests/FakeItEasy.Dictionary.Tests.xml
@@ -1,4 +1,4 @@
-<!-- NOTE (adamralph): For more info see: http://msdn.microsoft.com/en-us/library/bb514188.aspx -->
+<!-- NOTE (adamralph): For more info see: https://docs.microsoft.com/en-us/visualstudio/code-quality/how-to-customize-the-code-analysis-dictionary -->
 <Dictionary>
   <Words>
     <Recognized>


### PR DESCRIPTION
I noticed that the Markdown preview in VSCode didn't load the FakeItEasy logo because it was a non secure URL. So while I was at it, I updated all links to use https. (except sourcebrowser.io, which doesn't support https)