### PR TITLE
Throw FakeCreationException when using Sdk.Create to fake a value type with fake creation options

### DIFF
--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
@@ -115,12 +115,6 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
 
         public static bool CanGenerateProxy(Type typeOfProxy, [NotNullWhen(false)] out string? failReason)
         {
-            if (typeOfProxy.IsValueType)
-            {
-                failReason = DynamicProxyMessages.ProxyIsValueType(typeOfProxy);
-                return false;
-            }
-
             if (typeOfProxy.IsSealed)
             {
                 failReason = DynamicProxyMessages.ProxyIsSealedType(typeOfProxy);

--- a/src/FakeItEasy/Creation/CastleDynamicProxy/DynamicProxyMessages.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/DynamicProxyMessages.cs
@@ -13,9 +13,6 @@
         public static string ProxyIsSealedType(Type type) =>
             $"The type of proxy {type} is sealed.";
 
-        public static string ProxyIsValueType(Type type) =>
-            $"The type of proxy must be an interface or a class but it was {type}.";
-
         public static string ProxyTypeWithNoDefaultConstructor(Type type) =>
             $"No usable default constructor was found on the type {type}.";
     }

--- a/src/FakeItEasy/Creation/FakeAndDummyManager.cs
+++ b/src/FakeItEasy/Creation/FakeAndDummyManager.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy.Creation
 {
     using System;
+    using FakeItEasy.Core;
 
     internal class FakeAndDummyManager
     {
@@ -32,6 +33,11 @@ namespace FakeItEasy.Creation
             Action<IFakeOptions> optionsBuilder,
             LoopDetectingResolutionContext resolutionContext)
         {
+            if (typeOfFake.IsValueType)
+            {
+                throw new FakeCreationException(ExceptionMessages.FailedToFakeValueType(typeOfFake));
+            }
+
             var proxyOptions = this.proxyOptionsFactory.BuildProxyOptions(typeOfFake, optionsBuilder);
             return this.fakeCreator.CreateFake(typeOfFake, proxyOptions, this.dummyValueResolver, resolutionContext).Result !;
         }

--- a/src/FakeItEasy/Creation/FakeAndDummyManager.cs
+++ b/src/FakeItEasy/Creation/FakeAndDummyManager.cs
@@ -24,8 +24,7 @@ namespace FakeItEasy.Creation
             Type typeOfFake,
             LoopDetectingResolutionContext resolutionContext)
         {
-            var proxyOptions = this.proxyOptionsFactory.BuildProxyOptions(typeOfFake, null);
-            return this.fakeCreator.CreateFake(typeOfFake, proxyOptions, this.dummyValueResolver, resolutionContext).Result !;
+            return this.CreateFake(typeOfFake, optionsBuilder: null!, resolutionContext);
         }
 
         public object CreateFake(

--- a/src/FakeItEasy/ExceptionMessages.cs
+++ b/src/FakeItEasy/ExceptionMessages.cs
@@ -118,5 +118,8 @@ namespace FakeItEasy
 
         public static string NotAnInterface(Type interfaceType) =>
             $"The specified type {interfaceType} is not an interface";
+
+        public static string FailedToFakeValueType(Type fakeType) =>
+            $"Failed to create Fake of type {fakeType} because it's a value type.";
     }
 }

--- a/tests/FakeItEasy.Specs/CreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationSpecs.cs
@@ -813,6 +813,25 @@ namespace FakeItEasy.Specs
 "));
         }
 
+        [Scenario]
+        public void StructCannotBeFakedWithOptions(Exception exception)
+        {
+            "Given a struct"
+                .See<Struct>();
+
+            "When I create a fake of the struct supplying fake creation options"
+                .x(() => exception = Record.Exception(() => (Struct)Sdk.Create.Fake(typeof(Struct), options => { })));
+
+            "Then it throws a fake creation exception"
+                .x(() => exception.Should().BeOfType<FakeCreationException>());
+
+            "And the exception message indicates the reason for failure"
+                .x(() => exception.Message.Should().StartWithModuloLineEndings(@"
+  Failed to create fake of type FakeItEasy.Specs.CreationSpecsBase+Struct:
+    The type of proxy must be an interface or a class but it was FakeItEasy.Specs.CreationSpecsBase+Struct.
+"));
+        }
+
         protected override T CreateFake<T>()
         {
             return (T)Sdk.Create.Fake(typeof(T));

--- a/tests/FakeItEasy.Specs/CreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationSpecs.cs
@@ -807,10 +807,8 @@ namespace FakeItEasy.Specs
                 .x(() => exception.Should().BeOfType<FakeCreationException>());
 
             "And the exception message indicates the reason for failure"
-                .x(() => exception.Message.Should().StartWithModuloLineEndings(@"
-  Failed to create fake of type FakeItEasy.Specs.CreationSpecsBase+Struct:
-    The type of proxy must be an interface or a class but it was FakeItEasy.Specs.CreationSpecsBase+Struct.
-"));
+                .x(() => exception.Message.Should()
+                    .Be("Failed to create Fake of type FakeItEasy.Specs.CreationSpecsBase+Struct because it's a value type."));
         }
 
         [Scenario]
@@ -826,10 +824,8 @@ namespace FakeItEasy.Specs
                 .x(() => exception.Should().BeOfType<FakeCreationException>());
 
             "And the exception message indicates the reason for failure"
-                .x(() => exception.Message.Should().StartWithModuloLineEndings(@"
-  Failed to create fake of type FakeItEasy.Specs.CreationSpecsBase+Struct:
-    The type of proxy must be an interface or a class but it was FakeItEasy.Specs.CreationSpecsBase+Struct.
-"));
+                .x(() => exception.Message.Should()
+                    .Be("Failed to create Fake of type FakeItEasy.Specs.CreationSpecsBase+Struct because it's a value type."));
         }
 
         protected override T CreateFake<T>()


### PR DESCRIPTION
Fixes #1830.