### PR TITLE
Limit typeparams for Fake options and builder classes

### DIFF
--- a/src/FakeItEasy/Creation/FakeAndDummyManager.cs
+++ b/src/FakeItEasy/Creation/FakeAndDummyManager.cs
@@ -59,7 +59,7 @@ namespace FakeItEasy.Creation
             return false;
         }
 
-        private static IFakeOptions CreateFakeOptions<T>(ProxyOptions proxyOptions) => new FakeOptions<T>(proxyOptions);
+        private static IFakeOptions CreateFakeOptions<T>(ProxyOptions proxyOptions) where T : class => new FakeOptions<T>(proxyOptions);
 
         private static Func<ProxyOptions, IFakeOptions> GetFakeOptionsFactory(Type typeOfFake)
         {

--- a/src/FakeItEasy/Creation/FakeOptions.cs
+++ b/src/FakeItEasy/Creation/FakeOptions.cs
@@ -6,7 +6,7 @@ namespace FakeItEasy.Creation
     using System.Linq.Expressions;
     using FakeItEasy.Core;
 
-    internal class FakeOptions<T> : IFakeOptions<T>, IFakeOptions
+    internal class FakeOptions<T> : IFakeOptions<T>, IFakeOptions where T : class
     {
         private readonly ProxyOptions proxyOptions;
 

--- a/src/FakeItEasy/Creation/IFakeOptions.of.T.cs
+++ b/src/FakeItEasy/Creation/IFakeOptions.of.T.cs
@@ -9,7 +9,7 @@ namespace FakeItEasy.Creation
     /// Provides options for generating fake object.
     /// </summary>
     /// <typeparam name="T">The type of fake object generated.</typeparam>
-    public interface IFakeOptions<T> : IHideObjectMembers
+    public interface IFakeOptions<T> : IHideObjectMembers where T : class
     {
         /// <summary>
         /// Specifies arguments for the constructor of the faked class.

--- a/src/FakeItEasy/FakeOptionsBuilder.cs
+++ b/src/FakeItEasy/FakeOptionsBuilder.cs
@@ -8,7 +8,7 @@ namespace FakeItEasy
     /// A base implementation for classes that can build options for fakes of type <typeparamref name="TFake"/>.
     /// </summary>
     /// <typeparam name="TFake">The type of fake.</typeparam>
-    public abstract class FakeOptionsBuilder<TFake> : IFakeOptionsBuilder
+    public abstract class FakeOptionsBuilder<TFake> : IFakeOptionsBuilder where TFake : class
     {
         /// <summary>
         /// Gets the priority of the options builder. When multiple builders that apply to

--- a/src/FakeItEasy/FakeOptionsExtensions.cs
+++ b/src/FakeItEasy/FakeOptionsExtensions.cs
@@ -15,7 +15,7 @@ namespace FakeItEasy
         /// <typeparam name="T">The type of fake object.</typeparam>
         /// <param name="options">Options used to create the fake object.</param>
         /// <returns>An options object.</returns>
-        public static IFakeOptions<T> Strict<T>(this IFakeOptions<T> options)
+        public static IFakeOptions<T> Strict<T>(this IFakeOptions<T> options) where T : class
         {
             Guard.AgainstNull(options, nameof(options));
 
@@ -49,7 +49,7 @@ namespace FakeItEasy
         /// <typeparam name="T">The type of fake object.</typeparam>
         /// <param name="options">Options used to create the fake object.</param>
         /// <returns>An options object.</returns>
-        public static IFakeOptions<T> CallsBaseMethods<T>(this IFakeOptions<T> options)
+        public static IFakeOptions<T> CallsBaseMethods<T>(this IFakeOptions<T> options) where T : class
         {
             Guard.AgainstNull(options, nameof(options));
 

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net40.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net40.approved.txt
@@ -180,6 +180,7 @@ namespace FakeItEasy
         public static T GetArgument<T>(this FakeItEasy.Core.IFakeObjectCall call, string argumentName) { }
     }
     public abstract class FakeOptionsBuilder<TFake> : FakeItEasy.IFakeOptionsBuilder
+        where TFake :  class
     {
         protected FakeOptionsBuilder() { }
         public virtual FakeItEasy.Priority Priority { get; }
@@ -187,9 +188,11 @@ namespace FakeItEasy
     }
     public class static FakeOptionsExtensions
     {
-        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions CallsBaseMethods(this FakeItEasy.Creation.IFakeOptions options) { }
-        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions Strict(this FakeItEasy.Creation.IFakeOptions options) { }
     }
     public class Fake<T> : FakeItEasy.IHideObjectMembers
@@ -558,6 +561,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions Wrapping(object wrappedInstance);
     }
     public interface IFakeOptions<T> : FakeItEasy.IHideObjectMembers
+        where T :  class
     {
         FakeItEasy.Creation.IFakeOptions<T> ConfigureFake(System.Action<T> action);
         FakeItEasy.Creation.IFakeOptions<T> Implements(System.Type interfaceType);

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
@@ -180,6 +180,7 @@ namespace FakeItEasy
         public static T GetArgument<T>(this FakeItEasy.Core.IFakeObjectCall call, string argumentName) { }
     }
     public abstract class FakeOptionsBuilder<TFake> : FakeItEasy.IFakeOptionsBuilder
+        where TFake :  class
     {
         protected FakeOptionsBuilder() { }
         public virtual FakeItEasy.Priority Priority { get; }
@@ -187,9 +188,11 @@ namespace FakeItEasy
     }
     public class static FakeOptionsExtensions
     {
-        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions CallsBaseMethods(this FakeItEasy.Creation.IFakeOptions options) { }
-        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions Strict(this FakeItEasy.Creation.IFakeOptions options) { }
     }
     public class Fake<T> : FakeItEasy.IHideObjectMembers
@@ -555,6 +558,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions Wrapping(object wrappedInstance);
     }
     public interface IFakeOptions<T> : FakeItEasy.IHideObjectMembers
+        where T :  class
     {
         FakeItEasy.Creation.IFakeOptions<T> ConfigureFake(System.Action<T> action);
         FakeItEasy.Creation.IFakeOptions<T> Implements(System.Type interfaceType);

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard1.6.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard1.6.approved.txt
@@ -180,6 +180,7 @@ namespace FakeItEasy
         public static T GetArgument<T>(this FakeItEasy.Core.IFakeObjectCall call, string argumentName) { }
     }
     public abstract class FakeOptionsBuilder<TFake> : FakeItEasy.IFakeOptionsBuilder
+        where TFake :  class
     {
         protected FakeOptionsBuilder() { }
         public virtual FakeItEasy.Priority Priority { get; }
@@ -187,9 +188,11 @@ namespace FakeItEasy
     }
     public class static FakeOptionsExtensions
     {
-        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions CallsBaseMethods(this FakeItEasy.Creation.IFakeOptions options) { }
-        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions Strict(this FakeItEasy.Creation.IFakeOptions options) { }
     }
     public class Fake<T> : FakeItEasy.IHideObjectMembers
@@ -555,6 +558,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions Wrapping(object wrappedInstance);
     }
     public interface IFakeOptions<T> : FakeItEasy.IHideObjectMembers
+        where T :  class
     {
         FakeItEasy.Creation.IFakeOptions<T> ConfigureFake(System.Action<T> action);
         FakeItEasy.Creation.IFakeOptions<T> Implements(System.Type interfaceType);

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
@@ -180,6 +180,7 @@ namespace FakeItEasy
         public static T GetArgument<T>(this FakeItEasy.Core.IFakeObjectCall call, string argumentName) { }
     }
     public abstract class FakeOptionsBuilder<TFake> : FakeItEasy.IFakeOptionsBuilder
+        where TFake :  class
     {
         protected FakeOptionsBuilder() { }
         public virtual FakeItEasy.Priority Priority { get; }
@@ -187,9 +188,11 @@ namespace FakeItEasy
     }
     public class static FakeOptionsExtensions
     {
-        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions CallsBaseMethods(this FakeItEasy.Creation.IFakeOptions options) { }
-        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions Strict(this FakeItEasy.Creation.IFakeOptions options) { }
     }
     public class Fake<T> : FakeItEasy.IHideObjectMembers
@@ -555,6 +558,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions Wrapping(object wrappedInstance);
     }
     public interface IFakeOptions<T> : FakeItEasy.IHideObjectMembers
+        where T :  class
     {
         FakeItEasy.Creation.IFakeOptions<T> ConfigureFake(System.Action<T> action);
         FakeItEasy.Creation.IFakeOptions<T> Implements(System.Type interfaceType);

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
@@ -180,6 +180,7 @@ namespace FakeItEasy
         public static T GetArgument<T>(this FakeItEasy.Core.IFakeObjectCall call, string argumentName) { }
     }
     public abstract class FakeOptionsBuilder<TFake> : FakeItEasy.IFakeOptionsBuilder
+        where TFake :  class
     {
         protected FakeOptionsBuilder() { }
         public virtual FakeItEasy.Priority Priority { get; }
@@ -187,9 +188,11 @@ namespace FakeItEasy
     }
     public class static FakeOptionsExtensions
     {
-        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> CallsBaseMethods<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions CallsBaseMethods(this FakeItEasy.Creation.IFakeOptions options) { }
-        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options) { }
+        public static FakeItEasy.Creation.IFakeOptions<T> Strict<T>(this FakeItEasy.Creation.IFakeOptions<T> options)
+            where T :  class { }
         public static FakeItEasy.Creation.IFakeOptions Strict(this FakeItEasy.Creation.IFakeOptions options) { }
     }
     public class Fake<T> : FakeItEasy.IHideObjectMembers
