### PR TITLE
upgrade SimpleExec to 5.0.0-beta.1

### DIFF
--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <NoWarn>$(NoWarn),SA0001</NoWarn>
-        <SimpleExecVersion>4.2.0</SimpleExecVersion>
+        <SimpleExecVersion>5.0.0-beta.1</SimpleExecVersion>
         <NuGetVersion>4.1.0</NuGetVersion>
         <OctokitVersion>0.31.0</OctokitVersion>
     </PropertyGroup>


### PR DESCRIPTION
Hope you don't mind me using you as beta guinea pigs again. 😀

Functional changes between SimpleExec 4.2.0 and 5.0.0-beta.1:

- **(Breaking)** [Use cmd.exe on Windows](https://github.com/adamralph/simple-exec/issues/100) - _Shouldn't make any difference to your build, and it's only marked as breaking pessimistically. It probably won't break anyone._
- **(Breaking)** [Remove deprecated CommandException](https://github.com/adamralph/simple-exec/issues/104) - _You're not using it. You're already using `NonZeroExitCodeException`._
- [upgrade sourcelink to 1.0.0-beta2-18618-05](https://github.com/adamralph/simple-exec/pull/98) - _Probably won't change anything. I guess if you do ever step into SimpleExec, there may be some minor fixes/enhancements to that experience._
- [Handle large output when reading](https://github.com/adamralph/simple-exec/pull/111) - _You probably don't need this._