### PR TITLE
Improve call configuration for methods with parameters

### DIFF
--- a/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
+++ b/src/FakeItEasy/Configuration/PropertyExpressionHelper.cs
@@ -19,10 +19,13 @@ namespace FakeItEasy.Configuration
                                             "' must refer to a property or indexer getter, but doesn't.");
             }
 
-            var parameterTypes = parsedCallExpression.ArgumentsExpressions
-                .Select(p => p.ArgumentInformation.ParameterType)
-                .Concat(new[] { parsedCallExpression.CalledMethod.ReturnType })
-                .ToArray();
+            var parameterTypes = new Type[parsedCallExpression.ArgumentsExpressions.Length + 1];
+            for (int i = 0; i < parsedCallExpression.ArgumentsExpressions.Length; ++i)
+            {
+                parameterTypes[i] = parsedCallExpression.ArgumentsExpressions[i].ArgumentInformation.ParameterType;
+            }
+
+            parameterTypes[parsedCallExpression.ArgumentsExpressions.Length] = parsedCallExpression.CalledMethod.ReturnType;
 
             // The DeclaringType may be null, so fall back to the faked object type.
             // (It's unlikely to happen, though, and would require the client code to have passed a specially
@@ -51,9 +54,9 @@ namespace FakeItEasy.Configuration
                 BuildArgumentThatMatchesAnything<TValue>(),
                 originalParameterInfos.Last());
 
-            var arguments = parsedCallExpression.ArgumentsExpressions
-                .Take(originalParameterInfos.Length - 1)
-                .Concat(new[] { newParsedSetterValueExpression });
+            var arguments = new ParsedArgumentExpression[originalParameterInfos.Length];
+            Array.Copy(parsedCallExpression.ArgumentsExpressions, arguments, originalParameterInfos.Length - 1);
+            arguments[originalParameterInfos.Length - 1] = newParsedSetterValueExpression;
 
             return new ParsedCallExpression(indexerSetterInfo, parsedCallExpression.CallTarget, arguments);
         }

--- a/src/FakeItEasy/Configuration/PropertySetterConfiguration.cs
+++ b/src/FakeItEasy/Configuration/PropertySetterConfiguration.cs
@@ -102,9 +102,9 @@ namespace FakeItEasy.Configuration
                 valueExpression.Body,
                 originalParameterInfos.Last());
 
-            var arguments = this.parsedSetterExpression.ArgumentsExpressions
-                .Take(originalParameterInfos.Length - 1)
-                .Concat(new[] { parsedValueExpression });
+            var arguments = new ParsedArgumentExpression[originalParameterInfos.Length];
+            Array.Copy(this.parsedSetterExpression.ArgumentsExpressions, arguments, originalParameterInfos.Length - 1);
+            arguments[originalParameterInfos.Length - 1] = parsedValueExpression;
 
             return new ParsedCallExpression(
                 this.parsedSetterExpression.CalledMethod,

--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -30,7 +30,13 @@ namespace FakeItEasy.Expressions
             this.methodInfoManager = methodInfoManager;
             this.Method = parsedExpression.CalledMethod;
 
-            this.argumentConstraints = GetArgumentConstraints(parsedExpression.ArgumentsExpressions, constraintFactory).ToArray();
+            var constraints = new IArgumentConstraint[parsedExpression.ArgumentsExpressions.Length];
+            for (var i = 0; i < constraints.Length; i++)
+            {
+                constraints[i] = constraintFactory.GetArgumentConstraint(parsedExpression.ArgumentsExpressions[i]);
+            }
+
+            this.argumentConstraints = constraints;
             this.argumentsPredicate = this.ArgumentsMatchesArgumentConstraints;
         }
 
@@ -81,10 +87,6 @@ namespace FakeItEasy.Expressions
 
             return values == null ? (Func<IFakeObjectCall, ICollection<object>>)null : call => values;
         }
-
-        private static IEnumerable<IArgumentConstraint> GetArgumentConstraints(IEnumerable<ParsedArgumentExpression> argumentExpressions, ExpressionArgumentConstraintFactory constraintFactory) =>
-            from argument in argumentExpressions
-            select constraintFactory.GetArgumentConstraint(argument);
 
         private bool InvokesSameMethodOnTarget(Type type, MethodInfo first, MethodInfo second)
         {

--- a/src/FakeItEasy/Expressions/ParsedCallExpression.cs
+++ b/src/FakeItEasy/Expressions/ParsedCallExpression.cs
@@ -12,7 +12,7 @@ namespace FakeItEasy.Expressions
         public ParsedCallExpression(
             MethodInfo calledMethod,
             Expression callTargetExpression,
-            IEnumerable<ParsedArgumentExpression> argumentsExpressions)
+            ParsedArgumentExpression[] argumentsExpressions)
         {
             this.CalledMethod = calledMethod;
             this.ArgumentsExpressions = argumentsExpressions;
@@ -22,7 +22,7 @@ namespace FakeItEasy.Expressions
         public ParsedCallExpression(
             MethodInfo calledMethod,
             object callTarget,
-            IEnumerable<ParsedArgumentExpression> argumentsExpressions)
+            ParsedArgumentExpression[] argumentsExpressions)
         {
             this.CalledMethod = calledMethod;
             this.ArgumentsExpressions = argumentsExpressions;
@@ -31,7 +31,7 @@ namespace FakeItEasy.Expressions
 
         public MethodInfo CalledMethod { get; }
 
-        public IEnumerable<ParsedArgumentExpression> ArgumentsExpressions { get; }
+        public ParsedArgumentExpression[] ArgumentsExpressions { get; }
 
         public object CallTarget => this.callTarget.Value;
     }


### PR DESCRIPTION
Connects to #1470.

I noticed two hotspots in the code afetr the latest optimization:

1. zipping and otherwise transforming constraint argument expressions, and
2. determining whether a method was static when checking the validity of the argument constraints (basically do we have nested `A._`s and the like.

I didn't save my dotTrace output from the first change, only the second. It does improve the case when we're using a built-in extension such as `Is.EqualTo` or the like, but may have a (much smaller) drag when we're using a user-supplied extension method. I show both scenarios here, in that order:

![image](https://user-images.githubusercontent.com/3275797/47963613-b4085e00-dffc-11e8-921b-ca39c553f444.png)

![image](https://user-images.githubusercontent.com/3275797/47963615-ba96d580-dffc-11e8-8165-c12b9834d189.png)

I do have the benchmarks for what's in develop, after the first commit ("no-zip") and after the second commit. Now with error bars!

![image](https://user-images.githubusercontent.com/3275797/47963655-21b48a00-dffd-11e8-91ec-7db4cc66f54e.png)
