### PR TITLE
Make fast expression evaluation even faster

### DIFF
--- a/src/FakeItEasy/ExpressionExtensions.cs
+++ b/src/FakeItEasy/ExpressionExtensions.cs
@@ -41,6 +41,7 @@ namespace FakeItEasy
         //     A<SomethingA>._
         //     myObj.someProperty
         // - method calls
+        // - array creation (including params arrays)
         private static bool TryFastEvaluate(Expression expression, out object result)
         {
             result = null;
@@ -122,6 +123,21 @@ namespace FakeItEasy
                     }
 
                     break;
+
+                case ExpressionType.NewArrayInit:
+                    var newArrayExpression = (NewArrayExpression)expression;
+                    object[] arrayItems = new object[newArrayExpression.Expressions.Count];
+
+                    for (int i = 0; i < newArrayExpression.Expressions.Count; i++)
+                    {
+                        if (!TryFastEvaluate(newArrayExpression.Expressions[i], out arrayItems[i]))
+                        {
+                            return false;
+                        }
+                    }
+
+                    result = arrayItems;
+                    return true;
             }
 
             return false;

--- a/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
+++ b/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
@@ -71,11 +71,6 @@ namespace FakeItEasy.Expressions
             return new EqualityArgumentConstraint(expressionValue);
         }
 
-        private static object InvokeExpression(Expression expression)
-        {
-            return Expression.Lambda(expression).Compile().DynamicInvoke();
-        }
-
         private static void CheckArgumentExpressionIsValid(Expression expression)
         {
             expression = GetExpressionWithoutConversion(expression);
@@ -155,7 +150,7 @@ namespace FakeItEasy.Expressions
 
             var trappedConstraints = this.argumentConstraintTrapper.TrapConstraints(() =>
             {
-                expressionValue = InvokeExpression(expression);
+                expressionValue = expression.Evaluate();
             }).ToList();
 
             foreach (var constraint in trappedConstraints.OfType<ITypedArgumentConstraint>())


### PR DESCRIPTION
Connects to #1470.

By handling multi-argument method calls, array creation (including params arrays), and quoted expressions, we get a substantial improvement in argument constraint creation speed:

|                                          Method |     Job |       Mean | Error | Ratio |
|------------------------------------------------ |-------- |-----------:|------:|------:|
|                                        NoParams |   4.9.1 |  19.540 us |    NA |  1.00 |
|                                        NoParams | this PR |   9.332 us |    NA |  0.48 |
|                                  A&lt;int&gt;._ |   4.9.1 | 173.855 us |    NA |  1.00 |
|                                  A&lt;int&gt;._ | this PR |  20.351 us |    NA |  0.12 |
|                                               7 |   4.9.1 | 145.185 us |    NA |  1.00 |
|                                               7 | this PR |  17.193 us |    NA |  0.12 |
|                               That.IsEqualTo(7) |   4.9.1 | 202.741 us |    NA |  1.00 |
|                               That.IsEqualTo(7) | this PR |  33.860 us |    NA |  0.17 |
|                           That.IsGreaterThan(7) |   4.9.1 | 199.721 us |    NA |  1.00 |
|                           That.IsGreaterThan(7) | this PR |  33.176 us |    NA |  0.17 |
|                    That.Matches(i =&gt; i == 7) |   4.9.1 | 504.409 us |    NA |  1.00 |
|                    That.Matches(i =&gt; i == 7) | this PR | 172.835 us |    NA |  0.34 |
|                                   That.IsNull() |   4.9.1 | 204.735 us |    NA |  1.00 |
|                                   That.IsNull() | this PR |  33.509 us |    NA |  0.16 |
|                                That.IsNotNull() |   4.9.1 | 204.980 us |    NA |  1.00 |
|                                That.IsNotNull() | this PR |  33.462 us |    NA |  0.16 |
|                               That.Not.IsNull() |   4.9.1 | 237.424 us |    NA |  1.00 |
|                               That.Not.IsNull() | this PR |  37.436 us |    NA |  0.16 |
|                             That.IsSameAs(this) |   4.9.1 | 356.611 us |    NA |  1.00 |
|                             That.IsSameAs(this) | this PR |  34.870 us |    NA |  0.10 |
|               That.IsInstanceOf(typeof(string)) |   4.9.1 | 223.003 us |    NA |  1.00 |
|               That.IsInstanceOf(typeof(string)) | this PR |  34.816 us |    NA |  0.16 |
|                                             Out |   4.9.1 | 269.075 us |    NA |  1.00 |
|                                             Out | this PR |  20.817 us |    NA |  0.08 |
|   That.IsSameSequenceAs(Enumerable.Range(1, 5)) |   4.9.1 | 249.108 us |    NA |  1.00 |
|   That.IsSameSequenceAs(Enumerable.Range(1, 5)) | this PR |  41.653 us |    NA |  0.17 |
|            That.IsSameSequenceAs(1, 2, 3, 4, 5) |   4.9.1 | 411.127 us |    NA |  1.00 |
|            That.IsSameSequenceAs(1, 2, 3, 4, 5) | this PR |  44.201 us |    NA |  0.11 |

One deviation from the original fast evaluation is that now if we're unable to interpret any subtree of an expression, we quit and then just compile and dynamically invoke the whole expression. I did this because I doubt compiling the whole expression is much more expensive than compiling the subtree, and it's an easy way to ensure that we don't (for example) compile 3 subtrees and combine the results.