### PR TITLE
update Bullseye to 2.3.0-beta.3

### DIFF
--- a/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
+++ b/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.1.0" />
+    <PackageReference Include="Bullseye" Version="2.3.0-beta.3" />
     <PackageReference Include="SimpleExec" Version="$(SimpleExecVersion)" />
     <PackageReference Include="PdbGit" Version="3.0.41" ToolName="PdbGit" ToolExe="PdbGit.exe" />
   </ItemGroup>

--- a/tools/FakeItEasy.Build/Program.cs
+++ b/tools/FakeItEasy.Build/Program.cs
@@ -76,7 +76,7 @@
                 forEach: Pdbs,
                 action: pdb => Run(ToolPaths.PdbGit, $"-u https://github.com/FakeItEasy/FakeItEasy -s {pdb}"));
 
-            RunTargets(args);
+            RunTargetsAndExit(args);
         }
     }
 }


### PR DESCRIPTION
Main features:

## [RunTargetsAndExit() and RunTargetsAndExitAsync()](https://github.com/adamralph/bullseye/issues/172)

### Before

<img src="https://user-images.githubusercontent.com/677704/49482106-0de38a00-f82e-11e8-9d38-53249bd5b9d9.png" width="612px" />

Returns after a two second delay while three entries are written to the OS event logs.

### After

<img src="https://user-images.githubusercontent.com/677704/49482039-d4ab1a00-f82d-11e8-94e8-552f1d9a2ea5.png" width="375px" />

Returns immediately with nothing written to the OS event logs.

## [Option to show dependency tree](https://github.com/adamralph/bullseye/issues/128)

<img src="https://user-images.githubusercontent.com/677704/49481869-0bccfb80-f82d-11e8-809f-08b275419136.png" width="675px" />