### PR TITLE
(Re)-allow constraining arguments to be collections that contain null

### DIFF
--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -97,7 +97,6 @@ namespace FakeItEasy
         public static T Contains<T>(this IArgumentConstraintManager<T> manager, object value) where T : IEnumerable
         {
             Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(value, nameof(value));
 
             return manager.NullCheckedMatches(
                 x => x.Cast<object>().Contains(value),

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -175,6 +175,27 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
+        public static void CollectionParameterContainsNull(
+            IIHaveACollectionParameter fake,
+            Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IIHaveACollectionParameter>());
+
+            "And a call with argument [1, \"hello\", NULL, NULL, \"foo\", \"bar\"] made on this fake"
+                .x(() => fake.Bar(new object[] { 1, "hello", null, null, "foo", "bar" }));
+
+            "When I assert that a call with an argument that contains null has happened on this fake"
+                .x(() => exception = Record.Exception(
+                    () => A.CallTo(
+                            () => fake.Bar(A<object[]>.That.Contains(null)))
+                        .MustHaveHappened()));
+
+            "Then the assertion should pass"
+                .x(() => exception.Should().BeNull());
+        }
+
+        [Scenario]
         public static void FailingMatchOfCollectionParameter(
             IIHaveACollectionParameter fake,
             Exception exception)


### PR DESCRIPTION
I broke this in #1686. Fortunately, we've not released, so we can just fold the fix in. On that basis, labelling as enhancement, like the original was.