### PR TITLE
Stop using Zip to check argument constraints

### DIFF
--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -15,7 +15,7 @@ namespace FakeItEasy.Expressions
         : ICallMatcher
     {
         private readonly MethodInfoManager methodInfoManager;
-        private IEnumerable<IArgumentConstraint> argumentConstraints;
+        private IArgumentConstraint[] argumentConstraints;
         private Func<ArgumentCollection, bool> argumentsPredicate;
         private bool useExplicitArgumentsPredicate;
 
@@ -107,10 +107,15 @@ namespace FakeItEasy.Expressions
 
         private bool ArgumentsMatchesArgumentConstraints(ArgumentCollection argumentCollection)
         {
-            return argumentCollection
-                .AsEnumerable()
-                .Zip(this.argumentConstraints, (x, y) => new { ArgumentValue = x, Constraint = y })
-                .All(x => x.Constraint.IsValid(x.ArgumentValue));
+            for (int i = 0; i < argumentCollection.Count; ++i)
+            {
+                if (!this.argumentConstraints[i].IsValid(argumentCollection[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private class PredicatedArgumentConstraint


### PR DESCRIPTION
|     Method |                       Job |      Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|----------- |-------------------------- |----------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
|     Verify |           4.10.0-alpha094 | 22.444 us | 0.2249 us | 0.2104 us |  1.00 |    0.00 |      1.8500 |      0.0200 |      0.0100 |             5.83 KB |
|     Verify | 4.10.0-optimize-verify001 | 21.444 us | 0.2543 us | 0.2379 us |  0.96 |    0.02 |      1.8200 |      0.0200 |      0.0100 |             5.73 KB |
| VerifyOnly |           4.10.0-alpha094 |  6.459 us | 0.1397 us | 0.1307 us |  1.00 |    0.00 |      0.6400 |           - |           - |             1.99 KB |
| VerifyOnly | 4.10.0-optimize-verify001 |  5.934 us | 0.2179 us | 0.2039 us |  0.92 |    0.05 |      0.6100 |           - |           - |              1.9 KB |

![image](https://user-images.githubusercontent.com/3275797/49191729-b9c83980-f345-11e8-8cf6-aaa12eaed864.png)
