### PR TITLE
Update MinVer to 2.3.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="2.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 


### PR DESCRIPTION
According to https://github.com/adamralph/minver/pull/347, if we don't, we'll have problems building with dotnet sdk 3.1.300+