### PR TITLE
Prevent TypeCatalogueInstanceProvider from throwing a first chance MissingMethodException instantiating DefaultEnumerableValueFormatter

### DIFF
--- a/src/FakeItEasy/Core/TypeCatalogue.cs
+++ b/src/FakeItEasy/Core/TypeCatalogue.cs
@@ -13,7 +13,6 @@ namespace FakeItEasy.Core
     /// <summary>
     /// Provides access to all types in:
     /// <list type="bullet">
-    ///   <item>FakeItEasy,</item>
     ///   <item>currently loaded assemblies that reference FakeItEasy and</item>
     ///   <item>assemblies whose paths are supplied to the constructor, that also reference FakeItEasy.</item>
     /// </list>
@@ -107,7 +106,6 @@ namespace FakeItEasy.Core
             // This optimization can be fooled by test runners that make shadow copies of the assemblies but it's a start.
             return GetAssemblies(extraAssemblyFiles.Except(loadedAssemblyFiles))
                 .Concat(loadedAssembliesReferencingFakeItEasy)
-                .Concat(FakeItEasyAssembly)
                 .Distinct();
         }
 

--- a/src/FakeItEasy/RootModule.cs
+++ b/src/FakeItEasy/RootModule.cs
@@ -3,6 +3,7 @@ namespace FakeItEasy
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
     using System.Text;
     using FakeItEasy.Configuration;
     using FakeItEasy.Core;
@@ -33,7 +34,12 @@ namespace FakeItEasy
             var typeCatalogueInstanceProvider = new TypeCatalogueInstanceProvider(typeCatalogue);
 
             var argumentValueFormatters = typeCatalogueInstanceProvider.InstantiateAllOfType<IArgumentValueFormatter>();
-            var dummyFactories = typeCatalogueInstanceProvider.InstantiateAllOfType<IDummyFactory>();
+            var dummyFactories = typeCatalogueInstanceProvider.InstantiateAllOfType<IDummyFactory>()
+                .Concat(new[]
+                {
+                    new StringDummyFactory()
+                });
+
             var fakeOptionsBuilders = typeCatalogueInstanceProvider.InstantiateAllOfType<IFakeOptionsBuilder>();
 
             var implicitOptionsBuilderCatalogue = new ImplicitOptionsBuilderCatalogue(fakeOptionsBuilders);

--- a/src/FakeItEasy/TypeExtensions.cs
+++ b/src/FakeItEasy/TypeExtensions.cs
@@ -26,7 +26,7 @@ namespace FakeItEasy
             }
 
             var typeInfo = type.GetTypeInfo();
-            return !typeInfo.IsAbstract && !typeInfo.ContainsGenericParameters;
+            return !typeInfo.IsAbstract && !typeInfo.ContainsGenericParameters && type.HasDefaultConstructor();
         }
 
         public static bool IsNullable(this Type type)
@@ -34,6 +34,12 @@ namespace FakeItEasy
             var typeInfo = type.GetTypeInfo();
             return !typeInfo.IsValueType
                 || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+
+        [DebuggerStepThrough]
+        private static bool HasDefaultConstructor(this Type type)
+        {
+            return type.GetConstructor(Type.EmptyTypes) is object;
         }
     }
 }

--- a/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
@@ -81,7 +81,7 @@ namespace FakeItEasy.IntegrationTests
         }
 
         [Fact]
-        public void Should_be_able_to_get_types_from_fakeiteasy()
+        public void Should_not_include_types_from_fakeiteasy()
         {
             // Arrange
             var catalogue = new TypeCatalogue();
@@ -90,7 +90,7 @@ namespace FakeItEasy.IntegrationTests
             CaptureConsoleOutput(() => catalogue.Load(Enumerable.Empty<string>()));
 
             // Assert
-            catalogue.GetAvailableTypes().Should().Contain(typeof(A));
+            catalogue.GetAvailableTypes().Should().NotContain(typeof(A));
         }
 
         [Fact]

--- a/tests/FakeItEasy.Tests/TypeExtensionsTests.cs
+++ b/tests/FakeItEasy.Tests/TypeExtensionsTests.cs
@@ -52,6 +52,16 @@
             type.CanBeInstantiatedAs(targetType).Should().BeTrue();
         }
 
+        [Theory]
+        [InlineData(typeof(NonPublicConstructorFoo), typeof(IBar))]
+        [InlineData(typeof(MissingDefaultConstructorFoo), typeof(IBar))]
+        public void CanBeInstantiatedAs_should_return_false_when_the_type_does_not_have_a_default_public_constructor(
+            Type type,
+            Type targetType)
+        {
+            type.CanBeInstantiatedAs(targetType).Should().BeFalse();
+        }
+
         private abstract class AbstractBar : IBar
         {
         }
@@ -62,6 +72,23 @@
 
         private class GenericBar<T> : AbstractBar
         {
+        }
+
+        private class NonPublicConstructorFoo : IBar
+        {
+            private NonPublicConstructorFoo()
+            {
+            }
+        }
+
+        private class MissingDefaultConstructorFoo : IBar
+        {
+            private readonly string bar;
+
+            public MissingDefaultConstructorFoo(string bar)
+            {
+                this.bar = bar;
+            }
         }
     }
 }


### PR DESCRIPTION
- Exclude FIE Assembly from TypeCatalogue
- Adjust CanBeInstantiatedAs to include checking for a public no-arg constructor.

All the tests were passing on .NET Core, I had issues w/ getting the full framework to run on my machine due to missing very old framework versions.