### PR TITLE
Upgrade StyleCop.Analyzers to 1.2.0-beta.113

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" PrivateAssets="all" />
     <CodeAnalysisDictionary Include="$(MSBuildThisFileDirectory)src/FakeItEasy.Dictionary.xml">
       <Link>Properties\FakeItEasy.Dictionary.xml</Link>

--- a/src/FakeItEasy/A.cs
+++ b/src/FakeItEasy/A.cs
@@ -89,7 +89,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Used to specify the type of dummy.")]
         public static T Dummy<T>()
         {
-            return (T)FakeAndDummyManager.CreateDummy(typeof(T), new LoopDetectingResolutionContext()) !;
+            return (T)FakeAndDummyManager.CreateDummy(typeof(T), new LoopDetectingResolutionContext())!;
         }
 
         /// <summary>

--- a/src/FakeItEasy/Core/FakeManager.EventRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.EventRule.cs
@@ -165,7 +165,7 @@ namespace FakeItEasy.Core
                     IFakeObjectCall fakeObjectCall)
                 {
                     // This method is only called when IsApplicableTo is true, so eventInfo will not be null.
-                    var eventInfo = GetEvent(fakeObjectCall.Method) !;
+                    var eventInfo = GetEvent(fakeObjectCall.Method)!;
 
                     return new EventCall(eventInfo, fakeObjectCall.Method, (Delegate)fakeObjectCall.Arguments[0] !);
                 }

--- a/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
+++ b/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
@@ -45,10 +45,10 @@ namespace FakeItEasy.Core
         }
 
         /// <summary>
-        /// Converts a raiser into an <see cref="EventHandler{TEventArgs}"/>
+        /// Converts a raiser into an <see cref="EventHandler{TEventArgs}"/>.
         /// </summary>
         /// <param name="raiser">The raiser to convert.</param>
