### PR TITLE
Remove MonoDevelop section from sln

### DIFF
--- a/FakeItEasy.sln
+++ b/FakeItEasy.sln
@@ -226,8 +226,4 @@ Global
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E70BBF50-5920-49F2-835D-4A2DBD73F0E1}
 	EndGlobalSection
-	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 0.1
-		StartupItem = src\FakeItEasy\FakeItEasy.csproj
-	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Just noticed this when searching for references to develop in the repo. I think it's been a very long time since anyone used MonoDevelop to work on FakeItEasy!