### PR TITLE
Remove bad slash in link to default behaviour

### DIFF
--- a/docs/invoking-custom-code.md
+++ b/docs/invoking-custom-code.md
@@ -20,7 +20,7 @@ Now when the System Under Test calls `SellSmarties`, the Fake will
 call `OrderMoreSmarties`.
 
 If the method being configured has a return value, it will continue to return the
-[default value for an unconfigured fake](default-fake-behavior.md/#overrideable-members-are-faked)
+[default value for an unconfigured fake](default-fake-behavior.md#overrideable-members-are-faked)
 unless you override it with `Returns` or `ReturnsLazily`.
 
 There are also more advanced variants that can invoke actions based on


### PR DESCRIPTION
Fixes up an error I made in #1552.
I'd previewed that change in VSCode, which wasn't bothered by the extra slash, but [on the Read The Docs site](https://fakeiteasy.readthedocs.io/en/latest/invoking-custom-code/), it's a broken link.
