### PR TITLE
Add and remove null parameter checks

### DIFF
--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -77,6 +77,9 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static string Contains(this IArgumentConstraintManager<string> manager, string value)
         {
+            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(value, nameof(value));
+
 #if FEATURE_STRING_CONTAINS_COMPARISONTYPE
             return manager.NullCheckedMatches(x => x.Contains(value, StringComparison.CurrentCulture), x => x.Write("string that contains ").WriteArgumentValue(value));
 #else
@@ -93,6 +96,9 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T Contains<T>(this IArgumentConstraintManager<T> manager, object value) where T : IEnumerable
         {
+            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(value, nameof(value));
+
             return manager.NullCheckedMatches(
                 x => x.Cast<object>().Contains(value),
                 x => x.Write("sequence that contains the value ").WriteArgumentValue(value));
@@ -106,6 +112,9 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static string StartsWith(this IArgumentConstraintManager<string> manager, string value)
         {
+            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(value, nameof(value));
+
             return manager.NullCheckedMatches(x => x.StartsWith(value, StringComparison.Ordinal), x => x.Write("string that starts with ").WriteArgumentValue(value));
         }
 
@@ -117,6 +126,9 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static string EndsWith(this IArgumentConstraintManager<string> manager, string value)
         {
+            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(value, nameof(value));
+
             return manager.NullCheckedMatches(x => x.EndsWith(value, StringComparison.Ordinal), x => x.Write("string that ends with ").WriteArgumentValue(value));
         }
 
@@ -127,6 +139,8 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static string IsNullOrEmpty(this IArgumentConstraintManager<string> manager)
         {
+            Guard.AgainstNull(manager, nameof(manager));
+
             return manager.Matches(x => string.IsNullOrEmpty(x), "NULL or string.Empty");
         }
 
@@ -154,6 +168,9 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsSameSequenceAs<T>(this IArgumentConstraintManager<T> manager, IEnumerable values) where T : IEnumerable
         {
+            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(values, nameof(values));
+
             var list = values.AsList();
             return manager.NullCheckedMatches(
                 x => x.Cast<object>().SequenceEqual(list),
@@ -170,6 +187,9 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsSameSequenceAs<T>(this IArgumentConstraintManager<T> manager, params object[] values) where T : IEnumerable
         {
+            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(values, nameof(values));
+
             return manager.IsSameSequenceAs((IEnumerable)values);
         }
 
@@ -181,6 +201,8 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsEmpty<T>(this IArgumentConstraintManager<T> manager) where T : IEnumerable
         {
+            Guard.AgainstNull(manager, nameof(manager));
+
             return manager.NullCheckedMatches(
                 x => !x.Cast<object>().Any(),
                 x => x.Write("empty collection"));
@@ -227,6 +249,9 @@ namespace FakeItEasy
         /// <returns>A dummy value.</returns>
         public static T IsInstanceOf<T>(this IArgumentConstraintManager<T> manager, Type type)
         {
+            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(type, nameof(type));
+
             return manager.Matches(x => x is object && type.IsAssignableFrom(x.GetType()), description => description.Write("Instance of ").Write(type.ToString()));
         }
 
@@ -251,6 +276,8 @@ namespace FakeItEasy
         public static T Matches<T>(this IArgumentConstraintManager<T> scope, Func<T, bool> predicate, string description)
         {
             Guard.AgainstNull(scope, nameof(scope));
+            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(description, nameof(description));
 
             return scope.Matches(predicate, x => x.Write(description));
         }
@@ -279,6 +306,9 @@ namespace FakeItEasy
         public static T Matches<T>(this IArgumentConstraintManager<T> manager, Func<T, bool> predicate, string descriptionFormat, params object[] args)
         {
             Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(descriptionFormat, nameof(descriptionFormat));
+            Guard.AgainstNull(args, nameof(args));
 
             return manager.Matches(predicate, x => x.Write(descriptionFormat, args));
         }
@@ -301,6 +331,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Appropriate for Linq expressions.")]
         public static T Matches<T>(this IArgumentConstraintManager<T> scope, Expression<Func<T, bool>> predicate)
         {
+            Guard.AgainstNull(scope, nameof(scope));
             Guard.AgainstNull(predicate, nameof(predicate));
 
             return scope.Matches(predicate.Compile(), predicate.ToString());
@@ -319,6 +350,8 @@ namespace FakeItEasy
         public static T NullCheckedMatches<T>(this IArgumentConstraintManager<T> manager, Func<T, bool> predicate, Action<IOutputWriter> descriptionWriter)
         {
             Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(descriptionWriter, nameof(descriptionWriter));
 
             return manager.Matches(
                 x => x is object && predicate(x),

--- a/src/FakeItEasy/CallbackConfigurationExtensions.cs
+++ b/src/FakeItEasy/CallbackConfigurationExtensions.cs
@@ -24,6 +24,7 @@ namespace FakeItEasy
         public static TInterface Invokes<TInterface>(this ICallbackConfiguration<TInterface> configuration, Action actionToInvoke)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
 
             return configuration.Invokes(call => actionToInvoke());
         }

--- a/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
@@ -25,6 +25,9 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "The compiler would not be able to figure out the type.")]
         public static IEnumerable<ICompletedFakeObjectCall> Matching<TFake>(this IEnumerable<ICompletedFakeObjectCall> calls, Expression<Action<TFake>> callSpecification)
         {
+            Guard.AgainstNull(calls, nameof(calls));
+            Guard.AgainstNull(callSpecification, nameof(callSpecification));
+
             var factory = ServiceLocator.Resolve<IExpressionCallMatcherFactory>();
             var callExpressionParser = ServiceLocator.Resolve<ICallExpressionParser>();
             var matcher = factory.CreateCallMatcher(callExpressionParser.Parse(callSpecification));

--- a/src/FakeItEasy/Configuration/ArgumentCollection.cs
+++ b/src/FakeItEasy/Configuration/ArgumentCollection.cs
@@ -106,8 +106,9 @@ namespace FakeItEasy.Configuration
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Used to cast the argument to the specified type.")]
         public T Get<T>(string argumentName)
         {
-            var index = this.GetArgumentIndex(argumentName);
+            Guard.AgainstNull(argumentName, nameof(argumentName));
 
+            var index = this.GetArgumentIndex(argumentName);
             return (T)this.arguments[index];
         }
 

--- a/src/FakeItEasy/Configuration/PropertySetterConfiguration.cs
+++ b/src/FakeItEasy/Configuration/PropertySetterConfiguration.cs
@@ -26,6 +26,8 @@ namespace FakeItEasy.Configuration
 
         public IPropertySetterConfiguration To(Expression<Func<TValue>> valueConstraint)
         {
+            Guard.AgainstNull(valueConstraint, nameof(valueConstraint));
+
             var newSetterExpression = this.CreateSetterExpressionWithNewValue(valueConstraint);
             var voidArgumentValidationConfiguration = this.CreateArgumentValidationConfiguration(newSetterExpression);
             return AsPropertySetterConfiguration(voidArgumentValidationConfiguration);

--- a/src/FakeItEasy/Configuration/RuleBuilder.cs
+++ b/src/FakeItEasy/Configuration/RuleBuilder.cs
@@ -68,6 +68,8 @@ namespace FakeItEasy.Configuration
 
         public virtual IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws(Func<IFakeObjectCall, Exception> exceptionFactory)
         {
+            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+
             this.AddRuleIfNeeded();
             this.RuleBeingBuilt.UseApplicator(call => throw exceptionFactory(call));
             return this;
@@ -94,6 +96,7 @@ namespace FakeItEasy.Configuration
         public virtual IVoidConfiguration Invokes(Action<IFakeObjectCall> action)
         {
             Guard.AgainstNull(action, nameof(action));
+
             this.AddRuleIfNeeded();
             this.RuleBeingBuilt.Actions.Add(action);
             return this;
@@ -138,6 +141,9 @@ namespace FakeItEasy.Configuration
 
         public IAnyCallConfigurationWithVoidReturnType Where(Func<IFakeObjectCall, bool> predicate, Action<IOutputWriter> descriptionWriter)
         {
+            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(descriptionWriter, nameof(descriptionWriter));
+
             this.RuleBeingBuilt.ApplyWherePredicate(predicate, descriptionWriter);
             return this;
         }
@@ -199,6 +205,7 @@ namespace FakeItEasy.Configuration
             public IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TMember>> ReturnsLazily(Func<IFakeObjectCall, TMember> valueProducer)
             {
                 Guard.AgainstNull(valueProducer, nameof(valueProducer));
+
                 this.ParentConfiguration.AddRuleIfNeeded();
                 this.ParentConfiguration.RuleBeingBuilt.UseApplicator(call => call.SetReturnValue(valueProducer(call)));
                 return this;
@@ -222,22 +229,17 @@ namespace FakeItEasy.Configuration
                 return this;
             }
 
-            public UnorderedCallAssertion MustHaveHappened(int numberOfTimes, Times timesOption)
-            {
-                Guard.AgainstNull(timesOption, nameof(timesOption));
+            public UnorderedCallAssertion MustHaveHappened(int numberOfTimes, Times timesOption) =>
+                this.ParentConfiguration.MustHaveHappened(numberOfTimes, timesOption);
 
-                return this.ParentConfiguration.MustHaveHappened(numberOfTimes, timesOption);
-            }
-
-            public UnorderedCallAssertion MustHaveHappenedANumberOfTimesMatching(Expression<Func<int, bool>> predicate)
-            {
-                Guard.AgainstNull(predicate, nameof(predicate));
-
-                return this.ParentConfiguration.MustHaveHappenedANumberOfTimesMatching(predicate);
-            }
+            public UnorderedCallAssertion MustHaveHappenedANumberOfTimesMatching(Expression<Func<int, bool>> predicate) =>
+                this.ParentConfiguration.MustHaveHappenedANumberOfTimesMatching(predicate);
 
             public IAnyCallConfigurationWithReturnTypeSpecified<TMember> Where(Func<IFakeObjectCall, bool> predicate, Action<IOutputWriter> descriptionWriter)
             {
+                Guard.AgainstNull(predicate, nameof(predicate));
+                Guard.AgainstNull(descriptionWriter, nameof(descriptionWriter));
+
                 this.ParentConfiguration.RuleBeingBuilt.ApplyWherePredicate(predicate, descriptionWriter);
                 return this;
             }

--- a/src/FakeItEasy/Configuration/UnorderedCallAssertion.cs
+++ b/src/FakeItEasy/Configuration/UnorderedCallAssertion.cs
@@ -29,6 +29,8 @@ namespace FakeItEasy.Configuration
         /// <exception cref="ExpectationException">The call was not made in the expected order.</exception>
         public IOrderableCallAssertion Then(UnorderedCallAssertion nextAssertion)
         {
+            Guard.AgainstNull(nextAssertion, nameof(nextAssertion));
+
             var context = ServiceLocator.Resolve<SequentialCallContext.Factory>().Invoke();
             this.CheckCallHappenedInOrder(context);
             return new OrderedCallAssertion(context).Then(nextAssertion);
@@ -51,6 +53,7 @@ namespace FakeItEasy.Configuration
             public IOrderableCallAssertion Then(UnorderedCallAssertion nextAssertion)
             {
                 Guard.AgainstNull(nextAssertion, nameof(nextAssertion));
+
                 nextAssertion.CheckCallHappenedInOrder(this.context);
                 return this;
             }

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -109,6 +109,8 @@ namespace FakeItEasy.Core
         /// <param name="rule">The rule to add.</param>
         public virtual void AddRuleFirst(IFakeObjectCallRule rule)
         {
+            Guard.AgainstNull(rule, nameof(rule));
+
             lock (this.allUserRules)
             {
                 this.allUserRules.AddFirst(CallRuleMetadata.NeverCalled(rule));
@@ -121,6 +123,8 @@ namespace FakeItEasy.Core
         /// <param name="rule">The rule to add.</param>
         public virtual void AddRuleLast(IFakeObjectCallRule rule)
         {
+            Guard.AgainstNull(rule, nameof(rule));
+
             lock (this.allUserRules)
             {
                 this.allUserRules.AddLast(CallRuleMetadata.NeverCalled(rule));
@@ -148,6 +152,8 @@ namespace FakeItEasy.Core
         /// <param name="listener">The listener to add.</param>
         public void AddInterceptionListener(IInterceptionListener listener)
         {
+            Guard.AgainstNull(listener, nameof(listener));
+
             this.interceptionListeners.AddFirst(listener);
         }
 

--- a/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
+++ b/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
@@ -52,6 +52,8 @@ namespace FakeItEasy.Core
         [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates", Justification = "Provides the event raising syntax.")]
         public static implicit operator EventHandler<TEventArgs>(Raise<TEventArgs> raiser)
         {
+            Guard.AgainstNull(raiser, nameof(raiser));
+
             return raiser.Now;
         }
 
@@ -63,6 +65,8 @@ namespace FakeItEasy.Core
         [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates", Justification = "Provides the event raising syntax.")]
         public static implicit operator EventHandler(Raise<TEventArgs> raiser)
         {
+            Guard.AgainstNull(raiser, nameof(raiser));
+
             return raiser.Now;
         }
 

--- a/src/FakeItEasy/Creation/FakeOptions.cs
+++ b/src/FakeItEasy/Creation/FakeOptions.cs
@@ -17,6 +17,8 @@ namespace FakeItEasy.Creation
 
         IFakeOptions IFakeOptions.ConfigureFake(Action<object> action)
         {
+            Guard.AgainstNull(action, nameof(action));
+
             return (IFakeOptions)this.ConfigureFake(fake => action(fake));
         }
 
@@ -47,11 +49,15 @@ namespace FakeItEasy.Creation
 
         public IFakeOptions<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
         {
+            Guard.AgainstNull(constructorCall, nameof(constructorCall));
+
             return this.WithArgumentsForConstructor(GetConstructorArgumentsFromExpression(constructorCall));
         }
 
         IFakeOptions IFakeOptions.WithArgumentsForConstructor<TConstructor>(Expression<Func<TConstructor>> constructorCall)
         {
+            Guard.AgainstNull(constructorCall, nameof(constructorCall));
+
             return (IFakeOptions)this.WithArgumentsForConstructor(GetConstructorArgumentsFromExpression(constructorCall));
         }
 
@@ -62,6 +68,8 @@ namespace FakeItEasy.Creation
 
         public IFakeOptions<T> WithArgumentsForConstructor(IEnumerable<object> argumentsForConstructor)
         {
+            Guard.AgainstNull(argumentsForConstructor, nameof(argumentsForConstructor));
+
             this.proxyOptions.ArgumentsForConstructor = argumentsForConstructor;
             return this;
         }
@@ -82,24 +90,31 @@ namespace FakeItEasy.Creation
         public IFakeOptions<T> Wrapping(T wrappedInstance)
         {
             Guard.AgainstNull(wrappedInstance, nameof(wrappedInstance));
+
             this.ConfigureFake(fake => ConfigureFakeToWrap(fake, wrappedInstance));
             return this;
         }
 
         public IFakeOptions<T> Implements(Type interfaceType)
         {
+            Guard.AgainstNull(interfaceType, nameof(interfaceType));
+
             this.proxyOptions.AddInterfaceToImplement(interfaceType);
             return this;
         }
 
         public IFakeOptions<T> ConfigureFake(Action<T> action)
         {
+            Guard.AgainstNull(action, nameof(action));
+
             this.proxyOptions.AddProxyConfigurationAction(proxy => action((T)proxy));
             return this;
         }
 
         public IFakeOptions<T> Named(string name)
         {
+            Guard.AgainstNull(name, nameof(name));
+
             this.proxyOptions.Name = name;
             return this;
         }

--- a/src/FakeItEasy/ExceptionThrowerConfigurationExtensions.cs
+++ b/src/FakeItEasy/ExceptionThrowerConfigurationExtensions.cs
@@ -24,6 +24,7 @@ namespace FakeItEasy
         public static IAfterCallConfiguredConfiguration<TInterface> Throws<TInterface>(this IExceptionThrowerConfiguration<TInterface> configuration, Exception exception)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(exception, nameof(exception));
 
             return configuration.Throws(_ => exception);
         }
@@ -39,6 +40,7 @@ namespace FakeItEasy
         public static IAfterCallConfiguredConfiguration<TInterface> Throws<TInterface>(this IExceptionThrowerConfiguration<TInterface> configuration, Func<Exception> exceptionFactory)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
 
             return configuration.Throws(_ => exceptionFactory());
         }

--- a/src/FakeItEasy/OutputWriterExtensions.cs
+++ b/src/FakeItEasy/OutputWriterExtensions.cs
@@ -32,6 +32,8 @@ namespace FakeItEasy
         public static IOutputWriter Write(this IOutputWriter writer, string format, params object[] args)
         {
             Guard.AgainstNull(writer, nameof(writer));
+            Guard.AgainstNull(format, nameof(format));
+            Guard.AgainstNull(args, nameof(args));
 
             writer.Write(string.Format(format, args));
             return writer;

--- a/src/FakeItEasy/ReturnValueConfigurationExtensions.StronglyTyped.cs
+++ b/src/FakeItEasy/ReturnValueConfigurationExtensions.StronglyTyped.cs
@@ -34,6 +34,7 @@ namespace FakeItEasy
             ReturnsLazily<TReturnType, T1>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, TReturnType> valueProducer)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -86,6 +87,7 @@ namespace FakeItEasy
             ReturnsLazily<TReturnType, T1, T2>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, TReturnType> valueProducer)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -140,6 +142,7 @@ namespace FakeItEasy
             ReturnsLazily<TReturnType, T1, T2, T3>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, TReturnType> valueProducer)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -196,6 +199,7 @@ namespace FakeItEasy
             ReturnsLazily<TReturnType, T1, T2, T3, T4>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, TReturnType> valueProducer)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -254,6 +258,7 @@ namespace FakeItEasy
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, T5, TReturnType> valueProducer)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -314,6 +319,7 @@ namespace FakeItEasy
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, T5, T6, TReturnType> valueProducer)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -376,6 +382,7 @@ namespace FakeItEasy
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6, T7>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, T5, T6, T7, TReturnType> valueProducer)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -440,6 +447,7 @@ namespace FakeItEasy
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6, T7, T8>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturnType> valueProducer)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             return configuration.ReturnsLazily(call =>
                 {

--- a/src/FakeItEasy/ReturnValueConfigurationExtensions.StronglyTyped.tt
+++ b/src/FakeItEasy/ReturnValueConfigurationExtensions.StronglyTyped.tt
@@ -52,6 +52,7 @@ namespace FakeItEasy
             ReturnsLazily<TReturnType, <#= typeParamList #>>(this IReturnValueConfiguration<TReturnType> configuration, Func<<#= typeParamList #>, TReturnType> valueProducer)
         {
             Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(valueProducer, nameof(valueProducer));
 
             return configuration.ReturnsLazily(call =>
                 {


### PR DESCRIPTION
Some public methods that will not allow null argument values lack null checks.
Perhaps some have arguably too many.