### PR TITLE
Optimize IsParamArrayExpression

### DIFF
--- a/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
+++ b/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
@@ -53,12 +53,12 @@ namespace FakeItEasy.Expressions
 
         private static bool IsParamArrayExpression(ParsedArgumentExpression argument)
         {
-            return IsTaggedWithParamArrayAttribute(argument) && argument.Expression is NewArrayExpression;
+            return argument.Expression is NewArrayExpression && IsTaggedWithParamArrayAttribute(argument);
         }
 
         private static bool IsTaggedWithParamArrayAttribute(ParsedArgumentExpression argument)
         {
-            return argument.ArgumentInformation.GetCustomAttributes(typeof(ParamArrayAttribute), true).Any();
+            return argument.ArgumentInformation.IsDefined(typeof(ParamArrayAttribute), true);
         }
 
         private static bool IsOutArgument(ParsedArgumentExpression argument)


### PR DESCRIPTION
Connects to #1470.

Checking to see if a parameter is a params array is expensive. Let's at least not do it unless the parameter is an array. Also, let's check smarter.

![image](https://user-images.githubusercontent.com/3275797/47913177-86db7480-de71-11e8-95e9-13c4272ba3fa.png)



