### PR TITLE
Add EqualTo overload with equality comparer

### DIFF
--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -63,6 +63,7 @@ used. There are a few built-in matchers:
 |IsNull()|`null`|
 |IsNotNull()|not `null`|
 |IsEqualTo(other)|object equality using `object.Equals`|
+|IsEqualTo(other, equalityComparer)|object equality using `equalityComparer.Equals`|
 |IsSameAs(other)|object identity - like `object.ReferenceEquals`|
 |IsInstanceOf(type)|an argument that can be assigned to a variable of type `type`|
 |Contains(string)|substring match with ordinal string comparison|

--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -283,6 +283,7 @@ namespace FakeItEasy
         public static T IsEqualTo<T>(this IArgumentConstraintManager<T> manager, T value, IEqualityComparer<T> comparer)
         {
             Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(comparer, nameof(comparer));
 
             return manager.Matches(
                 x => comparer.Equals(value, x),

--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy
 {
     using System;
     using System.Collections;
+    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Linq.Expressions;
@@ -268,6 +269,23 @@ namespace FakeItEasy
 
             return manager.Matches(
                 x => object.Equals(value, x),
+                x => x.Write("equal to ").WriteArgumentValue(value));
+        }
+
+        /// <summary>
+        /// Tests that the passed in argument is equal to the specified value using provided equality comparer.
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="manager">The constraint manager to match the constraint.</param>
+        /// <param name="value">The value to compare to.</param>
+        /// <param name="comparer">The comparer to use for equality comparison.</param>
+        /// <returns>A dummy argument value.</returns>
+        public static T IsEqualTo<T>(this IArgumentConstraintManager<T> manager, T value, IEqualityComparer<T> comparer)
+        {
+            Guard.AgainstNull(manager, nameof(manager));
+
+            return manager.Matches(
+                x => comparer.Equals(value, x),
                 x => x.Write("equal to ").WriteArgumentValue(value));
         }
 

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
@@ -44,6 +44,7 @@ namespace FakeItEasy
         public static T IsEmpty<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
             where T : System.Collections.IEnumerable { }
         public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
+        public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public static T IsGreaterThan<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value)
             where T : System.IComparable { }
         public static T IsInstanceOf<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Type type) { }

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.approved.txt
@@ -44,6 +44,7 @@ namespace FakeItEasy
         public static T IsEmpty<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
             where T : System.Collections.IEnumerable { }
         public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
+        public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public static T IsGreaterThan<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value)
             where T : System.IComparable { }
         public static T IsInstanceOf<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Type type) { }

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
@@ -44,6 +44,7 @@ namespace FakeItEasy
         public static T IsEmpty<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
             where T : System.Collections.IEnumerable { }
         public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
+        public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public static T IsGreaterThan<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value)
             where T : System.IComparable { }
         public static T IsInstanceOf<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Type type) { }

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
@@ -44,6 +44,7 @@ namespace FakeItEasy
         public static T IsEmpty<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
             where T : System.Collections.IEnumerable { }
         public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
+        public static T IsEqualTo<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public static T IsGreaterThan<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value)
             where T : System.IComparable { }
         public static T IsInstanceOf<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Type type) { }

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/EqualToWithComparerConstraintTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/EqualToWithComparerConstraintTests.cs
@@ -2,6 +2,8 @@ namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq.Expressions;
+    using FakeItEasy.Core;
     using FakeItEasy.Tests.TestHelpers;
     using Xunit;
 
@@ -36,6 +38,18 @@ namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
         public override void IsValid_should_return_true_for_valid_values(object validValue)
         {
             base.IsValid_should_return_true_for_valid_values(validValue);
+        }
+
+        [Fact]
+        public void IsEqualTo_should_be_null_guarded_when_comparer_is_null()
+        {
+            // Arrange
+            var constraintManager = new DefaultArgumentConstraintManager<string>(x => { });
+            Expression<Action> call = () => constraintManager.IsEqualTo(null!, StringComparer.OrdinalIgnoreCase);
+
+            // Act
+            // Assert
+            call.Should().BeNullGuarded();
         }
 
         protected override void CreateConstraint(INegatableArgumentConstraintManager<string> scope)

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/EqualToWithComparerConstraintTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/EqualToWithComparerConstraintTests.cs
@@ -1,0 +1,46 @@
+namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
+{
+    using System;
+    using System.Collections.Generic;
+    using FakeItEasy.Tests.TestHelpers;
+    using Xunit;
+
+    public class EqualToWithComparerConstraintTests
+        : ArgumentConstraintTestBase<string>
+    {
+        protected override string ExpectedDescription => @"equal to ""IgnoreCase""";
+
+        public static IEnumerable<object?[]> InvalidValues()
+        {
+            return TestCases.FromObject(
+                (object?)null,
+                string.Empty,
+                " ",
+                "differentValue");
+        }
+
+        public static IEnumerable<object?[]> ValidValues()
+        {
+            return TestCases.FromObject("IgnoreCase", "ignoreCase");
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidValues))]
+        public override void IsValid_should_return_false_for_invalid_values(object invalidValue)
+        {
+            base.IsValid_should_return_false_for_invalid_values(invalidValue);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidValues))]
+        public override void IsValid_should_return_true_for_valid_values(object validValue)
+        {
+            base.IsValid_should_return_true_for_valid_values(validValue);
+        }
+
+        protected override void CreateConstraint(INegatableArgumentConstraintManager<string> scope)
+        {
+            scope.IsEqualTo("IgnoreCase", StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
Hi, we have started using FakeItEasy in our main code base and while migrating from RhinoMocks I missed a method argument constraint where you can use EqualTo with custom comparer. Originaly we were using `That.Matches(Predicate)` constraint, then we have created our own extension method for that to be able to pass equality comparer and I thought it would be nice if it was part of the framework so I created this PR if you are interested.

Cheers 🎆 