### PR TITLE
Restore fancy docs table of contents structure

### DIFF
--- a/docs/analyzer.md
+++ b/docs/analyzer.md
@@ -1,2 +1,2 @@
 The contents of this page have moved. See
-the [FakeItEasy Analyzer documentation](/projects/analyzers/) for information about the FakeItEasy Analyzer.
+the [FakeItEasy Analyzer documentation](https://fakeiteasy.readthedocs.io/projects/analyzers/) for information about the FakeItEasy Analyzer.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ theme: readthedocs
 repo_url: https://github.com/FakeItEasy/FakeItEasy
 extra_css: [css/extra-highlight.css]
 
-nav:
+pages:
 - FakeItEasy: index.md
 - Quickstart: quickstart.md
 - Creating Fakes:
@@ -37,7 +37,7 @@ nav:
 - Scanning for Extension Points: scanning-for-extension-points.md
 - Bootstrapper: bootstrapper.md
 - Advanced usage: advanced-usage.md
-- Analyzer: /projects/analyzers/
+- Analyzer: analyzer.md
 - Snippets for FakeItEasy in SideWaffle: snippets-for-fakeiteasy-in-sidewaffle.md
 - Platform support: platform-support.md
 - Source Stepping: source-stepping.md


### PR DESCRIPTION
Contributes to #1735. Corrects an error introduced in #1741.