### PR TITLE
Protect out and ref parameters value producer

### DIFF
--- a/src/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/src/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -14,7 +14,6 @@ namespace FakeItEasy.Configuration
         private readonly List<WherePredicate> wherePredicates;
         private Action<IInterceptedFakeObjectCall> applicator;
         private bool wasApplicatorSet;
-        private Func<IFakeObjectCall, ICollection<object>> outAndRefParametersValueProducer;
         private bool canSetOutAndRefParametersValueProducer;
 
         protected BuildableCallRule()
@@ -37,21 +36,7 @@ namespace FakeItEasy.Configuration
         /// </summary>
         public Func<IFakeObjectCall, ICollection<object>> OutAndRefParametersValueProducer
         {
-            get
-            {
-                return this.outAndRefParametersValueProducer;
-            }
-
-            set
-            {
-                if (!this.canSetOutAndRefParametersValueProducer)
-                {
-                    throw new InvalidOperationException("How to assign out and ref parameters has already been defined for this call");
-                }
-
-                this.outAndRefParametersValueProducer = value;
-                this.canSetOutAndRefParametersValueProducer = false;
-            }
+            get; protected set;
         }
 
         /// <summary>
@@ -172,6 +157,26 @@ namespace FakeItEasy.Configuration
         }
 
         /// <summary>
+        /// Sets the delegate that will provide out and ref parameters when an applicable call is made.
+        /// May only be called once per BuildableCallRule.
+        /// <seealso cref="OutAndRefParametersValueProducer" />
+        /// </summary>
+        /// <param name="producer">The new value producer.</param>
+        /// <exception cref="System.InvalidOperationException">
+        /// Thrown when the SetOutAndRefParametersValueProducer method has previously been called.
+        /// </exception>
+        public void SetOutAndRefParametersValueProducer(Func<IFakeObjectCall, ICollection<object>> producer)
+        {
+            if (!this.canSetOutAndRefParametersValueProducer)
+            {
+                throw new InvalidOperationException("How to assign out and ref parameters has already been defined for this call");
+            }
+
+            this.OutAndRefParametersValueProducer = producer;
+            this.canSetOutAndRefParametersValueProducer = false;
+        }
+
+        /// <summary>
         /// When overridden in a derived class, returns a new instance of the same type and copies the call
         /// specification members for that type.
         /// </summary>
@@ -179,16 +184,6 @@ namespace FakeItEasy.Configuration
         protected abstract BuildableCallRule CloneCallSpecificationCore();
 
         protected abstract bool OnIsApplicableTo(IFakeObjectCall fakeObjectCall);
-
-        /// <summary>
-        /// Sets the OutAndRefParametersValueProducer directly, bypassing the public setter logic, hence allowing
-        /// it to be set again later.
-        /// </summary>
-        /// <param name="value">The new value for OutAndRefParametersValueProducer.</param>
-        protected void SetOutAndRefParametersValueProducer(Func<IFakeObjectCall, ICollection<object>> value)
-        {
-            this.outAndRefParametersValueProducer = value;
-        }
 
         private static ICollection<int> GetIndexesOfOutAndRefParameters(IInterceptedFakeObjectCall fakeObjectCall)
         {

--- a/src/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/src/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -32,14 +32,6 @@ namespace FakeItEasy.Configuration
         public virtual ICollection<Action<IFakeObjectCall>> Actions { get; }
 
         /// <summary>
-        /// Gets or sets a function that provides values to apply to output and reference variables.
-        /// </summary>
-        public Func<IFakeObjectCall, ICollection<object>> OutAndRefParametersValueProducer
-        {
-            get; protected set;
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether the base method of the fake object call should be
         /// called when the fake object call is made.
         /// </summary>
@@ -49,6 +41,14 @@ namespace FakeItEasy.Configuration
         /// Gets or sets the number of times the configured rule should be used.
         /// </summary>
         public virtual int? NumberOfTimesToCall { get; set; }
+
+        /// <summary>
+        /// Sets a function that provides values to apply to output and reference variables.
+        /// </summary>
+        protected Func<IFakeObjectCall, ICollection<object>> OutAndRefParametersValueProducer
+        {
+            private get; set;
+        }
 
         /// <summary>
         /// Writes a description of calls the rule is applicable to.

--- a/src/FakeItEasy/Configuration/RuleBuilder.cs
+++ b/src/FakeItEasy/Configuration/RuleBuilder.cs
@@ -130,7 +130,7 @@ namespace FakeItEasy.Configuration
             Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             this.AddRuleIfNeeded();
-            this.RuleBeingBuilt.OutAndRefParametersValueProducer = valueProducer;
+            this.RuleBeingBuilt.SetOutAndRefParametersValueProducer(valueProducer);
 
             return this;
         }

--- a/src/FakeItEasy/Expressions/ExpressionCallRule.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallRule.cs
@@ -20,7 +20,7 @@ namespace FakeItEasy.Expressions
             Guard.AgainstNull(expressionMatcher, nameof(expressionMatcher));
 
             this.ExpressionMatcher = expressionMatcher;
-            this.SetOutAndRefParametersValueProducer(expressionMatcher.GetOutAndRefParametersValueProducer());
+            this.OutAndRefParametersValueProducer = expressionMatcher.GetOutAndRefParametersValueProducer();
         }
 
         /// <summary>

