### PR TITLE
Avoid LINQ when constructing list of all proxy interfaces

### DIFF
--- a/src/FakeItEasy/Creation/IProxyOptions.cs
+++ b/src/FakeItEasy/Creation/IProxyOptions.cs
@@ -2,13 +2,14 @@ namespace FakeItEasy.Creation
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq.Expressions;
 
     internal interface IProxyOptions
     {
         IEnumerable<object> ArgumentsForConstructor { get; }
 
-        IEnumerable<Type> AdditionalInterfacesToImplement { get; }
+        ReadOnlyCollection<Type> AdditionalInterfacesToImplement { get; }
 
         IEnumerable<Action<object>> ProxyConfigurationActions { get; }
 

--- a/src/FakeItEasy/Creation/ProxyOptions.cs
+++ b/src/FakeItEasy/Creation/ProxyOptions.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy.Creation
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Linq.Expressions;
 #if FEATURE_NETCORE_REFLECTION
@@ -18,7 +19,7 @@ namespace FakeItEasy.Creation
 
         public IEnumerable<object> ArgumentsForConstructor { get; set; }
 
-        public IEnumerable<Type> AdditionalInterfacesToImplement => this.additionalInterfacesToImplement;
+        public ReadOnlyCollection<Type> AdditionalInterfacesToImplement => this.additionalInterfacesToImplement.AsReadOnly();
 
         public IEnumerable<Action<object>> ProxyConfigurationActions => this.proxyConfigurationActions;
 
@@ -50,7 +51,7 @@ namespace FakeItEasy.Creation
         {
             public IEnumerable<object> ArgumentsForConstructor { get; } = null;
 
-            public IEnumerable<Type> AdditionalInterfacesToImplement { get; } = Type.EmptyTypes;
+            public ReadOnlyCollection<Type> AdditionalInterfacesToImplement { get; } = new ReadOnlyCollection<Type>(new List<Type>());
 
             public IEnumerable<Action<object>> ProxyConfigurationActions { get; } = Enumerable.Empty<Action<object>>();
 

--- a/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyGeneratorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyGeneratorTests.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Linq.Expressions;
 #if FEATURE_NETCORE_REFLECTION
@@ -16,6 +17,8 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
 
     public class CastleDynamicProxyGeneratorTests
     {
+        private readonly ReadOnlyCollection<Type> noAdditionalInterfaces = new ReadOnlyCollection<Type>(new List<Type>());
+
         public interface IInterfaceType
         {
             void Foo(int argument1, int argument2);
@@ -45,7 +48,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Arrange
 
             // Act
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
             result.GeneratedProxy.Should().NotBeNull();
@@ -58,7 +61,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Arrange
 
             // Act
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
             result.GeneratedProxy.Should().NotBeNull()
@@ -72,7 +75,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Arrange
 
             // Act
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
             result.ProxyWasSuccessfullyGenerated.Should().BeTrue();
@@ -85,7 +88,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Arrange
 
             // Act
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
             result.ProxyWasSuccessfullyGenerated.Should().BeFalse();
@@ -100,7 +103,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
 
             var fakeCallProcessorProvider = CreateFakeCallProcessorProvider(c => interceptedFakeObjectCall = c);
 
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeThatImplementsInterfaceType, Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), fakeCallProcessorProvider);
+            var result = CastleDynamicProxyGenerator.GenerateProxy(typeThatImplementsInterfaceType, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), fakeCallProcessorProvider);
 
             var proxy = (IInterfaceType)result.GeneratedProxy;
 
@@ -123,7 +126,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
 
             // Act
-            CastleDynamicProxyGenerator.GenerateProxy(typeThatImplementsInterfaceType, Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), fakeCallProcessorProvider);
+            CastleDynamicProxyGenerator.GenerateProxy(typeThatImplementsInterfaceType, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), fakeCallProcessorProvider);
 
             // Assert
             A.CallTo(() => fakeCallProcessorProvider.Fetch(A<object>._)).MustNotHaveHappened();
@@ -138,7 +141,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Arrange
             // Here we can't use A.Dummy<IFakeCallProcessorProvider>() because the EnsureInitialized() call within GenerateProxy()
             // triggers the Castle issue #65 (https://github.com/castleproject/Core/issues/65)
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, Type.EmptyTypes, null, Enumerable.Empty<Expression<Func<Attribute>>>(), new SerializableFakeCallProcessorProvider());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), new SerializableFakeCallProcessorProvider());
             var proxy = result.GeneratedProxy;
 
             // Act
