### PR TITLE
update build tools

### DIFF
--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <NoWarn>$(NoWarn),SA0001</NoWarn>
-        <SimpleExecVersion>6.0.0</SimpleExecVersion>
+        <SimpleExecVersion>6.1.0-beta.1</SimpleExecVersion>
         <NuGetVersion>4.1.0</NuGetVersion>
         <OctokitVersion>0.31.0</OctokitVersion>
     </PropertyGroup>

--- a/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
+++ b/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.4.0-rc.2" />
+    <PackageReference Include="Bullseye" Version="3.0.0-beta.3" />
     <PackageReference Include="SimpleExec" Version="$(SimpleExecVersion)" />
     <PackageReference Include="PdbGit" Version="3.0.41" ToolName="PdbGit" ToolExe="PdbGit.exe" />
   </ItemGroup>


### PR DESCRIPTION
- [Bullseye 3.0.0-beta.3](https://github.com/adamralph/bullseye/issues?q=milestone%3A3.0.0+label%3Aenhancement)
- [SimpleExec 6.1.0-beta.1](https://github.com/adamralph/simple-exec/issues?q=label%3Aenhancement+milestone%3A6.1.0)

I'd love to get your feedback on these changes. They are mainly cosmetic: a bunch of logging tweaks. In the case of Bullseye, a few of the changes are marked `breaking` but purely because the logging was previously done to stdout, so theoretically the output could have been being piped to another program and parsed. All logging is done to stderr now.