-        /// <returns>The new event handler</returns>
+        /// <returns>The new event handler.</returns>
         [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates", Justification = "Provides the event raising syntax.")]
         public static implicit operator EventHandler<TEventArgs>(Raise<TEventArgs> raiser)
         {
@@ -58,10 +58,10 @@ namespace FakeItEasy.Core
         }
 
         /// <summary>
-        /// Converts a raiser into an <see cref="EventHandler"/>
+        /// Converts a raiser into an <see cref="EventHandler"/>.
         /// </summary>
         /// <param name="raiser">The raiser to convert.</param>
-        /// <returns>The new event handler</returns>
+        /// <returns>The new event handler.</returns>
         [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates", Justification = "Provides the event raising syntax.")]
         public static implicit operator EventHandler(Raise<TEventArgs> raiser)
         {

--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidator.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidator.cs
@@ -72,7 +72,7 @@
         {
             if (callTarget is object)
             {
-                return this.methodInfoManager.GetMethodOnTypeThatWillBeInvokedByMethodInfo(callTarget.GetType(), method) !;
+                return this.methodInfoManager.GetMethodOnTypeThatWillBeInvokedByMethodInfo(callTarget.GetType(), method)!;
             }
 
             return method;

--- a/src/FakeItEasy/Creation/CreationResult.cs
+++ b/src/FakeItEasy/Creation/CreationResult.cs
@@ -33,7 +33,7 @@ namespace FakeItEasy.Creation
         /// Returns a creation result for a dummy by combining two results.
         /// Successful results are preferred to failed. Failed results will have their reasons for failure aggregated.
         /// </summary>
-        /// <param name="other">The other result to merge. Must not be <code>null</code>.</param>
+        /// <param name="other">The other result to merge. Must not be <c>null</c>.</param>
         /// <returns>A combined creation result. Successful if either input was successful, and failed otherwise.</returns>
         public abstract CreationResult MergeIntoDummyResult(CreationResult other);
 

--- a/src/FakeItEasy/ExpressionExtensions.cs
+++ b/src/FakeItEasy/ExpressionExtensions.cs
@@ -14,7 +14,7 @@ namespace FakeItEasy
         /// </summary>
         /// <notes>
         /// This method evaluates an expression, but tries to do it in a light-weight way that doesn't compile it into a delegate.
-        /// It is often used to solve 'what object/value does the user-supplied Expression refer to?'
+        /// It is often used to determine what object/value the user-supplied Expression refers to.
         /// </notes>
         /// <param name="expression">The expression to be evaluated.</param>
         /// <returns>The value returned from the delegate compiled from the expression.</returns>

--- a/src/FakeItEasy/IHideObjectMembers.cs
+++ b/src/FakeItEasy/IHideObjectMembers.cs
@@ -8,7 +8,7 @@ namespace FakeItEasy
     /// Hides standard Object members to make fluent interfaces
     /// easier to read. Found in the source of Autofac: <see cref="!:https://code.google.com/p/autofac/"/>
     /// Based on blog post here:
-    /// <see cref="!:http://blogs.clariusconsulting.net/kzu/how-to-hide-system-object-members-from-your-interfaces/"/>
+    /// <see cref="!:http://blogs.clariusconsulting.net/kzu/how-to-hide-system-object-members-from-your-interfaces/"/>.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public interface IHideObjectMembers

--- a/src/FakeItEasy/Times.cs
+++ b/src/FakeItEasy/Times.cs
@@ -6,7 +6,7 @@ namespace FakeItEasy
     /// <summary>
     /// Helps define the number of times to expect a faked call to have occurred.
     /// Can be used to indicate whether the call must have occurred exactly the specified number of
-    /// times, at least the specified number of times, or at most the specified number of times
+    /// times, at least the specified number of times, or at most the specified number of times.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1623:PropertySummaryDocumentationMustMatchAccessors", Justification = "Fluent API.")]
     public abstract class Times

--- a/tests/FakeItEasy.Analyzer.Tests.Shared/Helpers/CodeFixVerifier.Helper.cs
+++ b/tests/FakeItEasy.Analyzer.Tests.Shared/Helpers/CodeFixVerifier.Helper.cs
@@ -25,7 +25,7 @@
         {
             var operations = codeAction.GetOperationsAsync(CancellationToken.None).Result;
             var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
-            return solution.GetDocument(document.Id) !;
+            return solution.GetDocument(document.Id)!;
         }
 
         /// <summary>

--- a/tests/FakeItEasy.Analyzer.Tests.Shared/Helpers/DiagnosticVerifier.Helper.cs
+++ b/tests/FakeItEasy.Analyzer.Tests.Shared/Helpers/DiagnosticVerifier.Helper.cs
@@ -205,7 +205,7 @@ namespace FakeItEasy.Analyzer.Tests.Helpers
                     count++;
                 }
 
-                return solution.GetProject(projectId) !;
+                return solution.GetProject(projectId)!;
             }
         }
 
@@ -235,7 +235,7 @@ namespace FakeItEasy.Analyzer.Tests.Helpers
         private static MetadataReference[] GetMetadataReferences()
         {
             var systemAssemblyLocation = typeof(object).Assembly.Location;
-            var coreDir = Path.GetDirectoryName(systemAssemblyLocation) !;
+            var coreDir = Path.GetDirectoryName(systemAssemblyLocation)!;
             var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 systemAssemblyLocation,

--- a/tests/FakeItEasy.IntegrationTests/ExternalAssemblyGenerator.cs
+++ b/tests/FakeItEasy.IntegrationTests/ExternalAssemblyGenerator.cs
@@ -48,7 +48,7 @@ namespace FakeItEasy.IntegrationTests
         private static IEnumerable<string> GetFrameworkAssemblyLocations()
         {
             var systemAssemblyLocation = typeof(object).GetTypeInfo().Assembly.Location;
-            var coreDir = Path.GetDirectoryName(systemAssemblyLocation) !;
+            var coreDir = Path.GetDirectoryName(systemAssemblyLocation)!;
             return new[] { "mscorlib.dll", "System.Runtime.dll" }
                 .Select(s => Path.Combine(coreDir, s))
                 .Concat(new[]

--- a/tests/FakeItEasy.Specs/DummyCreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/DummyCreationSpecs.cs
@@ -870,7 +870,7 @@ namespace FakeItEasy.Specs
     {
         protected override T CreateDummy<T>()
         {
-            return (T)Sdk.Create.Dummy(typeof(T)) !;
+            return (T)Sdk.Create.Dummy(typeof(T))!;
         }
 
         protected override IList<T> CreateCollectionOfDummy<T>(int count)

--- a/tests/FakeItEasy.Specs/DummyFactorySpecs.cs
+++ b/tests/FakeItEasy.Specs/DummyFactorySpecs.cs
@@ -73,7 +73,7 @@ namespace FakeItEasy.Specs
 
         public object Create(Type type)
         {
-            var dummy = (DomainEvent)Activator.CreateInstance(type) !;
+            var dummy = (DomainEvent)Activator.CreateInstance(type)!;
             dummy.ID = this.nextID++;
             return dummy;
         }

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -12,6 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
     <PackageReference Include="Xbehave.Core" Version="2.4.0" />

--- a/tests/FakeItEasy.Specs/stylecop.json
+++ b/tests/FakeItEasy.Specs/stylecop.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "namingRules": {
+      "includeInferredTupleElementNames": true,
+      "tupleElementNameCasing": "camelCase"
+    }
+  }
+}

--- a/tests/FakeItEasy.Tests.Approval/ApiApproval.cs
+++ b/tests/FakeItEasy.Tests.Approval/ApiApproval.cs
@@ -60,6 +60,6 @@ namespace FakeItEasy.Tests.Approval
             public string Name { get; }
         }
 
-        private static string GetSourceDirectory([CallerFilePath] string path = "") => Path.GetDirectoryName(path) !;
+        private static string GetSourceDirectory([CallerFilePath] string path = "") => Path.GetDirectoryName(path)!;
     }
 }

