### PR TITLE
Apply Object member rules to overridden members

### DIFF
--- a/docs/default-fake-behavior.md
+++ b/docs/default-fake-behavior.md
@@ -49,6 +49,18 @@ This behavior can be used to
 * supply values for the system under test to use (via the getter) or to
 * verify that the system under test performed the `set` action on the Fake
 
+### Object members
+
+Virtual methods inherited from `System.Object` are faked with a special default behavior:
+
+* `Equals` uses reference equality: it returns `true` if the argument is the fake
+  itself, `false` for any other argument.
+* `GetHashCode` returns a hashcode consistent with the behavior of `Equals`.
+* `ToString` returns a string of the form "Faked &lt;type of fake&gt;"
+
+This behavior applies to all fakes, including fakes of types that override these
+methods. Like any other method, the behavior can be explictly configured.
+
 ### Cancellation tokens
 
 When a faked method that accepts a `CancellationToken` receives a canceled token

--- a/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
@@ -9,9 +9,9 @@ namespace FakeItEasy.Core
             : SharedFakeObjectCallRule
         {
             public override bool IsApplicableTo(IFakeObjectCall fakeObjectCall) =>
-                fakeObjectCall.Method.IsSameMethodAs(EqualsMethod) ||
-                fakeObjectCall.Method.IsSameMethodAs(ToStringMethod) ||
-                fakeObjectCall.Method.IsSameMethodAs(GetHashCodeMethod);
+                fakeObjectCall.Method.HasSameBaseMethodAs(EqualsMethod) ||
+                fakeObjectCall.Method.HasSameBaseMethodAs(ToStringMethod) ||
+                fakeObjectCall.Method.HasSameBaseMethodAs(GetHashCodeMethod);
 
             public override void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
@@ -34,7 +34,7 @@ namespace FakeItEasy.Core
 
             private static bool TryHandleGetHashCode(IInterceptedFakeObjectCall fakeObjectCall, FakeManager fakeManager)
             {
-                if (!fakeObjectCall.Method.IsSameMethodAs(GetHashCodeMethod))
+                if (!fakeObjectCall.Method.HasSameBaseMethodAs(GetHashCodeMethod))
                 {
                     return false;
                 }
@@ -46,7 +46,7 @@ namespace FakeItEasy.Core
 
             private static bool TryHandleToString(IInterceptedFakeObjectCall fakeObjectCall, FakeManager fakeManager)
             {
-                if (!fakeObjectCall.Method.IsSameMethodAs(ToStringMethod))
+                if (!fakeObjectCall.Method.HasSameBaseMethodAs(ToStringMethod))
                 {
                     return false;
                 }
@@ -58,7 +58,7 @@ namespace FakeItEasy.Core
 
             private static bool TryHandleEquals(IInterceptedFakeObjectCall fakeObjectCall, FakeManager fakeManager)
             {
-                if (!fakeObjectCall.Method.IsSameMethodAs(EqualsMethod))
+                if (!fakeObjectCall.Method.HasSameBaseMethodAs(EqualsMethod))
                 {
                     return false;
                 }

--- a/src/FakeItEasy/Core/MethodInfoManager.cs
+++ b/src/FakeItEasy/Core/MethodInfoManager.cs
@@ -41,29 +41,11 @@ namespace FakeItEasy.Core
             return MethodCache.GetOrAdd(key, k => FindMethodOnTypeThatWillBeInvokedByMethodInfo(k.Type, new FakeItEasy.Compatibility.MethodInfoWrapper(k.MethodInfo, k.Type)));
         }
 
-        private static bool HasSameBaseMethod(MethodInfo first, MethodInfo second)
-        {
-            var baseOfFirst = GetBaseDefinition(first);
-            var baseOfSecond = GetBaseDefinition(second);
-
-            return baseOfFirst.IsSameMethodAs(baseOfSecond);
-        }
-
-        private static MethodInfo GetBaseDefinition(MethodInfo method)
-        {
-            if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
-            {
-                method = method.GetGenericMethodDefinition();
-            }
-
-            return method.GetBaseDefinition();
-        }
-
         private static MethodInfo? FindMethodOnTypeThatWillBeInvokedByMethodInfo(Type type, FakeItEasy.Compatibility.MethodInfoWrapper methodWrapper)
         {
             return
                 (from typeMethod in type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-                 where HasSameBaseMethod(typeMethod, methodWrapper.Method)
+                 where typeMethod.HasSameBaseMethodAs(methodWrapper.Method)
                  select MakeGeneric(typeMethod, methodWrapper.Method)).FirstOrDefault()
                 ?? GetMethodOnTypeThatImplementsInterfaceMethod(type, methodWrapper.Method)
                 ?? GetMethodOnInterfaceTypeImplementedByMethod(type, methodWrapper);
@@ -90,7 +72,7 @@ namespace FakeItEasy.Core
                 var foundMethod =
                     (from methodTargetPair in interfaceMap.InterfaceMethods
                          .Zip(interfaceMap.TargetMethods, (interfaceMethod, targetMethod) => new { InterfaceMethod = interfaceMethod, TargetMethod = targetMethod })
-                     where HasSameBaseMethod(EnsureNonGeneric(methodWrapper.Method), EnsureNonGeneric(methodTargetPair.TargetMethod))
+                     where EnsureNonGeneric(methodWrapper.Method).HasSameBaseMethodAs(EnsureNonGeneric(methodTargetPair.TargetMethod))
                      select MakeGeneric(methodTargetPair.InterfaceMethod, methodWrapper.Method)).FirstOrDefault();
 
                 if (foundMethod is object)
@@ -116,7 +98,7 @@ namespace FakeItEasy.Core
             return
                 (from methodTargetPair in interfaceMap.InterfaceMethods
                      .Zip(interfaceMap.TargetMethods, (interfaceMethod, targetMethod) => new { InterfaceMethod = interfaceMethod, TargetMethod = targetMethod })
-                 where HasSameBaseMethod(EnsureNonGeneric(methodTargetPair.InterfaceMethod), EnsureNonGeneric(method))
+                 where EnsureNonGeneric(methodTargetPair.InterfaceMethod).HasSameBaseMethodAs(EnsureNonGeneric(method))
                  select MakeGeneric(methodTargetPair.TargetMethod, method)).First();
         }
 

--- a/src/FakeItEasy/Core/MethodInfoManager.cs
+++ b/src/FakeItEasy/Core/MethodInfoManager.cs
@@ -72,7 +72,7 @@ namespace FakeItEasy.Core
                 var foundMethod =
                     (from methodTargetPair in interfaceMap.InterfaceMethods
                          .Zip(interfaceMap.TargetMethods, (interfaceMethod, targetMethod) => new { InterfaceMethod = interfaceMethod, TargetMethod = targetMethod })
-                     where EnsureNonGeneric(methodWrapper.Method).HasSameBaseMethodAs(EnsureNonGeneric(methodTargetPair.TargetMethod))
+                     where methodWrapper.Method.HasSameBaseMethodAs(methodTargetPair.TargetMethod)
                      select MakeGeneric(methodTargetPair.InterfaceMethod, methodWrapper.Method)).FirstOrDefault();
 
                 if (foundMethod is object)
@@ -98,13 +98,8 @@ namespace FakeItEasy.Core
             return
                 (from methodTargetPair in interfaceMap.InterfaceMethods
                      .Zip(interfaceMap.TargetMethods, (interfaceMethod, targetMethod) => new { InterfaceMethod = interfaceMethod, TargetMethod = targetMethod })
-                 where EnsureNonGeneric(methodTargetPair.InterfaceMethod).HasSameBaseMethodAs(EnsureNonGeneric(method))
+                 where methodTargetPair.InterfaceMethod.HasSameBaseMethodAs(method)
                  select MakeGeneric(methodTargetPair.TargetMethod, method)).First();
-        }
-
-        private static MethodInfo EnsureNonGeneric(MethodInfo methodInfo)
-        {
-            return methodInfo.IsGenericMethod ? methodInfo.GetGenericMethodDefinition() : methodInfo;
         }
 
         private static MethodInfo MakeGeneric(MethodInfo methodToMakeGeneric, MethodInfo originalMethod)

--- a/src/FakeItEasy/MethodBaseExtensions.cs
+++ b/src/FakeItEasy/MethodBaseExtensions.cs
@@ -59,9 +59,27 @@ namespace FakeItEasy
         public static bool IsSameMethodAs(this MethodBase method, MethodBase otherMethod)
         {
             return method.DeclaringType == otherMethod.DeclaringType
-                       && method.MetadataToken == otherMethod.MetadataToken
-                       && method.Module == otherMethod.Module
-                       && method.GetGenericArguments().SequenceEqual(otherMethod.GetGenericArguments());
+                && method.MetadataToken == otherMethod.MetadataToken
+                && method.Module == otherMethod.Module
+                && method.GetGenericArguments().SequenceEqual(otherMethod.GetGenericArguments());
+        }
+
+        public static bool HasSameBaseMethodAs(this MethodInfo first, MethodInfo second)
+        {
+            var baseOfFirst = GetBaseDefinition(first);
+            var baseOfSecond = GetBaseDefinition(second);
+
+            return baseOfFirst.IsSameMethodAs(baseOfSecond);
+        }
+
+        private static MethodInfo GetBaseDefinition(MethodInfo method)
+        {
+            if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
+            {
+                method = method.GetGenericMethodDefinition();
+            }
+
+            return method.GetBaseDefinition();
         }
 
         private static void AppendMethodName(StringBuilder builder, MethodBase method)

--- a/src/FakeItEasy/MethodInfoExtensions.cs
+++ b/src/FakeItEasy/MethodInfoExtensions.cs
@@ -6,11 +6,11 @@ namespace FakeItEasy
     using System.Text;
 
     /// <summary>
-    /// Provides extension methods for <see cref="MethodBase"/>.
+    /// Provides extension methods for <see cref="MethodInfo"/>.
     /// </summary>
-    internal static class MethodBaseExtensions
+    internal static class MethodInfoExtensions
     {
-        public static string GetGenericArgumentsString(this MethodBase method)
+        public static string GetGenericArgumentsString(this MethodInfo method)
         {
             var genericArguments = method.GetGenericArguments();
             if (genericArguments.Length == 0)
@@ -26,22 +26,22 @@ namespace FakeItEasy
                 "]");
         }
 
-        public static bool IsPropertyGetterOrSetter(this MethodBase method)
+        public static bool IsPropertyGetterOrSetter(this MethodInfo method)
         {
             return method.IsPropertyGetter() || method.IsPropertySetter();
         }
 
-        public static bool IsPropertySetter(this MethodBase method)
+        public static bool IsPropertySetter(this MethodInfo method)
         {
             return method.IsSpecialName && method.Name.StartsWith("set_", StringComparison.Ordinal);
         }
 
-        public static bool IsPropertyGetter(this MethodBase method)
+        public static bool IsPropertyGetter(this MethodInfo method)
         {
             return method.IsSpecialName && method.Name.StartsWith("get_", StringComparison.Ordinal);
         }
 
-        public static string GetDescription(this MethodBase method)
+        public static string GetDescription(this MethodInfo method)
         {
             var builder = new StringBuilder();
 
@@ -56,7 +56,7 @@ namespace FakeItEasy
             return builder.ToString();
         }
 
-        public static bool IsSameMethodAs(this MethodBase method, MethodBase otherMethod)
+        public static bool IsSameMethodAs(this MethodInfo method, MethodInfo otherMethod)
         {
             return method.DeclaringType == otherMethod.DeclaringType
                 && method.MetadataToken == otherMethod.MetadataToken
@@ -82,7 +82,7 @@ namespace FakeItEasy
             return method.GetBaseDefinition();
         }
 
-        private static void AppendMethodName(StringBuilder builder, MethodBase method)
+        private static void AppendMethodName(StringBuilder builder, MethodInfo method)
         {
             if (IsPropertyGetterOrSetter(method))
             {
@@ -96,7 +96,7 @@ namespace FakeItEasy
             builder.Append(method.GetGenericArgumentsString());
         }
 
-        private static void AppendParameterList(StringBuilder builder, MethodBase method)
+        private static void AppendParameterList(StringBuilder builder, MethodInfo method)
         {
             var parameters = method.GetParameters();
 
@@ -110,7 +110,7 @@ namespace FakeItEasy
             }
         }
 
-        private static void AppendParameterListPrefix(StringBuilder builder, MethodBase method)
+        private static void AppendParameterListPrefix(StringBuilder builder, MethodInfo method)
         {
             if (method.IsPropertyGetterOrSetter())
             {
@@ -122,7 +122,7 @@ namespace FakeItEasy
             }
         }
 
-        private static void AppendParameterListSuffix(StringBuilder builder, MethodBase method)
+        private static void AppendParameterListSuffix(StringBuilder builder, MethodInfo method)
         {
             if (method.IsPropertyGetterOrSetter())
             {

--- a/tests/FakeItEasy.Specs/ObjectMembersSpecs.cs
+++ b/tests/FakeItEasy.Specs/ObjectMembersSpecs.cs
@@ -122,6 +122,61 @@ namespace FakeItEasy.Specs
                 .x(() => stringRepresentation.Should().Be("Faked FakeItEasy.Specs.ObjectMembersSpecs+Foo"));
         }
 
+        [Scenario]
+        public static void HiddenEqualsWithSelf(Bar fake, bool equals)
+        {
+            "Given a fake of a type that hides Equals"
+                .x(() => fake = A.Fake<Bar>(o => o.WithArgumentsForConstructor(() => new Bar(1))));
+
+            "When Equals is called on the fake with the fake as the argument"
+                .x(() => equals = fake.Equals(fake));
+
+            "Then it returns false"
+                .x(() => equals.Should().BeFalse());
+        }
+
+        [Scenario]
+        public static void HiddenEqualsWithOtherFake(Bar fake, Foo otherFake, bool equals)
+        {
+            "Given a fake of a type that hides Equals"
+                .x(() => fake = A.Fake<Bar>(o => o.WithArgumentsForConstructor(() => new Bar(1))));
+
+            "And another fake of the same type"
+                .x(() => otherFake = A.Fake<Foo>(o => o.WithArgumentsForConstructor(() => new Foo(2))));
+
+            "When Equals is called on the first fake with the other fake as the argument"
+                .x(() => equals = fake.Equals(otherFake));
+
+            "Then it returns false"
+                .x(() => equals.Should().BeFalse());
+        }
+
+        [Scenario]
+        public static void HiddenGetHashCode(Bar fake, int fakeHashCode)
+        {
+            "Given a fake of a type that hides GetHashCode"
+                .x(() => fake = A.Fake<Bar>(o => o.WithArgumentsForConstructor(() => new Bar(1))));
+
+            "When GetHashCode is called on the fake"
+                .x(() => fakeHashCode = fake.GetHashCode());
+
+            "Then it returns 0"
+                .x(() => fakeHashCode.Should().Be(0));
+        }
+
+        [Scenario]
+        public static void HiddenToString(Bar fake, string? stringRepresentation)
+        {
+            "Given a fake of a type that hides ToString"
+                .x(() => fake = A.Fake<Bar>(o => o.WithArgumentsForConstructor(() => new Bar(1))));
+
+            "When ToString is called on the fake"
+                .x(() => stringRepresentation = fake.ToString());
+
+            "Then it should return an empty string"
+                .x(() => stringRepresentation.Should().BeEmpty());
+        }
+
         public interface IFoo
         {
             void Bar();
@@ -141,6 +196,22 @@ namespace FakeItEasy.Specs
             public override int GetHashCode() => this.Value.GetHashCode();
 
             public override string ToString() => $"Foo {this.Value}";
+        }
+
+        public class Bar
+        {
+            public Bar(int value)
+            {
+                this.Value = value;
+            }
+
+            public int Value { get; }
+
+            public new virtual bool Equals(object? obj) => obj is Foo other && other.Value == this.Value;
+
+            public new virtual int GetHashCode() => this.Value.GetHashCode();
+
+            public new virtual string ToString() => $"Foo {this.Value}";
         }
     }
 }

--- a/tests/FakeItEasy.Specs/ObjectMembersSpecs.cs
+++ b/tests/FakeItEasy.Specs/ObjectMembersSpecs.cs
@@ -64,9 +64,83 @@ namespace FakeItEasy.Specs
                 .x(() => stringRepresentation.Should().Be("Faked FakeItEasy.Specs.ObjectMembersSpecs+IFoo"));
         }
 