--- a/tests/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
@@ -104,7 +104,7 @@ namespace FakeItEasy.Tests.Configuration
         public void Apply_should_set_ref_and_out_parameters_when_specified()
         {
             // Arrange
-            this.rule.OutAndRefParametersValueProducer = x => new object[] { 1, "foo" };
+            this.rule.SetOutAndRefParametersValueProducer(x => new object[] { 1, "foo" });
             this.rule.UseApplicator(x => { });
 
             var call = A.Fake<IInterceptedFakeObjectCall>();
@@ -122,7 +122,7 @@ namespace FakeItEasy.Tests.Configuration
         public void Apply_should_throw_when_OutAndRefParametersValues_length_differs_from_the_number_of_out_and_ref_parameters_in_the_call()
         {
             // Arrange
-            this.rule.OutAndRefParametersValueProducer = x => new object[] { 1, "foo", "bar" };
+            this.rule.SetOutAndRefParametersValueProducer(x => new object[] { 1, "foo", "bar" });
             this.rule.UseApplicator(x => { });
 
             var call = A.Fake<IInterceptedFakeObjectCall>();
@@ -278,9 +278,9 @@ namespace FakeItEasy.Tests.Configuration
         [Fact]
         public void OutAndRefParameterProducer_should_not_be_settable_more_than_once()
         {
-            this.rule.OutAndRefParametersValueProducer = x => Array.Empty<object>();
+            this.rule.SetOutAndRefParametersValueProducer(x => Array.Empty<object>());
 
-            var exception = Record.Exception(() => this.rule.OutAndRefParametersValueProducer = x => new object[] { "test" });
+            var exception = Record.Exception(() => this.rule.SetOutAndRefParametersValueProducer(x => new object[] { "test" }));
             exception.Should().BeAnExceptionOfType<InvalidOperationException>();
         }
 

--- a/tests/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/RuleBuilderTests.cs
@@ -194,28 +194,10 @@ namespace FakeItEasy.Tests.Configuration
         }
 
         [Fact]
-        public void AssignsOutAndRefParameters_should_set_values_to_rule()
-        {
-            this.builder.AssignsOutAndRefParameters(1, "foo");
-
-            var valueProducer = this.ruleProducedByFactory.OutAndRefParametersValueProducer;
-            valueProducer(null).Should().BeEquivalentTo(1, "foo");
-        }
-
-        [Fact]
         public void AssignsOutAndRefParametersLazily_should_be_null_guarded()
         {
             Expression<Action> call = () => this.builder.AssignsOutAndRefParametersLazily(null);
             call.Should().BeNullGuarded();
-        }
-
-        [Fact]
-        public void AssignsOutAndRefParametersLazily_should_set_values_to_rule()
-        {
-            this.builder.AssignsOutAndRefParametersLazily(call => new object[] { 1, "foo" });
-
-            var valueProducer = this.ruleProducedByFactory.OutAndRefParametersValueProducer;
-            valueProducer(null).Should().BeEquivalentTo(1, "foo");
         }
 
         [Fact]


### PR DESCRIPTION
Came out of the nullability work for #1613. I found an opportunity to remove more  nullability warnings without using the C# 8 language features. While I was looking, I noticed that the `OutAndRefParametersValueProducer` is only ever gotten from outside the class by unit tests that are covered in the specs.
I was going to remove the getter, but then we'd have a set-only property, which StyleCop would complain about.
And it seems to me that if we're going to have annoying checks and chances of failure, that code would fit better on a method than a property, so I swapped their roles.

I'll be sending another pull request to pre-reduce some nullability warnings, including the unset `OutAndRefParametersValueProducer`.