### PR TITLE
switch to Bullseye 2.1.0 beta 1

### DIFF
--- a/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
+++ b/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.0.0-rc.3" />
+    <PackageReference Include="Bullseye" Version="2.1.0-beta.1" />
     <PackageReference Include="SimpleExec" Version="$(SimpleExecVersion)" />
     <PackageReference Include="GitVersion.CommandLine" Version="4.0.0-beta0012" ToolName="GitVersion" ToolExe="GitVersion.exe" />
     <PackageReference Include="PdbGit" Version="3.0.41" ToolName="PdbGit" ToolExe="PdbGit.exe" />


### PR DESCRIPTION
Looking for feedback on this version. The main change is that a specific colour palette is chosen depending on which CI system is detected. Currently Appveyor, Travis CI, and TeamCity are supported.

For reference, this is how the output looks in a local console:

<img src="https://user-images.githubusercontent.com/677704/46593694-5866b580-cace-11e8-944c-b798a65ad21a.png" width="960px" />

And these are the console colours available on Appveyor:

<img src="https://user-images.githubusercontent.com/677704/46593573-6831ca00-cacd-11e8-9867-e037127be7a7.png" width="100px" />

## Before

<img src="https://user-images.githubusercontent.com/677704/46593541-1e48e400-cacd-11e8-8882-a8e80609cdff.png" width="933px" />

## After

<img src="https://user-images.githubusercontent.com/677704/46593543-23a62e80-cacd-11e8-98a9-7bd076d50fd4.png" width="918px" />