+        [Scenario]
+        public static void OverriddenEqualsWithSelf(Foo fake, bool equals)
+        {
+            "Given a fake of a type that overrides Equals"
+                .x(() => fake = A.Fake<Foo>(o => o.WithArgumentsForConstructor(() => new Foo(1))));
+
+            "When Equals is called on the fake with the fake as the argument"
+                .x(() => equals = fake.Equals(fake));
+
+            "Then it returns true"
+                .x(() => equals.Should().BeTrue());
+        }
+
+        [Scenario]
+        public static void OverriddenEqualsWithOtherFake(Foo fake, Foo otherFake, bool equals)
+        {
+            "Given a fake of a type that overrides Equals"
+                .x(() => fake = A.Fake<Foo>(o => o.WithArgumentsForConstructor(() => new Foo(1))));
+
+            "And another fake of the same type"
+                .x(() => otherFake = A.Fake<Foo>(o => o.WithArgumentsForConstructor(() => new Foo(2))));
+
+            "When Equals is called on the first fake with the other fake as the argument"
+                .x(() => equals = fake.Equals(otherFake));
+
+            "Then it returns false"
+                .x(() => equals.Should().BeFalse());
+        }
+
+        [Scenario]
+        public static void OverriddenGetHashCode(Foo fake, FakeManager manager, int fakeHashCode)
+        {
+            "Given a fake of a type that overrides GetHashCode"
+                .x(() => fake = A.Fake<Foo>(o => o.WithArgumentsForConstructor(() => new Foo(1))));
+
+            "And its manager"
+                .x(() => manager = Fake.GetFakeManager(fake));
+
+            "When GetHashCode is called on the fake"
+                .x(() => fakeHashCode = fake.GetHashCode());
+
+            "Then it returns the manager's hash code"
+                .x(() => fakeHashCode.Should().Be(manager.GetHashCode()));
+        }
+
+        [Scenario]
+        public static void OverriddenToString(Foo fake, string? stringRepresentation)
+        {
+            "Given a fake of a type that overrides ToString"
+                .x(() => fake = A.Fake<Foo>(o => o.WithArgumentsForConstructor(() => new Foo(1))));
+
+            "When ToString is called on the fake"
+                .x(() => stringRepresentation = fake.ToString());
+
+            "Then it should return a string representation of the fake"
+                .x(() => stringRepresentation.Should().Be("Faked FakeItEasy.Specs.ObjectMembersSpecs+Foo"));
+        }
+
         public interface IFoo
         {
             void Bar();
+        }
+
+        public class Foo
+        {
+            public Foo(int value)
+            {
+                this.Value = value;
+            }
+
+            public int Value { get; }
+
+            public override bool Equals(object? obj) => obj is Foo other && other.Value == this.Value;
+
+            public override int GetHashCode() => this.Value.GetHashCode();
+
+            public override string ToString() => $"Foo {this.Value}";
         }
     }
 }

