### PR TITLE
Simplify type checking in AnyCallRule

### DIFF
--- a/src/FakeItEasy/Configuration/AnyCallCallRule.cs
+++ b/src/FakeItEasy/Configuration/AnyCallCallRule.cs
@@ -6,39 +6,30 @@ namespace FakeItEasy.Configuration
     internal class AnyCallCallRule
         : BuildableCallRule
     {
-        private Func<ArgumentCollection, bool> argumentsPredicate;
-        private bool applicableToAllNonVoidReturnTypes;
-        private Type applicableToMembersWithReturnType;
-
-        public AnyCallCallRule()
-        {
-            this.argumentsPredicate = x => true;
-        }
+        private Func<ArgumentCollection, bool> argumentsPredicate = x => true;
+        private Type applicableToMembersWithReturnType = typeof(AllReturnTypes);
 
         public void MakeApplicableToMembersWithReturnType(Type type) => this.applicableToMembersWithReturnType = type;
 
-        public void MakeApplicableToAllNonVoidReturnTypes() => this.applicableToAllNonVoidReturnTypes = true;
+        public void MakeApplicableToAllNonVoidReturnTypes() => this.applicableToMembersWithReturnType = typeof(AllNonVoidReturnTypes);
 
         public override void DescribeCallOn(IOutputWriter writer)
         {
-            if (this.applicableToMembersWithReturnType is object)
-            {
-                if (this.applicableToMembersWithReturnType == typeof(void))
-                {
-                    writer.Write("Any call with void return type to the fake object.");
-                }
-                else
-                {
-                    writer.Write("Any call with return type ").Write(this.applicableToMembersWithReturnType).Write(" to the fake object.");
-                }
-            }
-            else if (this.applicableToAllNonVoidReturnTypes)
+            if (this.applicableToMembersWithReturnType == typeof(AllNonVoidReturnTypes))
             {
                 writer.Write("Any call with non-void return type to the fake object.");
             }
-            else
+            else if (this.applicableToMembersWithReturnType == typeof(void))
+            {
+                writer.Write("Any call with void return type to the fake object.");
+            }
+            else if (this.applicableToMembersWithReturnType == typeof(AllReturnTypes))
             {
                 writer.Write("Any call made to the fake object.");
+            }
+            else
+            {
+                writer.Write("Any call with return type ").Write(this.applicableToMembersWithReturnType).Write(" to the fake object.");
             }
         }
 
@@ -61,17 +52,17 @@ namespace FakeItEasy.Configuration
                 throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Arguments predicate"), ex);
             }
 
-            if (this.applicableToMembersWithReturnType is object)
+            if (this.applicableToMembersWithReturnType == typeof(AllReturnTypes))
             {
-                return this.applicableToMembersWithReturnType == fakeObjectCall.Method.ReturnType;
+                return true;
             }
 
-            if (this.applicableToAllNonVoidReturnTypes)
+            if (this.applicableToMembersWithReturnType == typeof(AllNonVoidReturnTypes))
             {
                 return fakeObjectCall.Method.ReturnType != typeof(void);
             }
 
-            return true;
+            return this.applicableToMembersWithReturnType == fakeObjectCall.Method.ReturnType;
         }
 
         protected override BuildableCallRule CloneCallSpecificationCore() =>
@@ -79,5 +70,13 @@ namespace FakeItEasy.Configuration
             {
                 argumentsPredicate = this.argumentsPredicate
             };
+
+        private class AllNonVoidReturnTypes
+        {
+        }
+
+        private class AllReturnTypes
+        {
+        }
     }
 }

--- a/src/FakeItEasy/Configuration/AnyCallCallRule.cs
+++ b/src/FakeItEasy/Configuration/AnyCallCallRule.cs
@@ -7,6 +7,7 @@ namespace FakeItEasy.Configuration
         : BuildableCallRule
     {
         private Func<ArgumentCollection, bool> argumentsPredicate;
+        private bool applicableToAllNonVoidReturnTypes;
 
         public AnyCallCallRule()
         {
@@ -15,7 +16,7 @@ namespace FakeItEasy.Configuration
 
         public Type ApplicableToMembersWithReturnType { get; set; }
 
-        public bool ApplicableToAllNonVoidReturnTypes { get; set; }
+        public void MakeApplicableToAllNonVoidReturnTypes() => this.applicableToAllNonVoidReturnTypes = true;
 
         public override void DescribeCallOn(IOutputWriter writer)
         {
@@ -30,7 +31,7 @@ namespace FakeItEasy.Configuration
                     writer.Write("Any call with return type ").Write(this.ApplicableToMembersWithReturnType).Write(" to the fake object.");
                 }
             }
-            else if (this.ApplicableToAllNonVoidReturnTypes)
+            else if (this.applicableToAllNonVoidReturnTypes)
             {
                 writer.Write("Any call with non-void return type to the fake object.");
             }
@@ -64,7 +65,7 @@ namespace FakeItEasy.Configuration
                 return this.ApplicableToMembersWithReturnType == fakeObjectCall.Method.ReturnType;
             }
 
-            if (this.ApplicableToAllNonVoidReturnTypes)
+            if (this.applicableToAllNonVoidReturnTypes)
             {
                 return fakeObjectCall.Method.ReturnType != typeof(void);
             }