@@ -594,6 +597,7 @@ namespace FakeItEasy.Creation
         FakeItEasy.Creation.IFakeOptions Wrapping(object wrappedInstance);
     }
     public interface IFakeOptions<T> : FakeItEasy.IHideObjectMembers
+        where T :  class
     {
         FakeItEasy.Creation.IFakeOptions<T> ConfigureFake(System.Action<T> action);
         FakeItEasy.Creation.IFakeOptions<T> Implements(System.Type interfaceType);


### PR DESCRIPTION
Could've been done as part of #1465, but I didn't think of it.
In addition to just providing a better view for the public API, this change removes 6 nullability warnings:

```
Creation\FakeOptions.cs(20,68): warning CS8604: Possible null reference argument for parameter 'obj' in 'void Action<object>.Invoke(object obj)'. 
Creation\FakeOptions.cs(84,31): warning CS8604: Possible null reference argument for parameter 'argument' in 'void Guard.AgainstNull(object argument, string argumentName)'. 
Creation\FakeOptions.cs(85,60): warning CS8604: Possible null reference argument for parameter 'fakedObject' in 'void FakeOptions<T>.ConfigureFakeToWrap(object fakedObject, object wrappedObject)'. 
Creation\FakeOptions.cs(85,66): warning CS8604: Possible null reference argument for parameter 'wrappedObject' in 'void FakeOptions<T>.ConfigureFakeToWrap(object fakedObject, object wrappedObject)'. 
FakeOptionsExtensions.cs(24,51): warning CS8604: Possible null reference argument for parameter 'fakedObject' in 'FakeManager Fake.GetFakeManager(object fakedObject)'. 
FakeOptionsExtensions.cs(56,59): warning CS8604: Possible null reference argument for parameter 'fake' in 'IAnyCallConfigurationWithNoReturnTypeSpecified A.CallTo(object fake)'. 
```