--- a/tests/FakeItEasy.Specs/ObjectMembersSpecs.cs
+++ b/tests/FakeItEasy.Specs/ObjectMembersSpecs.cs
@@ -1,0 +1,72 @@
+namespace FakeItEasy.Specs
+{
+    using FakeItEasy.Core;
+    using FluentAssertions;
+    using Xbehave;
+
+    public static class ObjectMembersSpecs
+    {
+        [Scenario]
+        public static void DefaultEqualsWithSelf(IFoo fake, bool equals)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "When Equals is called on the fake with the fake as the argument"
+                .x(() => equals = fake.Equals(fake));
+
+            "Then it returns true"
+                .x(() => equals.Should().BeTrue());
+        }
+
+        [Scenario]
+        public static void DefaultEqualsWithOtherFake(IFoo fake, IFoo otherFake, bool equals)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And another fake of the same type"
+                .x(() => otherFake = A.Fake<IFoo>());
+
+            "When Equals is called on the first fake with the other fake as the argument"
+                .x(() => equals = fake.Equals(otherFake));
+
+            "Then it returns false"
+                .x(() => equals.Should().BeFalse());
+        }
+
+        [Scenario]
+        public static void DefaultGetHashCode(IFoo fake, FakeManager manager, int fakeHashCode)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And its manager"
+                .x(() => manager = Fake.GetFakeManager(fake));
+
+            "When GetHashCode is called on the fake"
+                .x(() => fakeHashCode = fake.GetHashCode());
+
+            "Then it returns the manager's hash code"
+                .x(() => fakeHashCode.Should().Be(manager.GetHashCode()));
+        }
+
+        [Scenario]
+        public static void DefaultToString(IFoo fake, string? stringRepresentation)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "When ToString is called on the fake"
+                .x(() => stringRepresentation = fake.ToString());
+
+            "Then it should return a string representation of the fake"
+                .x(() => stringRepresentation.Should().Be("Faked FakeItEasy.Specs.ObjectMembersSpecs+IFoo"));
+        }
+
+        public interface IFoo
+        {
+            void Bar();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1777

To be merged after 6.1.0 release

The last commit is optional, but I thought it made sense. I needed a `MethodInfo` to get access to `GetBaseDefinition`, and I realized that the methods in `MethodBaseExtensions` were *always* called on `MethodInfo`, so I changed their signature and renamed the class. I'm happy to rollback if you have an objection.