--- a/src/FakeItEasy/Configuration/AnyCallCallRule.cs
+++ b/src/FakeItEasy/Configuration/AnyCallCallRule.cs
@@ -8,27 +8,28 @@ namespace FakeItEasy.Configuration
     {
         private Func<ArgumentCollection, bool> argumentsPredicate;
         private bool applicableToAllNonVoidReturnTypes;
+        private Type applicableToMembersWithReturnType;
 
         public AnyCallCallRule()
         {
             this.argumentsPredicate = x => true;
         }
 
-        public Type ApplicableToMembersWithReturnType { get; set; }
+        public void MakeApplicableToMembersWithReturnType(Type type) => this.applicableToMembersWithReturnType = type;
 
         public void MakeApplicableToAllNonVoidReturnTypes() => this.applicableToAllNonVoidReturnTypes = true;
 
         public override void DescribeCallOn(IOutputWriter writer)
         {
-            if (this.ApplicableToMembersWithReturnType is object)
+            if (this.applicableToMembersWithReturnType is object)
             {
-                if (this.ApplicableToMembersWithReturnType == typeof(void))
+                if (this.applicableToMembersWithReturnType == typeof(void))
                 {
                     writer.Write("Any call with void return type to the fake object.");
                 }
                 else
                 {
-                    writer.Write("Any call with return type ").Write(this.ApplicableToMembersWithReturnType).Write(" to the fake object.");
+                    writer.Write("Any call with return type ").Write(this.applicableToMembersWithReturnType).Write(" to the fake object.");
                 }
             }
             else if (this.applicableToAllNonVoidReturnTypes)
@@ -60,9 +61,9 @@ namespace FakeItEasy.Configuration
                 throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Arguments predicate"), ex);
             }
 
-            if (this.ApplicableToMembersWithReturnType is object)
+            if (this.applicableToMembersWithReturnType is object)
             {
-                return this.ApplicableToMembersWithReturnType == fakeObjectCall.Method.ReturnType;
+                return this.applicableToMembersWithReturnType == fakeObjectCall.Method.ReturnType;
             }
 
             if (this.applicableToAllNonVoidReturnTypes)

--- a/src/FakeItEasy/Configuration/AnyCallConfiguration.cs
+++ b/src/FakeItEasy/Configuration/AnyCallConfiguration.cs
@@ -30,7 +30,7 @@ namespace FakeItEasy.Configuration
 
         public IAnyCallConfigurationWithReturnTypeSpecified<object> WithNonVoidReturnType()
         {
-            this.configuredRule.ApplicableToAllNonVoidReturnTypes = true;
+            this.configuredRule.MakeApplicableToAllNonVoidReturnTypes();
             return this.configurationFactory.CreateConfiguration<object>(this.manager, this.configuredRule);
         }
 

--- a/src/FakeItEasy/Configuration/AnyCallConfiguration.cs
+++ b/src/FakeItEasy/Configuration/AnyCallConfiguration.cs
@@ -24,7 +24,7 @@ namespace FakeItEasy.Configuration
 
         public IAnyCallConfigurationWithReturnTypeSpecified<TMember> WithReturnType<TMember>()
         {
-            this.configuredRule.ApplicableToMembersWithReturnType = typeof(TMember);
+            this.configuredRule.MakeApplicableToMembersWithReturnType(typeof(TMember));
             return this.configurationFactory.CreateConfiguration<TMember>(this.manager, this.configuredRule);
         }
 
@@ -36,7 +36,7 @@ namespace FakeItEasy.Configuration
 
         public IAnyCallConfigurationWithVoidReturnType WithVoidReturnType()
         {
-            this.configuredRule.ApplicableToMembersWithReturnType = typeof(void);
+            this.configuredRule.MakeApplicableToMembersWithReturnType(typeof(void));
             return this.configurationFactory.CreateConfiguration(this.manager, this.configuredRule);
         }
 

--- a/tests/FakeItEasy.Tests/Configuration/AnyCallConfigurationTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/AnyCallConfigurationTests.cs
@@ -47,30 +47,6 @@ namespace FakeItEasy.Tests.Configuration
         }
 
         [Fact]
-        public void WithReturnType_should_set_the_type_to_the_configured_rule()
-        {
-            // Arrange
-
-            // Act
-            this.configuration.WithReturnType<string>();
-
-            // Assert
-            this.callRule.ApplicableToMembersWithReturnType.Should().Be(typeof(string));
-        }
-
-        [Fact]
-        public void WithVoidReturnType_should_set_the_type_to_the_configured_rule()
-        {
-            // Arrange
-
-            // Act
-            this.configuration.WithVoidReturnType();
-
-            // Assert
-            this.callRule.ApplicableToMembersWithReturnType.Should().Be(typeof(void));
-        }
-
-        [Fact]
         public void DoesNothing_delegates_to_configuration_produced_by_factory()
         {
             // Arrange

--- a/tests/FakeItEasy.Tests/Configuration/AnyCallConfigurationTests.cs
+++ b/tests/FakeItEasy.Tests/Configuration/AnyCallConfigurationTests.cs
@@ -59,18 +59,6 @@ namespace FakeItEasy.Tests.Configuration
         }
 
         [Fact]
-        public void WithNonVoidReturnType_should_cause_the_call_rule_to_apply_to_all_return_types()
-        {
-            // Arrange
-
-            // Act
-            this.configuration.WithNonVoidReturnType();
-
-            // Assert
-            this.callRule.ApplicableToAllNonVoidReturnTypes.Should().BeTrue();
-        }
-
-        [Fact]
         public void WithVoidReturnType_should_set_the_type_to_the_configured_rule()
         {
             // Arrange


### PR DESCRIPTION
Again, found while I was investigating #1613.
We have some properties that don't need to be exposed (and duplicated tests). Removing them and simplifying the implementation will eventually avoid some nullability warnings, since `applicableToMembersWithReturnType` will never be null now.