### PR TITLE
Warn that delegates can't call base method at configuration time

### DIFF
--- a/src/FakeItEasy/Configuration/RuleBuilder.cs
+++ b/src/FakeItEasy/Configuration/RuleBuilder.cs
@@ -3,6 +3,9 @@ namespace FakeItEasy.Configuration
     using System;
     using System.Collections.Generic;
     using System.Linq.Expressions;
+#if FEATURE_NETCORE_REFLECTION
+    using System.Reflection;
+#endif
     using FakeItEasy.Core;
 
     internal class RuleBuilder
@@ -123,6 +126,11 @@ namespace FakeItEasy.Configuration
 
         public virtual IAfterCallConfiguredConfiguration<IVoidConfiguration> CallsBaseMethod()
         {
+            if (this.manager.FakeObjectType.GetTypeInfo().IsSubclassOf(typeof(Delegate)))
+            {
+                throw new FakeConfigurationException(ExceptionMessages.DelegateCannotCallBaseMethod);
+            }
+
             this.AddRuleIfNeeded();
             this.RuleBeingBuilt.UseApplicator(x => { });
             this.RuleBeingBuilt.CallBaseMethod = true;

--- a/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
@@ -219,7 +219,7 @@ namespace FakeItEasy.Creation.DelegateProxies
 
             public override void CallBaseMethod()
             {
-                throw new NotSupportedException("Can not configure a delegate proxy to call base method.");
+                throw new FakeConfigurationException(ExceptionMessages.DelegateCannotCallBaseMethod);
             }
 
             public override void SetArgumentValue(int index, object value)

--- a/src/FakeItEasy/ExceptionMessages.cs
+++ b/src/FakeItEasy/ExceptionMessages.cs
@@ -28,6 +28,8 @@ namespace FakeItEasy
 
         public static string ArgumentConstraintCannotBeNestedInArgument => "An argument constraint, such as That, Ignored, or _, cannot be nested in an argument.";
 
+        public static string DelegateCannotCallBaseMethod => "Can not configure a delegate proxy to call a base method.";
+
         public static string WrongConstructorExpressionType(Type actualConstructorType, Type expectedConstructorType) =>
             $"Supplied constructor is for type {actualConstructorType}, but must be for {expectedConstructorType}.";
 

--- a/tests/FakeItEasy.Specs/FakingDelegates.cs
+++ b/tests/FakeItEasy.Specs/FakingDelegates.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy.Specs
 {
     using System;
+    using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using Xbehave;
@@ -98,16 +99,13 @@ namespace FakeItEasy.Specs
             "Given a fake delegate"
                 .x(() => fake = A.Fake<Action>());
 
-            "And I configure it to call its base method"
-                .x(() => A.CallTo(() => fake.Invoke()).CallsBaseMethod());
-
-            "When I invoke it"
-                .x(() => exception = Record.Exception(() => fake.Invoke()));
+            "When I configure it to call its base method"
+                .x(() => exception = Record.Exception(() => A.CallTo(() => fake.Invoke()).CallsBaseMethod()));
 
             "Then it throws a not supported exception"
                 .x(() => exception.Should()
-                    .BeAnExceptionOfType<NotSupportedException>()
-                    .WithMessage("Can not configure a delegate proxy to call base method."));
+                    .BeAnExceptionOfType<FakeConfigurationException>()
+                    .WithMessage("Can not configure a delegate proxy to call a base method."));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
@@ -23,7 +23,7 @@ namespace FakeItEasy.Tests.Configuration
             this.asserter = A.Fake<IFakeAsserter>();
             this.ruleProducedByFactory = A.Fake<BuildableCallRule>();
 
-            this.fakeManager = A.Fake<FakeManager>(o => o.CallsBaseMethods());
+            this.fakeManager = new FakeManager(typeof(object), new object());
 
             this.builder = this.CreateBuilder();
         }


### PR DESCRIPTION
Fixes #1492 