### PR TITLE
Streamline faked interface creation

### DIFF
--- a/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Creation.DelegateProxies
+namespace FakeItEasy.Creation.DelegateProxies
 {
     using System;
     using System.Collections.Generic;
@@ -16,28 +16,11 @@
         {
             Guard.AgainstNull(typeOfProxy, nameof(typeOfProxy));
 
-            if (!CanGenerateProxy(typeOfProxy, out string reasonCannotGenerate))
-            {
-                return new ProxyGeneratorResult(reasonCannotGenerate);
-            }
-
             var invokeMethod = typeOfProxy.GetMethod("Invoke");
             var eventRaiser = new DelegateCallInterceptedEventRaiser(fakeCallProcessorProvider, invokeMethod, typeOfProxy);
 
             fakeCallProcessorProvider.EnsureInitialized(eventRaiser.Instance);
             return new ProxyGeneratorResult(eventRaiser.Instance);
-        }
-
-        public static bool CanGenerateProxy(Type typeOfProxy, out string failReason)
-        {
-            if (!typeof(Delegate).IsAssignableFrom(typeOfProxy))
-            {
-                failReason = "The delegate proxy generator can only create proxies for delegate types.";
-                return false;
-            }
-
-            failReason = null;
-            return true;
         }
 
         private static Delegate CreateDelegateProxy(

--- a/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyGeneratorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyGeneratorTests.cs
@@ -21,19 +21,32 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
         {
         }
 
-        [Theory]
-        [InlineData(typeof(IInterfaceType))]
-        [InlineData(typeof(AbstractClass))]
-        [InlineData(typeof(ClassWithProtectedConstructor))]
-        [InlineData(typeof(ClassWithInternalConstructorVisibleToDynamicProxy))]
-        [InlineData(typeof(InternalClassVisibleToDynamicProxy))]
-        public void Should_ensure_fake_call_processor_is_initialized_but_not_fetched_when_no_method_on_fake_is_called(Type typeThatImplementsInterfaceType)
+        [Fact]
+        public void Should_ensure_fake_call_processor_is_initialized_but_not_fetched_when_no_method_on_fake_interface_is_called()
         {
             // Arrange
             var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
 
             // Act
-            CastleDynamicProxyGenerator.GenerateProxy(typeThatImplementsInterfaceType, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), fakeCallProcessorProvider);
+            CastleDynamicProxyGenerator.GenerateInterfaceProxy(typeof(IInterfaceType), this.noAdditionalInterfaces, Enumerable.Empty<Expression<Func<Attribute>>>(), fakeCallProcessorProvider);
+
+            // Assert
+            A.CallTo(() => fakeCallProcessorProvider.Fetch(A<object>._)).MustNotHaveHappened();
+            A.CallTo(() => fakeCallProcessorProvider.EnsureInitialized(A<object>._)).MustHaveHappened();
+        }
+
+        [Theory]
+        [InlineData(typeof(AbstractClass))]
+        [InlineData(typeof(ClassWithProtectedConstructor))]
+        [InlineData(typeof(ClassWithInternalConstructorVisibleToDynamicProxy))]
+        [InlineData(typeof(InternalClassVisibleToDynamicProxy))]
+        public void Should_ensure_fake_call_processor_is_initialized_but_not_fetched_when_no_method_on_fake_class_is_called(Type typeToProxy)
+        {
+            // Arrange
+            var fakeCallProcessorProvider = A.Fake<IFakeCallProcessorProvider>();
+
+            // Act
+            CastleDynamicProxyGenerator.GenerateClassProxy(typeToProxy, this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), fakeCallProcessorProvider);
 
             // Assert
             A.CallTo(() => fakeCallProcessorProvider.Fetch(A<object>._)).MustNotHaveHappened();
@@ -41,22 +54,31 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
         }
 
         [Fact]
