### PR TITLE
Stop using Linq in GetOutAndRefParametersValueProducer

### DIFF
--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -64,16 +64,22 @@ namespace FakeItEasy.Expressions
 
         public Func<IFakeObjectCall, ICollection<object>> GetOutAndRefParametersValueProducer()
         {
-            var values = this.argumentConstraints.OfType<IArgumentValueProvider>()
-                .Select(valueProvidingConstraint => valueProvidingConstraint.Value)
-                .ToList();
+            IList<object> values = null;
 
-            if (values.Any())
+            foreach (var argumentConstraint in this.argumentConstraints)
             {
-                return call => values;
+                if (argumentConstraint is IArgumentValueProvider valueProvidingConstraint)
+                {
+                    if (values == null)
+                    {
+                        values = new List<object>();
+                    }
+
+                    values.Add(valueProvidingConstraint.Value);
+                }
             }
 
-            return null;
+            return values == null ? (Func<IFakeObjectCall, ICollection<object>>)null : call => values;
         }
 
         private static IEnumerable<IArgumentConstraint> GetArgumentConstraints(IEnumerable<ParsedArgumentExpression> argumentExpressions, ExpressionArgumentConstraintFactory constraintFactory) =>


### PR DESCRIPTION
Connects to #1470.
Most of the time, we have no out or ref parameters to fetch values from, but we're LINQing and creating a list all the time. Even when we do have out and ref parameters, it's not the cheapest way to construct the list.