### PR TITLE
Reduce number of nullable reference warnings in Specs

### DIFF
--- a/tests/FakeItEasy.Specs/ArgumentMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/ArgumentMatchingSpecs.cs
@@ -85,7 +85,7 @@
                 .x(() => fake = A.Fake<IFoo>());
 
             "And a fake method with 2 parameters is configured to return a value when the arguments match a predicate"
-                .x(() => A.CallTo(() => fake.Bar(0, null))
+                .x(() => A.CallTo(() => fake.Bar(0, string.Empty))
                             .WhenArgumentsMatch(args => args.Get<int>(0) % 2 == 0 && args.Get<string>(1).Length < 3)
                             .Returns(42));
 
@@ -103,7 +103,7 @@
                 .x(() => fake = A.Fake<IFoo>());
 
             "And a fake method with 2 parameters is configured to return a value when the arguments match a predicate"
-                .x(() => A.CallTo(() => fake.Bar(0, null))
+                .x(() => A.CallTo(() => fake.Bar(0, string.Empty))
                             .WhenArgumentsMatch(args => args.Get<int>(0) % 2 == 0 && args.Get<string>(1).Length < 3)
                             .Returns(42));
 
@@ -177,7 +177,7 @@
                 .x(() => fake = A.Fake<IFoo>());
 
             "And a fake method with 2 parameters is configured to return a value when the arguments match a predicate"
-                .x(() => A.CallTo(() => fake.Bar(0, null))
+                .x(() => A.CallTo(() => fake.Bar(0, string.Empty))
                             .WhenArgumentsMatch((int a, string b) => a % 2 == 0 && b.Length < 3)
                             .Returns(42));
 
@@ -195,7 +195,7 @@
                 .x(() => fake = A.Fake<IFoo>());
 
             "And a fake method with 2 parameters is configured to return a value when the arguments match a predicate"
-                .x(() => A.CallTo(() => fake.Bar(0, null))
+                .x(() => A.CallTo(() => fake.Bar(0, string.Empty))
                             .WhenArgumentsMatch((int a, string b) => a % 2 == 0 && b.Length < 3)
                             .Returns(42));
 
@@ -214,7 +214,7 @@
 
             "And a fake method with 2 parameters is configured with an arguments predicate with an incompatible signature"
                 .x(() => exception = Record.Exception(
-                        () => A.CallTo(() => fake.Bar(0, null))
+                        () => A.CallTo(() => fake.Bar(0, string.Empty))
                             .WhenArgumentsMatch((long a, DateTime b) => true)
                             .Returns(42)));
 
@@ -233,7 +233,7 @@
                 .x(() => fake = A.Fake<IFoo>());
 
             "And a fake method with 3 parameters is configured to return a value when the arguments match a predicate"
-                .x(() => A.CallTo(() => fake.Bar(0, null, false))
+                .x(() => A.CallTo(() => fake.Bar(0, string.Empty, false))
                             .WhenArgumentsMatch((int a, string b, bool c) => a % 2 == 0 && b.Length < 3 && c)
                             .Returns(42));
 
@@ -251,7 +251,7 @@
                 .x(() => fake = A.Fake<IFoo>());
 
             "And a fake method with 3 parameters is configured to return a value when the arguments match a predicate"
-                .x(() => A.CallTo(() => fake.Bar(0, null, false))
+                .x(() => A.CallTo(() => fake.Bar(0, string.Empty, false))
                             .WhenArgumentsMatch((int a, string b, bool c) => a % 2 == 0 && b.Length < 3 && c)
                             .Returns(42));
 
@@ -270,7 +270,7 @@
 
             "And a fake method with 3 parameters is configured with an arguments predicate with an incompatible signature"
                 .x(() => exception = Record.Exception(
-                        () => A.CallTo(() => fake.Bar(0, null, false))
+                        () => A.CallTo(() => fake.Bar(0, string.Empty, false))
                             .WhenArgumentsMatch((long a, DateTime b, Type c) => true)
                             .Returns(42)));
 
@@ -289,7 +289,7 @@
                 .x(() => fake = A.Fake<IFoo>());
 
             "And a fake method with 4 parameters is configured to return a value when the arguments match a predicate"
-                .x(() => A.CallTo(() => fake.Bar(0, null, false, null))
+                .x(() => A.CallTo(() => fake.Bar(0, string.Empty, false, new object()))
                             .WhenArgumentsMatch((int a, string b, bool c, object d) => a % 2 == 0 && b.Length < 3 && c && d != null)
                             .Returns(42));
 
@@ -307,12 +307,12 @@
                 .x(() => fake = A.Fake<IFoo>());
 
             "And a fake method with 4 parameters is configured to return a value when the arguments match a predicate"
-                .x(() => A.CallTo(() => fake.Bar(0, null, false, null))
+                .x(() => A.CallTo(() => fake.Bar(0, string.Empty, false, new object()))
                             .WhenArgumentsMatch((int a, string b, bool c, object d) => a % 2 == 0 && b.Length < 3 && c && d != null)
                             .Returns(42));
 
             "When the method is called with arguments that don't satisfy the predicate"
-                .x(() => result = fake.Bar(3, "hello", false, null));
+                .x(() => result = fake.Bar(3, "hello", false, new object()));
 
             "Then it returns the default value"
                 .x(() => result.Should().Be(0));
@@ -326,7 +326,7 @@
 
             "And a fake method with 4 parameters is configured with an arguments predicate with an incompatible signature"
                 .x(() => exception = Record.Exception(
-                        () => A.CallTo(() => fake.Bar(0, null, false, null))
+                        () => A.CallTo(() => fake.Bar(0, string.Empty, false, new object()))
                             .WhenArgumentsMatch((long a, DateTime b, Type c, char d) => true)
                             .Returns(42)));
 

--- a/tests/FakeItEasy.Specs/AssertingCallCountSpecs.cs
+++ b/tests/FakeItEasy.Specs/AssertingCallCountSpecs.cs
@@ -28,7 +28,12 @@ namespace FakeItEasy.Specs
 
             public string AssertionError { get; }
 
-            public CallCountAsserter(int numberOfCalls, Expression<Action<IAssertConfiguration>> assertion, string assertionError = null)
+            public CallCountAsserter(int numberOfCalls, Expression<Action<IAssertConfiguration>> assertion)
+                : this(numberOfCalls, assertion, string.Empty)
+            {
+            }
+
+            public CallCountAsserter(int numberOfCalls, Expression<Action<IAssertConfiguration>> assertion, string assertionError)
             {
                 this.NumberOfCalls = numberOfCalls;
                 this.assertion = assertion;

--- a/tests/FakeItEasy.Specs/AssertingCallCountWithRepeatedSpecs.cs
+++ b/tests/FakeItEasy.Specs/AssertingCallCountWithRepeatedSpecs.cs
@@ -30,7 +30,12 @@ namespace FakeItEasy.Specs
 
             public string AssertionError { get; }
 
-            public CallCountAsserter(int numberOfCalls, Expression<Action<IAssertConfiguration>> assertion, string assertionError = null)
+            public CallCountAsserter(int numberOfCalls, Expression<Action<IAssertConfiguration>> assertion)
+                : this(numberOfCalls, assertion, string.Empty)
+            {
+            }
+
+            public CallCountAsserter(int numberOfCalls, Expression<Action<IAssertConfiguration>> assertion, string assertionError)
             {
                 this.NumberOfCalls = numberOfCalls;
                 this.assertion = assertion;

--- a/tests/FakeItEasy.Specs/CallDescriptionsInAssertionSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallDescriptionsInAssertionSpecs.cs
@@ -184,7 +184,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = A.Fake<IFoo>());
 
             "And the fake has a method with a parameter that has a custom argument value formatter"
-                .See<IFoo>(foo => foo.Bar(default(HasCustomValueFormatter)));
+                .See((IFoo foo, HasCustomValueFormatter hcvf) => foo.Bar(hcvf));
 
             "And no call is made to the fake"
                 .x(() => { });

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -813,7 +813,7 @@ namespace FakeItEasy.Specs
 
         public class Dummy
         {
-            public string X { get; set; }
+            public string X { get; set; } = string.Empty;
         }
 
         public class Z

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -752,9 +752,9 @@ namespace FakeItEasy.Specs
         {
             public bool WasCalled { get; private set; }
 
-            public string SomeNonVirtualProperty { get; set; }
+            public string SomeNonVirtualProperty { get; set; } = string.Empty;
 
-            public virtual string SomeProperty { get; set; }
+            public virtual string SomeProperty { get; set; } = string.Empty;
 
             public virtual void DoSomething()
             {
@@ -779,7 +779,7 @@ namespace FakeItEasy.Specs
 
         public class DerivedClass : BaseClass
         {
-            public sealed override string SomeProperty { get; set; }
+            public sealed override string SomeProperty { get; set; } = string.Empty;
 
             public sealed override void DoSomething()
             {

--- a/tests/FakeItEasy.Specs/CreationOptionsSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationOptionsSpecs.cs
@@ -65,7 +65,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake.VirtualMethodValueDuringConstructorCall.Should().Be("configured value in fake options"));
 
             "And it returns the configured value after the constructor"
-                .x(() => fake.VirtualMethod(null).Should().Be("configured value in fake options"));
+                .x(() => fake.VirtualMethod("call after constructor").Should().Be("configured value in fake options"));
         }
 
         [Scenario]
@@ -83,7 +83,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it uses the configured behavior"
                 .x(() => result.Should().Be("configured value in fake options"));
@@ -137,7 +137,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake.VirtualMethodValueDuringConstructorCall.Should().Be("first value"));
 
             "And the method uses the second behavior thereafter"
-                .x(() => fake.VirtualMethod(null).Should().Be("second value"));
+                .x(() => fake.VirtualMethod(string.Empty).Should().Be("second value"));
         }
 
         [Scenario]
@@ -156,7 +156,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the overridden method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it uses the configured behavior"
                 .x(() => result.Should().Be("a value from ConfigureFake"));
@@ -202,7 +202,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it uses the configured behavior"
                 .x(() => result.Should().Be("configured value of strict fake"));
@@ -248,7 +248,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it uses the configured behavior"
                 .x(() => result.Should().Be("configured value of strict fake"));
@@ -290,7 +290,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it calls the base method"
                 .x(() => result.Should().Be("implementation value"));
@@ -312,7 +312,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it calls the base method"
                 .x(() => result.Should().Be("implementation value"));
@@ -333,7 +333,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it calls the base method"
                 .x(() => result.Should().Be("implementation value"));
@@ -354,7 +354,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it calls the base method"
                 .x(() => result.Should().Be("implementation value"));
@@ -399,7 +399,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => exception = Record.Exception(() => fake.VirtualMethod(null)));
+                .x(() => exception = Record.Exception(() => fake.VirtualMethod(string.Empty)));
 
             "Then it throws an exception"
                 .x(() => exception
@@ -423,7 +423,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => exception = Record.Exception(() => fake.VirtualMethod(null)));
+                .x(() => exception = Record.Exception(() => fake.VirtualMethod(string.Empty)));
 
             "Then it throws an exception"
                 .x(() => exception
@@ -448,7 +448,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => exception = Record.Exception(() => fake.VirtualMethod(null)));
+                .x(() => exception = Record.Exception(() => fake.VirtualMethod(string.Empty)));
 
             "Then it throws an exception"
                 .x(() => exception
@@ -472,7 +472,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => exception = Record.Exception(() => fake.VirtualMethod(null)));
+                .x(() => exception = Record.Exception(() => fake.VirtualMethod(string.Empty)));
 
             "Then it throws an exception"
                 .x(() => exception
@@ -517,7 +517,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it delegates to the wrapped instance"
                 .x(() => result.Should().Be("implementation value"));
@@ -538,7 +538,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it delegates to the wrapped instance"
                 .x(() => result.Should().Be("wrapped value"));
@@ -560,7 +560,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it delegates to the wrapped instance"
                 .x(() => result.Should().Be("wrapped value"));
@@ -581,7 +581,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it delegates to the wrapped instance"
                 .x(() => result.Should().Be("wrapped value"));
@@ -602,7 +602,7 @@ namespace FakeItEasy.Specs
                 .x(() => fake = this.CreateFake(optionsBuilder));
 
             "When I call the method"
-                .x(() => result = fake.VirtualMethod(null));
+                .x(() => result = fake.VirtualMethod(string.Empty));
 
             "Then it delegates to the last wrapped instance"
                 .x(() => result.Should().Be("second wrapped value"));

--- a/tests/FakeItEasy.Specs/CreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationSpecs.cs
@@ -98,10 +98,10 @@ namespace FakeItEasy.Specs
                 .See(() => new ClassWithMultipleConstructors());
 
             "And another constructor throws"
-                .See(() => new ClassWithMultipleConstructors(default(string)));
+                .See((string s) => new ClassWithMultipleConstructors(s));
 
             "And a third constructor has an argument that cannot be resolved"
-                .See(() => new ClassWithMultipleConstructors(default(UnresolvableArgument), default(string)));
+                .See((UnresolvableArgument ua, string s) => new ClassWithMultipleConstructors(ua, s));
 
             "When I create a fake of the class"
                 .x(() => exception = Record.Exception(() => this.CreateFake<ClassWithMultipleConstructors>()));
@@ -148,10 +148,10 @@ namespace FakeItEasy.Specs
                 .See(() => new FakedClass());
 
             "And the class has a one-parameter constructor"
-                .See(() => new FakedClass(default));
+                .See((ArgumentThatShouldNeverBeResolved a) => new FakedClass(a));
 
             "And the class has a two-parameter constructor"
-                .See(() => new FakedClass(default, default));
+                .See((IDisposable disposable, string s) => new FakedClass(disposable, s));
 
             "When I create a fake of the class"
                 .x(() =>
@@ -190,10 +190,10 @@ namespace FakeItEasy.Specs
                 .See(() => new ClassWhosePreferredConstructorsThrow());
 
             "And the class has a two-parameter constructor that throws"
-                .See(() => new ClassWhosePreferredConstructorsThrow(default, default));
+                .See((IDisposable disposable, string s) => new ClassWhosePreferredConstructorsThrow(disposable, s));
 
             "And the class has a one-parameter constructor that succeeds"
-                .See(() => new ClassWhosePreferredConstructorsThrow(default));
+                .See((int i) => new ClassWhosePreferredConstructorsThrow(i));
 
             // If multiple theads attempt to create the fake at the same time, the
             // unsuccessful constructors may be called more than once, so serialize fake
@@ -599,10 +599,11 @@ namespace FakeItEasy.Specs
                 .See<ClassWithLongSelfReferentialConstructor>();
 
             "And the class has a one-parameter constructor not using its own type"
-                .See(() => new ClassWithLongSelfReferentialConstructor(typeof(object)));
+                .See((Type type) => new ClassWithLongSelfReferentialConstructor(type));
 
             "And the class has a two-parameter constructor using its own type"
-                .See(() => new ClassWithLongSelfReferentialConstructor(typeof(object), default));
+                .See((Type type, ClassWithLongSelfReferentialConstructor selfish) =>
+                    new ClassWithLongSelfReferentialConstructor(type, selfish));
 
             "When I create a fake of the class"
                 .x(() => fake1 = A.Fake<ClassWithLongSelfReferentialConstructor>());

--- a/tests/FakeItEasy.Specs/DomainEvents.cs
+++ b/tests/FakeItEasy.Specs/DomainEvents.cs
@@ -15,8 +15,6 @@ namespace FakeItEasy.Specs
 
         public int ID { get; set; }
 
-        public string Name { get; set; }
-
         public DateTime Timestamp { get; }
 
         public virtual DateTime CalculateTimestamp()

--- a/tests/FakeItEasy.Specs/DummyCreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/DummyCreationSpecs.cs
@@ -192,7 +192,8 @@ namespace FakeItEasy.Specs
                 .See<ClassWithLongConstructorWhoseArgumentsCannotBeResolved>();
 
             "And its longer constructor's argument cannot be resolved"
-                .See(() => new ClassWithLongConstructorWhoseArgumentsCannotBeResolved(default(ClassWhoseDummyFactoryThrows), default(int)));
+                .See((ClassWhoseDummyFactoryThrows thrower, int i) =>
+                    new ClassWithLongConstructorWhoseArgumentsCannotBeResolved(thrower, i));
 
             "When a dummy of that type is requested"
                 .x(() => dummy = this.CreateDummy<ClassWithLongConstructorWhoseArgumentsCannotBeResolved>());
@@ -212,7 +213,8 @@ namespace FakeItEasy.Specs
                 .See<SealedClassWithLongConstructorWhoseArgumentsCannotBeResolved>();
 
             "And its longer constructor's argument cannot be resolved"
-                .See(() => new SealedClassWithLongConstructorWhoseArgumentsCannotBeResolved(default(ClassWhoseDummyFactoryThrows), default(int)));
+                .See((ClassWhoseDummyFactoryThrows thrower, int i) =>
+                    new SealedClassWithLongConstructorWhoseArgumentsCannotBeResolved(thrower, i));
 
             "When a dummy of that type is requested"
                 .x(() => dummy = this.CreateDummy<SealedClassWithLongConstructorWhoseArgumentsCannotBeResolved>());
@@ -406,7 +408,8 @@ namespace FakeItEasy.Specs
                 .See(() => new ClassWithLongSelfReferentialConstructor(typeof(object)));
 
             "And the class has a two-parameter constructor using its own type"
-                .See(() => new ClassWithLongSelfReferentialConstructor(typeof(object), default));
+                .See((Type type, ClassWithLongSelfReferentialConstructor selfish) =>
+                    new ClassWithLongSelfReferentialConstructor(type, selfish));
 
             "When I create a dummy of the class"
                 .x(() => dummy1 = A.Dummy<ClassWithLongSelfReferentialConstructor>());

--- a/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
@@ -532,7 +532,6 @@ namespace FakeItEasy.Specs
             {
                 var domainEvent = (DomainEvent)fake;
                 domainEvent.ID = this.nextID++;
-                domainEvent.Name = typeOfFake.Name;
             })
                 .WithAttributes(() => new ForTestAttribute())
                 .Implements(typeof(IDisposable))

--- a/tests/FakeItEasy.Specs/FakingDelegates.cs
+++ b/tests/FakeItEasy.Specs/FakingDelegates.cs
@@ -71,7 +71,7 @@ namespace FakeItEasy.Specs
                 .x(() => A.CallTo(() => fakedDelegate.Invoke(A<string>._)).Throws(expectedException = new FormatException()));
 
             "When I invoke it"
-                .x(() => exception = Record.Exception(() => fakedDelegate(null)));
+                .x(() => exception = Record.Exception(() => fakedDelegate(string.Empty)));
 
             "Then it throws the configured exception"
                 .x(() => exception.Should().BeSameAs(expectedException));
@@ -87,7 +87,7 @@ namespace FakeItEasy.Specs
                 .x(() => A.CallTo(() => fakedDelegate(A<string>._)).Returns(10));
 
             "When I invoke it without specifying the Invoke method explicitly"
-                .x(() => result = fakedDelegate(null));
+                .x(() => result = fakedDelegate(string.Empty));
 
             "Then it returns the configured value"
                 .x(() => result.Should().Be(10));
@@ -141,9 +141,11 @@ namespace FakeItEasy.Specs
             "And I configure it to set ref and out parameters"
                 .x(() =>
                 {
-                    string refString = null;
+                    string refString = string.Empty;
                     int outInt;
-                    A.CallTo(() => fake.Invoke(ref refString, out outInt)).AssignsOutAndRefParameters("fancy ref string", 5);
+                    A.CallTo(() => fake.Invoke(ref refString, out outInt))
+                        .WithAnyArguments()
+                        .AssignsOutAndRefParameters("fancy ref string", 5);
                 });
 
             "When I invoke it"

--- a/tests/FakeItEasy.Specs/MakesVirtualCallInConstructor.cs
+++ b/tests/FakeItEasy.Specs/MakesVirtualCallInConstructor.cs
@@ -25,13 +25,13 @@ namespace FakeItEasy.Specs
             this.ConstructorArgument2 = argument2;
         }
 
-        public string ConstructorArgument1 { get; }
+        public string ConstructorArgument1 { get; } = string.Empty;
 
         public int ConstructorArgument2 { get; }
 
         public Exception ExceptionFromVirtualMethodCallInConstructor { get; }
 
-        public string VirtualMethodValueDuringConstructorCall { get; }
+        public string VirtualMethodValueDuringConstructorCall { get; } = string.Empty;
 
         public virtual string VirtualMethod(string parameter)
         {

--- a/tests/FakeItEasy.Specs/StringExtensions.cs
+++ b/tests/FakeItEasy.Specs/StringExtensions.cs
@@ -40,6 +40,45 @@ namespace FakeItEasy.Specs
         }
 
         /// <summary>
+        /// Creates a step builder that can be used to refer to a method that
+        /// creates a type, such as a constructor.
+        /// Useful when we want to establish a condition without actually performing an action.
+        /// </summary>
+        /// <typeparam name="T">The type that would be constructed.</typeparam>
+        /// <typeparam name="TArg">The type of the argument.</typeparam>
+        /// <param name="text">A description of the method's relevant quality.</param>
+        /// <param name="func">
+        /// The constructor (or other method that creates an instance) to look at.
+        /// Will not be executed.
+        /// </param>
+        /// <returns>A step builder.</returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "func", Justification = "Used to indicate the method to see.")]
+        public static IStepBuilder See<TArg, T>(this string text, Func<TArg, T> func)
+        {
+            return text.x(() => { });
+        }
+
+        /// <summary>
+        /// Creates a step builder that can be used to refer to a method that
+        /// creates a type, such as a constructor.
+        /// Useful when we want to establish a condition without actually performing an action.
+        /// </summary>
+        /// <typeparam name="T">The type that would be constructed.</typeparam>
+        /// <typeparam name="TArg1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArg2">The type of the second argument.</typeparam>
+        /// <param name="text">A description of the method's relevant quality.</param>
+        /// <param name="func">
+        /// The constructor (or other method that creates an instance) to look at.
+        /// Will not be executed.
+        /// </param>
+        /// <returns>A step builder.</returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "func", Justification = "Used to indicate the method to see.")]
+        public static IStepBuilder See<TArg1, TArg2, T>(this string text, Func<TArg1, TArg2, T> func)
+        {
+            return text.x(() => { });
+        }
+
+        /// <summary>
         /// Creates a step builder that can be used to refer to a type's method.
         /// Useful when we want to establish a condition without actually performing an action.
         /// </summary>
@@ -63,6 +102,21 @@ namespace FakeItEasy.Specs
         /// <returns>A step builder.</returns>
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "action", Justification = "Used to indicate the method to see.")]
         public static IStepBuilder See<T>(this string text, Action<T> action)
+        {
+            return text.x(() => { });
+        }
+
+        /// <summary>
+        /// Creates a step builder that can be used to refer to a type's method.
+        /// Useful when we want to establish a condition without actually performing an action.
+        /// </summary>
+        /// <typeparam name="T">The type to look at.</typeparam>
+        /// <typeparam name="TArg">The type of the method argument.</typeparam>
+        /// <param name="text">A description of the method's relevant quality.</param>
+        /// <param name="action">The method to look at. Will not be executed.</param>
+        /// <returns>A step builder.</returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "action", Justification = "Used to indicate the method to see.")]
+        public static IStepBuilder See<T, TArg>(this string text, Action<T, TArg> action)
         {
             return text.x(() => { });
         }

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -384,7 +384,12 @@ namespace FakeItEasy.Specs
 
         public class MyException : Exception
         {
-            public MyException(string message, Exception inner = null)
+            public MyException(string message)
+                : base(message)
+            {
+            }
+
+            public MyException(string message, Exception inner)
                 : base(message, inner)
             {
             }
@@ -411,7 +416,7 @@ namespace FakeItEasy.Specs
             protected override MyDummy Create()
             {
                 ThrowException();
-                return default;
+                return new MyDummy();
             }
         }
 

--- a/tests/FakeItEasy.Specs/WrappingFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/WrappingFakeSpecs.cs
@@ -52,7 +52,7 @@
                 .x(() => wrapper = A.Fake<IFoo>(o => o.Wrapping(realObject)));
 
             "When a non-void method is called on the wrapper"
-                .x(() => exception = Record.Exception(() => wrapper.NonVoidMethod(null)));
+                .x(() => exception = Record.Exception(() => wrapper.NonVoidMethod("throw")));
 
             "Then the real object's method is called"
                 .x(() => realObject.NonVoidMethodCalled.Should().BeTrue());
@@ -95,7 +95,7 @@
                 .x(() => wrapper = A.Fake<IFoo>(o => o.Wrapping(realObject)));
 
             "When a void method is called on the wrapper"
-                .x(() => exception = Record.Exception(() => wrapper.VoidMethod(null)));
+                .x(() => exception = Record.Exception(() => wrapper.VoidMethod("throw")));
 
             "Then the real object's method is called"
                 .x(() => realObject.VoidMethodCalled.Should().BeTrue());
@@ -147,7 +147,7 @@
             public int NonVoidMethod(string parameter)
             {
                 this.NonVoidMethodCalled = true;
-                if (parameter == null)
+                if (parameter == "throw")
                 {
                     throw new ArgumentNullException(nameof(parameter));
                 }
@@ -158,7 +158,7 @@
             public void VoidMethod(string parameter)
             {
                 this.VoidMethodCalled = true;
-                if (parameter == null)
+                if (parameter == "throw")
                 {
                     throw new ArgumentNullException(nameof(parameter));
                 }


### PR DESCRIPTION
Supports #1613.

Reduces nullability-related warnings in the Specs from 227 to 32. The remaining ones are probably better served via changes that involve new language features, like non-nullable typeparams or the new `?` operator.