### PR TITLE
Update Bullseye to 2.4.0-beta.1 and SimpleExec to 6.0.0

### DIFF
--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <NoWarn>$(NoWarn),SA0001</NoWarn>
-        <SimpleExecVersion>6.0.0-beta.1</SimpleExecVersion>
+        <SimpleExecVersion>6.0.0</SimpleExecVersion>
         <NuGetVersion>4.1.0</NuGetVersion>
         <OctokitVersion>0.31.0</OctokitVersion>
     </PropertyGroup>

--- a/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
+++ b/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.3.0-beta.6" />
+    <PackageReference Include="Bullseye" Version="2.4.0-beta.1" />
     <PackageReference Include="SimpleExec" Version="$(SimpleExecVersion)" />
     <PackageReference Include="PdbGit" Version="3.0.41" ToolName="PdbGit" ToolExe="PdbGit.exe" />
   </ItemGroup>


### PR DESCRIPTION
- Bullseye from 2.3.0 to 2.4.0-beta.1
- SimpleExec from 6.0.0-beta.1 to 6.0.0

Contains (among other things) adamralph/bullseye#168.