### PR TITLE
Use alternate when argument value formatter throws or returns null

### DIFF
--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -14,8 +14,6 @@ namespace FakeItEasy.Specs
         {
             int Bar(int x);
 
-            int Baz(HasCustomValueFormatter d);
-
             void OutAndRef(ref int x, out string s);
         }
 
@@ -129,31 +127,6 @@ namespace FakeItEasy.Specs
 
             "And its message should describe where the exception was thrown from"
                 .x(() => exception.Message.Should().Be("Call count constraint <a number of times matching the predicate 'n => ThrowException()'> threw an exception. See inner exception for details."));
-
-            "And the inner exception should be the original exception"
-                .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
-        }
-
-        [Scenario]
-        public void ExceptionInCustomArgumentValueFormatter(IFoo fake, Exception exception)
-        {
-            "Given a custom argument value formatter that throws an exception"
-                .See<HasCustomValueFormatterValueFormatter>();
-
-            "And a fake"
-                .x(() => fake = A.Fake<IFoo>());
-
-            "And no call is made to the fake"
-                .x(() => { });
-
-            "When an assertion using an argument of the type with the throwing formatter is made on the fake"
-                .x(() => exception = Record.Exception(() => A.CallTo(() => fake.Baz(new HasCustomValueFormatter())).MustHaveHappened()));
-
-            "Then a UserCallbackException should be thrown"
-                .x(() => exception.Should().BeAnExceptionOfType<UserCallbackException>());
-
-            "And its message should describe where the exception was thrown from"
-                .x(() => exception.Message.Should().Be("Custom argument value formatter 'FakeItEasy.Specs.UserCallbackExceptionSpecs+HasCustomValueFormatterValueFormatter' threw an exception. See inner exception for details."));
 
             "And the inner exception should be the original exception"
                 .x(() => exception.InnerException.Should().BeAnExceptionOfType<MyException>().Which.Message.Should().Be("Oops"));
@@ -397,18 +370,6 @@ namespace FakeItEasy.Specs
             public MyException(string message)
                 : base(message)
             {
-            }
-        }
-
-        public class HasCustomValueFormatter
-        {
-        }
-
-        public class HasCustomValueFormatterValueFormatter : ArgumentValueFormatter<HasCustomValueFormatter>
-        {
-            protected override string GetStringValue(HasCustomValueFormatter argumentValue)
-            {
-                throw new MyException("Oops");
             }
         }
 


### PR DESCRIPTION
Fixes #1690.