-        public void GenerateProxy_should_be_null_guarded()
+        public void GenerateInterfaceProxy_should_be_null_guarded()
         {
             // Arrange
 
             // Act
 
             // Assert
-            Expression<Action> call = () => CastleDynamicProxyGenerator.GenerateProxy(typeof(IInterfaceType), this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            Expression<Action> call = () => CastleDynamicProxyGenerator.GenerateInterfaceProxy(typeof(IInterfaceType), this.noAdditionalInterfaces, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
+            call.Should().BeNullGuarded();
+        }
+
+        [Fact]
+        public void GenerateClassProxy_should_be_null_guarded()
+        {
+            // Arrange
+
+            // Act
+
+            // Assert
+            Expression<Action> call = () => CastleDynamicProxyGenerator.GenerateClassProxy(typeof(AbstractClass), this.noAdditionalInterfaces, null, Enumerable.Empty<Expression<Func<Attribute>>>(), A.Dummy<IFakeCallProcessorProvider>());
             call.Should().BeNullGuarded();
         }
 
         public abstract class AbstractClass
         {
-            public virtual void Foo(int argument1, int argument2)
-            {
-            }
         }
 
         public class ClassWithProtectedConstructor


### PR DESCRIPTION
Connects to #1489.

We do a lot of double-checking of faked types and guarding against constructor arguments being present when we don't need to. If we have a dedicated method for faking interfaces (which I still hope is the most common case), we can save some work.

I took it in two steps. The second one just realizes that we don't need a common interface on `DelegateCreationStrategy` and `DefaultCreationStrategy` and that we can then remove the LINQing over the list of them. This actually improves configuration and verification performance a little bit, as it's cheaper to see who's responsible for intercepting a method.

My version of the BenchmarkMockNet tests:

|          Method |                         Job |                        NuGetReferences |      Mean |     Error |    StdDev | Ratio | RatioSD |
|---------------- |---------------------------- |--------------------------------------- |----------:|----------:|----------:|------:|--------:|
|        Callback |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 | 29.347 us | 1.2723 us | 0.4537 us |  1.00 |    0.00 |
|        Callback | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 | 27.499 us | 1.0720 us | 0.3823 us |  0.94 |    0.03 |
|        Callback | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 | 26.681 us | 0.5776 us | 0.2060 us |  0.91 |    0.01 |
|                 |                             |                                        |           |           |           |       |         |
|    CallbackOnly |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 |  6.360 us | 1.5918 us | 0.5677 us |  1.00 |    0.00 |
|    CallbackOnly | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 |  6.307 us | 1.6640 us | 0.5934 us |  0.99 |    0.02 |
|    CallbackOnly | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 |  6.366 us | 1.4357 us | 0.5120 us |  1.00 |    0.02 |
|                 |                             |                                        |           |           |           |       |         |
|    Construction |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 |  9.358 us | 0.2630 us | 0.0938 us |  1.00 |    0.00 |
|    Construction | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 |  8.141 us | 0.2426 us | 0.0865 us |  0.87 |    0.01 |
|    Construction | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 |  8.675 us | 1.2061 us | 0.4301 us |  0.93 |    0.05 |
|                 |                             |                                        |           |           |           |       |         |
|     EmptyMethod |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 | 18.195 us | 1.4476 us | 0.5162 us |  1.00 |    0.00 |
|     EmptyMethod | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 | 15.979 us | 0.3875 us | 0.1382 us |  0.88 |    0.02 |
|     EmptyMethod | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 | 16.483 us | 0.7798 us | 0.2781 us |  0.91 |    0.04 |
|                 |                             |                                        |           |           |           |       |         |
| EmptyMethodOnly |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 |  7.784 us | 2.8136 us | 1.0034 us |  1.00 |    0.00 |
| EmptyMethodOnly | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 |  7.877 us | 2.0247 us | 0.7220 us |  1.02 |    0.05 |
| EmptyMethodOnly | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 |  7.943 us | 2.2646 us | 0.8076 us |  1.02 |    0.03 |
|                 |                             |                                        |           |           |           |       |         |
|    EmptyReturns |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 | 18.591 us | 1.0612 us | 0.3784 us |  1.00 |    0.00 |
|    EmptyReturns | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 | 16.403 us | 0.8802 us | 0.3139 us |  0.88 |    0.03 |
|    EmptyReturns | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 | 16.643 us | 1.3203 us | 0.4708 us |  0.90 |    0.04 |
|                 |                             |                                        |           |           |           |       |         |
| EmptyReturnOnly |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 |  8.142 us | 2.3930 us | 0.8534 us |  1.00 |    0.00 |
| EmptyReturnOnly | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 |  8.112 us | 2.3078 us | 0.8230 us |  1.00 |    0.01 |
| EmptyReturnOnly | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 |  8.249 us | 2.2496 us | 0.8022 us |  1.01 |    0.03 |
|                 |                             |                                        |           |           |           |       |         |
|          Return |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 | 28.118 us | 0.5199 us | 0.1854 us |  1.00 |    0.00 |
|          Return | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 | 26.401 us | 0.6856 us | 0.2445 us |  0.94 |    0.01 |
|          Return | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 | 25.301 us | 0.4699 us | 0.1676 us |  0.90 |    0.01 |
|                 |                             |                                        |           |           |           |       |         |
|      ReturnOnly |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 |  8.321 us | 2.1064 us | 0.7512 us |  1.00 |    0.00 |
|      ReturnOnly | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 |  8.244 us | 2.4175 us | 0.8621 us |  0.99 |    0.04 |
|      ReturnOnly | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 |  8.432 us | 2.4468 us | 0.8725 us |  1.01 |    0.04 |
|                 |                             |                                        |           |           |           |       |         |
|          Verify |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 | 32.805 us | 0.6928 us | 0.2471 us |  1.00 |    0.00 |
|          Verify | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 | 31.515 us | 0.6933 us | 0.2472 us |  0.96 |    0.01 |
|          Verify | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 | 30.560 us | 0.7534 us | 0.2687 us |  0.93 |    0.01 |
|                 |                             |                                        |           |           |           |       |         |
|      VerifyOnly |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 |  7.121 us | 0.9012 us | 0.3214 us |  1.00 |    0.00 |
|      VerifyOnly | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 |  7.035 us | 0.4381 us | 0.1562 us |  0.99 |    0.04 |
|      VerifyOnly | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 |  6.407 us | 0.4772 us | 0.1702 us |  0.90 |    0.05 |

![fakeiteasy benchmark benchmarkmocknet-report](https://user-images.githubusercontent.com/3275797/48661059-44ea2b00-ea3a-11e8-995e-aa658942cfd0.png)

And my usual creation benchmarks:

|                                            Method |                         Job |                        NuGetReferences |      Mean |     Error |    StdDev | Ratio | RatioSD |
|-------------------------------------------------- |---------------------------- |--------------------------------------- |----------:|----------:|----------:|------:|--------:|
|                                   A.Fake&lt;IFake&gt;() |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 |  9.113 us | 0.2383 us | 0.0850 us |  1.00 |    0.00 |
|                                   A.Fake&lt;IFake&gt;() | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 |  8.019 us | 0.1626 us | 0.0580 us |  0.88 |    0.01 |
|                                   A.Fake&lt;IFake&gt;() | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 |  8.202 us | 0.3323 us | 0.1185 us |  0.90 |    0.01 |
|                                                   |                             |                                        |           |           |           |       |         |
|                             A.Fake&lt;SimpleClass&gt;() |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 |  8.675 us | 0.4666 us | 0.1664 us |  1.00 |    0.00 |
|                             A.Fake&lt;SimpleClass&gt;() | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 |  8.790 us | 0.5735 us | 0.2045 us |  1.01 |    0.04 |
|                             A.Fake&lt;SimpleClass&gt;() | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 |  8.186 us | 0.6281 us | 0.2240 us |  0.94 |    0.04 |
|                                                   |                             |                                        |           |           |           |       |         |
|                         A.Fake&lt;LessSimpleClass&gt;() |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 | 20.545 us | 0.7010 us | 0.2500 us |  1.00 |    0.00 |
|                         A.Fake&lt;LessSimpleClass&gt;() | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 | 20.680 us | 0.6353 us | 0.2265 us |  1.01 |    0.02 |
|                         A.Fake&lt;LessSimpleClass&gt;() | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 | 19.303 us | 0.5283 us | 0.1884 us |  0.94 |    0.01 |
|                                                   |                             |                                        |           |           |           |       |         |
| &#39;A.Fake&lt;SimpleClass&gt;(o =&gt; o.Implements&lt;IFake&gt;())&#39; |             4.10.0-alpha075 |             FakeItEasy 4.10.0-alpha075 |  9.950 us | 0.2457 us | 0.0876 us |  1.00 |    0.00 |
| &#39;A.Fake&lt;SimpleClass&gt;(o =&gt; o.Implements&lt;IFake&gt;())&#39; | 4.10.0-direct-interface-001 | FakeItEasy 4.10.0-direct-interface-001 | 10.176 us | 0.2508 us | 0.0894 us |  1.02 |    0.01 |
| &#39;A.Fake&lt;SimpleClass&gt;(o =&gt; o.Implements&lt;IFake&gt;())&#39; | 4.10.0-streamline-creati001 | FakeItEasy 4.10.0-streamline-creati001 |  9.664 us | 0.3623 us | 0.1292 us |  0.97 |    0.01 |

![fakeiteasy benchmark program creationbenchmarks-report](https://user-images.githubusercontent.com/3275797/48661075-824eb880-ea3a-11e8-8364-a12377e856a0.png)

In theory, this also sets  us up to use Dynamic Proxy's `CreateInterfaceProxyWithoutTarget`, which is rumoured to take half the time as our current proxying mechanism, but I've not yet tried. If you don't think the changes here are worthwhile, I can try that first.