### PR TITLE
Correct documentation on return value when Invokes is used

### DIFF
--- a/docs/invoking-custom-code.md
+++ b/docs/invoking-custom-code.md
@@ -19,11 +19,9 @@ A.CallTo(() => fakeShop.SellSmarties())
 Now when the System Under Test calls `SellSmarties`, the Fake will
 call `OrderMoreSmarties`.
 
-If the method being configured has a return value, you should use
-`Return` to specify the return value, or it will return `null` (or a
-default value for a value type). This is true even if the return type
-of the method is such that an unconfigured method would not return
-`null` (for example, if the method returns a string or `Task`).
+If the method being configured has a return value, it will continue to return the
+[default value for an unconfigured fake](default-fake-behavior.md/#overrideable-members-are-faked)
+unless you override it with `Returns` or `ReturnsLazily`.
 
 There are also more advanced variants that can invoke actions based on
 arguments supplied to the faked method. These act similarly to how you
@@ -39,6 +37,5 @@ A.CallTo(()=>fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
 A.CallTo(() => fakeShop.NumberOfSweetsSoldOn(A<DateTime>._))
  .Invokes(callObject => System.Console.Out.WriteLine(callObject.FakedObject +
                                                      " is closed on " +
-                                                     callObject.Arguments[0]))
- .Returns(0);
+                                                     callObject.Arguments[0]));
 ```

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -52,14 +52,14 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
-        public static void Callback(
+        public static void CallbackOnVoid(
             IFoo fake,
             bool wasCalled)
         {
             "Given a fake"
                 .x(() => fake = A.Fake<IFoo>());
 
-            "And I configure a method to invoke an action"
+            "And I configure a method to invoke an action when a void method is called"
                 .x(() => A.CallTo(() => fake.Bar()).Invokes(x => wasCalled = true));
 
             "When I call the method"
@@ -67,6 +67,28 @@ namespace FakeItEasy.Specs
 
             "Then it invokes the action"
                 .x(() => wasCalled.Should().BeTrue());
+        }
+
+        [Scenario]
+        public static void CallbackOnStringReturningMethod(
+            IFoo fake,
+            bool wasCalled,
+            string result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And I configure a method to invoke an action when a string-returning method is called"
+                .x(() => A.CallTo(() => fake.Bas()).Invokes(x => wasCalled = true));
+
+            "When I call the method"
+                .x(() => result = fake.Bas());
+
+            "Then it invokes the action"
+                .x(() => wasCalled.Should().BeTrue());
+
+            "And a default value is returned"
+                .x(() => result.Should().BeEmpty());
         }
 
         [Scenario]


### PR DESCRIPTION
While I was looking at #1496, I noticed that the documentation for `Invokes` said that the return value would be `null` or `default` unless `Returns` was used to change it, but this is not so.