@@ -156,7 +159,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Arrange
 
             // Act
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeof(int), Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(typeof(int), this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
             result.ReasonForFailure.Should().Be("The type of proxy must be an interface or a class but it was System.Int32.");
@@ -168,7 +171,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Arrange
 
             // Act
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeof(SealedType), A.Dummy<IEnumerable<Type>>(), A.Dummy<IEnumerable<object>>(), Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(typeof(SealedType), this.noAdditionalInterfaces, A.Dummy<IEnumerable<object>>(), Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
             result.ReasonForFailure.Should().Be("The type of proxy FakeItEasy.Tests.Creation.CastleDynamicProxy.CastleDynamicProxyGeneratorTests+SealedType is sealed.");
@@ -181,7 +184,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Arrange
 
             // Act
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeof(ClassWithPrivateConstructor), Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(typeof(ClassWithPrivateConstructor), this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
             result.ReasonForFailure.Should().StartWith("No usable default constructor was found on the type");
@@ -195,7 +198,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
 
             // Act
             var type = Type.GetType("FluentAssertions.Common.NullReflector, FluentAssertions.Core");
-            var result = CastleDynamicProxyGenerator.GenerateProxy(type, Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(type, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
             result.ReasonForFailure.Should().StartWith("No usable default constructor was found on the type FluentAssertions.Common.NullReflector.\r\nAn exception of type Castle.DynamicProxy.Generators.GeneratorException was caught during this call. Its message was:\r\nCan not create proxy for type FluentAssertions.Common.NullReflector because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly FluentAssertions.Core is strong-named.");
@@ -208,7 +211,12 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Arrange
 
             // Act
-            var result = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, new[] { typeof(IFoo) }, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            var result = CastleDynamicProxyGenerator.GenerateProxy(
+                typeOfProxy,
+                new ReadOnlyCollection<Type>(new List<Type> { typeof(IFoo) }),
+                argumentsForConstructor: null,
+                Enumerable.Empty<Expression<Func<Attribute>>>(),
+                A.Dummy<IFakeCallProcessorProvider>());
 
             // Assert
             result.GeneratedProxy.Should().NotBeNull().And.BeAssignableTo<IFoo>();
@@ -222,7 +230,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Act
 
             // Assert
-            Expression<Action> call = () => CastleDynamicProxyGenerator.GenerateProxy(typeof(IInterfaceType), Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            Expression<Action> call = () => CastleDynamicProxyGenerator.GenerateProxy(typeof(IInterfaceType), this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
             call.Should().BeNullGuarded();
         }
 
@@ -234,7 +242,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Act
             var result = CastleDynamicProxyGenerator.GenerateProxy(
                 typeof(TypeWithArgumentsForConstructor),
-                Enumerable.Empty<Type>(),
+                this.noAdditionalInterfaces,
                 new object[] { 10 },
                 Enumerable.Empty<Expression<Func<Attribute>>>(),
                 A.Dummy<IFakeCallProcessorProvider>());
@@ -253,7 +261,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             // Act
             var result = CastleDynamicProxyGenerator.GenerateProxy(
                 typeof(TypeWithArgumentsForConstructor),
-                Enumerable.Empty<Type>(),
+                this.noAdditionalInterfaces,
                 new object[] { "no constructor takes a string" },
                 Enumerable.Empty<Expression<Func<Attribute>>>(),
                 A.Dummy<IFakeCallProcessorProvider>());
@@ -270,7 +278,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             var arguments = new object[] { "no constructor on interface " };
 
             // Act
-            var ex = Record.Exception(() => CastleDynamicProxyGenerator.GenerateProxy(typeof(IInterfaceType), Enumerable.Empty<Type>(), arguments, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>()));
+            var ex = Record.Exception(() => CastleDynamicProxyGenerator.GenerateProxy(typeof(IInterfaceType), this.noAdditionalInterfaces, arguments, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>()));
 
             // Assert
             ex.Should().BeAnExceptionOfType<ArgumentException>()
@@ -285,7 +293,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             var fakeCallProcessorProvider = CreateFakeCallProcessorProvider(c => c.SetReturnValue("interception return value"));
 
             // Act
-            var proxy = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, Enumerable.Empty<Type>(), null, Enumerable.Empty<Expression<Func<Attribute>>>(), fakeCallProcessorProvider);
+            var proxy = CastleDynamicProxyGenerator.GenerateProxy(typeOfProxy, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), fakeCallProcessorProvider);
             var toStringResult = proxy.GeneratedProxy.ToString();
 
             // Assert


### PR DESCRIPTION
Connects to #1489.

Comparing develop (4.10.0-alpha068  / 19d298621bbe60c8f456a58ae92e285da31bc708) to this PR (4.10.0-do-not-linq-addit001) results in

|                                            Method |                         Job |      Mean |     Error |    StdDev | Ratio |
|-------------------------------------------------- |---------------------------- |----------:|----------:|----------:|------:|
| A.Fake&lt;SimpleClass&gt;(o =&gt; o.Implements&lt;IFake&gt;()) |             4.10.0-alpha068 | 10.481 us | 0.1211 us | 0.0801 us |  1.00 |
| A.Fake&lt;SimpleClass&gt;(o =&gt; o.Implements&lt;IFake&gt;()) | 4.10.0-do-not-linq-addit001 | 10.310 us | 0.1566 us | 0.1036 us |  0.98 |
|                             A.Fake&lt;SimpleClass&gt;() |             4.10.0-alpha068 |  9.737 us | 0.1732 us | 0.1146 us |  1.00 |
|                             A.Fake&lt;SimpleClass&gt;() | 4.10.0-do-not-linq-addit001 |  9.414 us | 0.1022 us | 0.0676 us |  0.97 |
|                         A.Fake&lt;LessSimpleClass&gt;() |             4.10.0-alpha068 | 21.370 us | 0.2606 us | 0.1724 us |  1.00 |
|                         A.Fake&lt;LessSimpleClass&gt;() | 4.10.0-do-not-linq-addit001 | 21.075 us | 0.2037 us | 0.1065 us |  0.99 |
|                                   A.Fake&lt;IFake&gt;() |             4.10.0-alpha068 | 11.694 us | 0.2005 us | 0.1193 us |  1.00 |
|                                   A.Fake&lt;IFake&gt;() | 4.10.0-do-not-linq-addit001 |  9.778 us | 0.0792 us | 0.0471 us |  0.84 |

![image](https://user-images.githubusercontent.com/3275797/48169350-f95cb200-e2c0-11e8-8913-dee1a31760b2.png)

