### PR TITLE
show messages only for build exceptions

### DIFF
--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <NoWarn>$(NoWarn),SA0001</NoWarn>
-        <SimpleExecVersion>4.0.0-beta.1</SimpleExecVersion>
+        <SimpleExecVersion>4.1.0</SimpleExecVersion>
         <NuGetVersion>4.1.0</NuGetVersion>
         <OctokitVersion>0.31.0</OctokitVersion>
     </PropertyGroup>

--- a/tools/FakeItEasy.Build/Program.cs
+++ b/tools/FakeItEasy.Build/Program.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.IO;
+    using SimpleExec;
     using static Bullseye.Targets;
     using static SimpleExec.Command;
 
@@ -76,7 +77,7 @@
                 forEach: Pdbs,
                 action: pdb => Run(ToolPaths.PdbGit, $"-u https://github.com/FakeItEasy/FakeItEasy -s {pdb}"));
 
-            RunTargetsAndExit(args);
+            RunTargetsAndExit<CommandException>(args);
         }
     }
 }


### PR DESCRIPTION
Since each target is a one-liner which calls SimpleExec, the stack traces are useless. This change this:

![image](https://user-images.githubusercontent.com/677704/49646099-69746a00-fa1e-11e8-95f6-aaa4563cd79e.png)

to this:

![image](https://user-images.githubusercontent.com/677704/49646164-90cb3700-fa1e-11e8-8d1e-9c49be0d0bd4.png)