--- a/tests/FakeItEasy.Tests/ArgumentValidationConfigurationExtensionsTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentValidationConfigurationExtensionsTests.cs
@@ -19,7 +19,7 @@ namespace FakeItEasy.Tests
             configuration.WithAnyArguments();
 
             // Assert
-            var predicate = Fake.GetCalls(configuration).Single().Arguments.Get<Func<ArgumentCollection?, bool>>(0) !;
+            var predicate = Fake.GetCalls(configuration).Single().Arguments.Get<Func<ArgumentCollection?, bool>>(0)!;
 
             predicate.Invoke(null).Should().BeTrue();
         }
@@ -34,7 +34,7 @@ namespace FakeItEasy.Tests
             configuration.WithAnyArguments();
 
             // Assert
-            var predicate = Fake.GetCalls(configuration).Single().Arguments.Get<Func<ArgumentCollection?, bool>>(0) !;
+            var predicate = Fake.GetCalls(configuration).Single().Arguments.Get<Func<ArgumentCollection?, bool>>(0)!;
 
             predicate.Invoke(null).Should().BeTrue();
         }

--- a/tests/FakeItEasy.Tests/Core/DefaultFakeObjectCallFormatterTests.cs
+++ b/tests/FakeItEasy.Tests/Core/DefaultFakeObjectCallFormatterTests.cs
@@ -86,7 +86,7 @@ namespace FakeItEasy.Tests.Core
                 "three");
 
             A.CallTo(() => this.argumentFormatter.GetArgumentValueAsString(A<object>._))
-                .ReturnsLazily(x => (x.GetArgument<object>(0) !).ToString() !);
+                .ReturnsLazily(x => (x.GetArgument<object>(0)!).ToString()!);
 
             // Act
             var description = this.formatter.GetDescription(call);
@@ -120,8 +120,8 @@ namespace FakeItEasy.Tests.Core
         {
             // Arrange
             var propertyGetter = typeof(TypeWithProperties).GetProperty(
-                nameof(TypeWithProperties.NormalProperty)) !
-                .GetSetMethod() !;
+                nameof(TypeWithProperties.NormalProperty))!
+                .GetSetMethod()!;
             var call = this.CreateFakeCall(typeof(TypeWithProperties), propertyGetter, "foo");
             A.CallTo(() => this.argumentFormatter.GetArgumentValueAsString("foo")).Returns(@"""foo""");
 
@@ -151,8 +151,8 @@ namespace FakeItEasy.Tests.Core
         public void Should_write_indexed_property_setter_properly()
         {
             // Arrange
-            var propertySetter = typeof(TypeWithProperties).GetProperty("Item") !
-                .GetSetMethod() !;
+            var propertySetter = typeof(TypeWithProperties).GetProperty("Item")!
+                .GetSetMethod()!;
             var call = this.CreateFakeCall(typeof(TypeWithProperties), propertySetter, 0, "argument");
             A.CallTo(() => this.argumentFormatter.GetArgumentValueAsString(0)).Returns("0");
             A.CallTo(() => this.argumentFormatter.GetArgumentValueAsString("argument")).Returns(@"""argument""");

--- a/tests/FakeItEasy.Tests/ExceptionContractTests.cs
+++ b/tests/FakeItEasy.Tests/ExceptionContractTests.cs
@@ -13,7 +13,7 @@ namespace FakeItEasy.Tests
             // Arrange
 
             // Act
-            var result = (T)Activator.CreateInstance(typeof(T), "A message") !;
+            var result = (T)Activator.CreateInstance(typeof(T), "A message")!;
 
             // Assert
             result.Message.Should().StartWith("A message");
@@ -25,7 +25,7 @@ namespace FakeItEasy.Tests
             // Arrange
 
             // Act
-            var result = (T)Activator.CreateInstance(typeof(T), "A message", new InvalidOperationException()) !;
+            var result = (T)Activator.CreateInstance(typeof(T), "A message", new InvalidOperationException())!;
 
             // Assert
             result.Message.Should().Be("A message");
@@ -38,7 +38,7 @@ namespace FakeItEasy.Tests
             var innerException = new InvalidOperationException();
 
             // Act
-            var result = (T)Activator.CreateInstance(typeof(T), string.Empty, innerException) !;
+            var result = (T)Activator.CreateInstance(typeof(T), string.Empty, innerException)!;
 
             // Assert
             result.InnerException.Should().Be(innerException);
@@ -50,7 +50,7 @@ namespace FakeItEasy.Tests
             // Arrange
 
             // Act
-            var result = (T)Activator.CreateInstance(typeof(T)) !;
+            var result = (T)Activator.CreateInstance(typeof(T))!;
 
             // Assert
             result.Should().NotBeNull();


### PR DESCRIPTION
Because it's nice to upgrade.
Also because the new rules understand constructs like 
`var eventInfo = GetEvent(fakeObjectCall.Method)!`, which I'd longed for while working on the nullability branch.