### PR TITLE
Event API improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-﻿# EditorConfig is awesome: https://editorconfig.org
+# EditorConfig is awesome: https://editorconfig.org
 
 # Top-most EditorConfig file
 root = true
@@ -45,3 +45,44 @@ dotnet_diagnostic.SA1601.severity = none    # Partial elements should be documen
 dotnet_diagnostic.SA1628.severity = warning # Documentation text must begin with a capital letter
 dotnet_diagnostic.SA1629.severity = warning # Documentation text must end with a period
 dotnet_diagnostic.SA1633.severity = none    # Files should have file headers
+
+csharp_using_directive_placement = inside_namespace
+
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_property = true
+dotnet_style_qualification_for_method = true
+dotnet_style_qualification_for_event = true
+
+# Naming rules
+
+## Symbols
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, method, event
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = *
+
+
+dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_symbols.static_fields.applicable_accessibilities = *
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_symbols.private_instance_field.applicable_kinds = field
+dotnet_naming_symbols.private_instance_field.applicable_accessibilities = private
+
+## Styles
+
+dotnet_naming_style.camel_case.capitalization = camel_case
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+## Rules
+
+dotnet_naming_rule.non_field_members_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_pascal_case.style = pascal_case
+dotnet_naming_rule.non_field_members_pascal_case.severity = warning
+
+dotnet_naming_rule.static_fields.symbols = non_field_members
+dotnet_naming_rule.static_fields.style = pascal_case
+dotnet_naming_rule.static_fields.severity = warning
+
+dotnet_naming_rule.private_instance_field.symbols = non_field_members
+dotnet_naming_rule.private_instance_field.style = camel_case
+dotnet_naming_rule.private_instance_field.severity = warning

--- a/docs/raising-events.md
+++ b/docs/raising-events.md
@@ -100,7 +100,10 @@ Similarly, strict fakes don't handle any call unless explicitly configured,
 including event subscription or unsubscription, so FakeItEasy also can't raise
 events on strict fakes.
 
-To work around this limitation, you have two options:
+To work around this limitation, you have three options:
+
+- For a strict fake, you can [enable the default event behavior on the fake at
+creation time](strict-fakes.md#events).
 
 - You can explicitly enable the default event behavior on the fake, for a
 specific event or for all events of the fake:

--- a/docs/raising-events.md
+++ b/docs/raising-events.md
@@ -87,6 +87,7 @@ This method may also be used from C# if you don't want to rely on late binding.
 ## Limitations
 
 The approach described above for raising events doesn't work in some situations:
+
 - Wrapping fakes
 - Fakes configured to call base methods
 
@@ -94,6 +95,10 @@ This is because the calls (including event subscription and unsubscription) are
 forwarded to another implementation (wrapped object or base class) that
 FakeItEasy has no control over, so the fake doesn't know about the handlers and
 cannot call them.
+
+Similarly, strict fakes don't handle any call unless explicitly configured,
+including event subscription or unsubscription, so FakeItEasy also can't raise
+events on strict fakes.
 
 To work around this limitation, you will need to explicitly configure the calls
 to the event accessors to handle event subscription yourself, as in the example
@@ -104,8 +109,8 @@ below:
 EventHandler handlers = null;
 
 // Configure event subscription on the fake
-A.CallTo(robot).Where(call => call.Method.Name == "add_FellInLove").Invokes((EventHandler h) => handlers += h);
-A.CallTo(robot).Where(call => call.Method.Name == "remove_FellInLove").Invokes((EventHandler h) => handlers -= h);
+A.CallTo(robot, EventAction.Add("FellInLove")).Invokes((EventHandler h) => handlers += h);
+A.CallTo(robot, EventAction.Remove("FellInLove")).Invokes((EventHandler h) => handlers -= h);
 
 // Raise the event
 handlers?.Invoke(robot, EventArgs.Empty);

--- a/docs/raising-events.md
+++ b/docs/raising-events.md
@@ -100,9 +100,18 @@ Similarly, strict fakes don't handle any call unless explicitly configured,
 including event subscription or unsubscription, so FakeItEasy also can't raise
 events on strict fakes.
 
-To work around this limitation, you will need to explicitly configure the calls
-to the event accessors to handle event subscription yourself, as in the example
-below:
+To work around this limitation, you have two options:
+
+- You can explicitly enable the default event behavior on the fake, for a
+specific event or for all events of the fake:
+
+```csharp
+Manage.Event("FellInLove").Of(robot);
+Manage.AllEvents.Of(robot);
+```
+
+- If you need more control, you can explicitly configure the calls to the event
+accessors to handle event subscription yourself, as in the example below:
 
 ```csharp
 // Declare a delegate to store the event handlers

--- a/docs/specifying-a-call-to-configure.md
+++ b/docs/specifying-a-call-to-configure.md
@@ -110,6 +110,23 @@ A.CallTo(fakeShop).Where(call => call.Method.Name == "set_Address")
                   .Throws(new Exception("we can't move"));
 ```
 
+## Specifying a call to an event accessor
+
+Although calls to event accessors can be specified using the approach described
+in the previous section, FakeItEasy also provides helper methods to make this
+easier:
+
+```csharp
+// Specifies a call to the add accessor of the MyEvent event of the fake
+A.CallTo(fake, EventAction.Add("MyEvent")).Invokes((EventHandler h) => ...);
+// Specifies a call to the remove accessor of the MyEvent event of the fake
+A.CallTo(fake, EventAction.Remove("MyEvent")).Invokes((EventHandler h) => ...);
+// Specifies a call to the add accessor of any event of the fake
+A.CallTo(fake, EventAction.Add()).Invokes(...);
+// Specifies a call to the remove accessor of any event of the fake
+A.CallTo(fake, EventAction.Remove()).Invokes(...);
+```
+
 ## VB.Net
 Special syntax is provided to specify `Func`s and `Sub`s in VB, using their respective keywords:
 

--- a/docs/strict-fakes.md
+++ b/docs/strict-fakes.md
@@ -45,3 +45,15 @@ var foo = A.Fake<IFoo>(x => x.Strict(StrictFakeOptions.AllowToString));
 // Allow calls to Equals and GetHashCode
 var foo = A.Fake<IFoo>(x => x.Strict(StrictFakeOptions.AllowEquals | StrictFakeOptions.AllowGetHashCode));
 ```
+
+## Events
+
+By default, calls to event accessors of a strict fake will fail if the
+calls are not configured. Although you can [manually handle event subscription
+or unsubscription](raising-events.md#limitations), there's often not much value
+in doing this manually. You can allow a strict fake to manage events
+automatically by passing the `AllowEvents` flag to the `Strict` method:
+
+```csharp
+var foo = A.Fake<IFoo>(x => x.Strict(StrictFakeOptions.AllowEvents));
+```

--- a/src/FakeItEasy/A.cs
+++ b/src/FakeItEasy/A.cs
@@ -172,5 +172,16 @@ namespace FakeItEasy
         {
             return ConfigurationManager.CallToSet(propertySpecification);
         }
+
+        /// <summary>
+        /// Configures subscription to or unsubscription from an event of a faked object.
+        /// </summary>
+        /// <param name="fake">The fake to configure.</param>
+        /// <param name="action">An <see cref="EventAction"/> that represents the action to configure.</param>
+        /// <returns>A configuration object.</returns>
+        public static IAnyCallConfigurationWithVoidReturnType CallTo(object fake, EventAction action)
+        {
+            return CallTo(fake).MatchingEventAction(fake, action);
+        }
     }
 }

--- a/src/FakeItEasy/Configuration/AnyCallConfigurationWithNoReturnTypeSpecifiedExtensions.cs
+++ b/src/FakeItEasy/Configuration/AnyCallConfigurationWithNoReturnTypeSpecifiedExtensions.cs
@@ -1,0 +1,16 @@
+namespace FakeItEasy.Configuration
+{
+    internal static class AnyCallConfigurationWithNoReturnTypeSpecifiedExtensions
+    {
+        public static IAnyCallConfigurationWithVoidReturnType MatchingEventAction(
+            this IAnyCallConfigurationWithNoReturnTypeSpecified configuration,
+            object fake,
+            EventAction action)
+        {
+            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(fake, nameof(fake));
+            Guard.AgainstNull(action, nameof(action));
+            return configuration.WithVoidReturnType().Where(action.Matches, writer => action.WriteDescription(fake, writer));
+        }
+    }
+}

--- a/src/FakeItEasy/Configuration/IManageEventConfiguration.cs
+++ b/src/FakeItEasy/Configuration/IManageEventConfiguration.cs
@@ -1,0 +1,16 @@
+namespace FakeItEasy.Configuration
+{
+    /// <summary>
+    /// Provides a method to specify on which fake events should be managed.
+    /// </summary>
+    public interface IManageEventConfiguration
+    {
+        /// <summary>
+        /// Specifies on which fake events should be managed.
+        /// </summary>
+        /// <param name="fake">The fake on which events should be managed.</param>
+#pragma warning disable CA1716 // Identifiers should not match keywords
+        void Of(object fake);
+#pragma warning restore CA1716 // Identifiers should not match keywords
+    }
+}

--- a/src/FakeItEasy/Core/EventCall.cs
+++ b/src/FakeItEasy/Core/EventCall.cs
@@ -38,9 +38,14 @@ namespace FakeItEasy.Core
             return true;
         }
 
-        public bool IsEventRegistration()
+        public bool IsEventSubscription()
         {
             return GetAddMethod(this.Event).Equals(this.CallingMethod);
+        }
+
+        public bool IsEventUnsubscription()
+        {
+            return GetRemoveMethod(this.Event).Equals(this.CallingMethod);
         }
 
         public bool TryTakeEventRaiserArgumentProvider([NotNullWhen(true)] out IEventRaiserArgumentProvider? argumentProvider)

--- a/src/FakeItEasy/Core/EventCallHandler.cs
+++ b/src/FakeItEasy/Core/EventCallHandler.cs
@@ -1,0 +1,111 @@
+﻿namespace FakeItEasy.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+
+    internal class EventCallHandler
+    {
+        private readonly FakeManager fakeManager;
+
+        private Dictionary<object, Delegate>? registeredEventHandlersField;
+
+        public EventCallHandler(FakeManager fakeManager)
+        {
+            this.fakeManager = fakeManager;
+        }
+
+        private Dictionary<object, Delegate> RegisteredEventHandlers
+        {
+            get
+            {
+                if (this.registeredEventHandlersField is null)
+                {
+                    this.registeredEventHandlersField = new Dictionary<object, Delegate>();
+                }
+
+                return this.registeredEventHandlersField;
+            }
+        }
+
+        public void HandleEventCall(EventCall eventCall)
+        {
+            if (eventCall.IsEventSubscription())
+            {
+                if (eventCall.TryTakeEventRaiserArgumentProvider(out var argumentProvider))
+                {
+                    this.RaiseEvent(eventCall, argumentProvider);
+                }
+                else
+                {
+                    this.AddEventListener(eventCall);
+                }
+            }
+            else
+            {
+                this.RemoveEventListener(eventCall);
+            }
+        }
+
+        private void RemoveEventListener(EventCall call)
+        {
+            this.RemoveHandler(call.Event, call.EventHandler);
+        }
+
+        private void AddEventListener(EventCall call)
+        {
+            this.AddHandler(call.Event, call.EventHandler);
+        }
+
+        private void AddHandler(object key, Delegate handler)
+        {
+            if (this.RegisteredEventHandlers.TryGetValue(key, out var result))
+            {
+                result = Delegate.Combine(result, handler);
+            }
+            else
+            {
+                result = handler;
+            }
+
+            this.RegisteredEventHandlers[key] = result;
+        }
+
+        private void RemoveHandler(object key, Delegate handler)
+        {
+            if (this.RegisteredEventHandlers.TryGetValue(key, out var registration))
+            {
+                registration = Delegate.Remove(registration, handler);
+
+                if (registration is not null)
+                {
+                    this.RegisteredEventHandlers[key] = registration;
+                }
+                else
+                {
+                    this.RegisteredEventHandlers.Remove(key);
+                }
+            }
+        }
+
+        private void RaiseEvent(EventCall call, IEventRaiserArgumentProvider argumentProvider)
+        {
+            if (this.RegisteredEventHandlers.TryGetValue(call.Event, out var raiseMethod))
+            {
+                var arguments = argumentProvider.GetEventArguments(this.fakeManager.Object!);
+
+                try
+                {
+                    raiseMethod.DynamicInvoke(arguments);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    // Exceptions thrown by event handlers should propagate outward as is, not
+                    // be wrapped in a TargetInvocationException.
+                    ex.InnerException?.Rethrow();
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/FakeItEasy/Core/EventCallHandler.cs
+++ b/src/FakeItEasy/Core/EventCallHandler.cs
@@ -8,24 +8,12 @@
     {
         private readonly FakeManager fakeManager;
 
-        private Dictionary<object, Delegate>? registeredEventHandlersField;
+        private readonly Dictionary<object, Delegate> registeredEventHandlers;
 
         public EventCallHandler(FakeManager fakeManager)
         {
             this.fakeManager = fakeManager;
-        }
-
-        private Dictionary<object, Delegate> RegisteredEventHandlers
-        {
-            get
-            {
-                if (this.registeredEventHandlersField is null)
-                {
-                    this.registeredEventHandlersField = new Dictionary<object, Delegate>();
-                }
-
-                return this.registeredEventHandlersField;
-            }
+            this.registeredEventHandlers = new Dictionary<object, Delegate>();
         }
 
         public void HandleEventCall(EventCall eventCall)
@@ -59,7 +47,7 @@
 
         private void AddHandler(object key, Delegate handler)
         {
-            if (this.RegisteredEventHandlers.TryGetValue(key, out var result))
+            if (this.registeredEventHandlers.TryGetValue(key, out var result))
             {
                 result = Delegate.Combine(result, handler);
             }
@@ -68,29 +56,29 @@
                 result = handler;
             }
 
-            this.RegisteredEventHandlers[key] = result;
+            this.registeredEventHandlers[key] = result;
         }
 
         private void RemoveHandler(object key, Delegate handler)
         {
-            if (this.RegisteredEventHandlers.TryGetValue(key, out var registration))
+            if (this.registeredEventHandlers.TryGetValue(key, out var registration))
             {
                 registration = Delegate.Remove(registration, handler);
 
                 if (registration is not null)
                 {
-                    this.RegisteredEventHandlers[key] = registration;
+                    this.registeredEventHandlers[key] = registration;
                 }
                 else
                 {
-                    this.RegisteredEventHandlers.Remove(key);
+                    this.registeredEventHandlers.Remove(key);
                 }
             }
         }
 
         private void RaiseEvent(EventCall call, IEventRaiserArgumentProvider argumentProvider)
         {
-            if (this.RegisteredEventHandlers.TryGetValue(call.Event, out var raiseMethod))
+            if (this.registeredEventHandlers.TryGetValue(call.Event, out var raiseMethod))
             {
                 var arguments = argumentProvider.GetEventArguments(this.fakeManager.Object!);
 

--- a/src/FakeItEasy/Core/FakeManager.EventRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.EventRule.cs
@@ -53,7 +53,7 @@ namespace FakeItEasy.Core
 
             private void HandleEventCall(EventCall eventCall)
             {
-                if (eventCall.IsEventRegistration())
+                if (eventCall.IsEventSubscription())
                 {
                     if (eventCall.TryTakeEventRaiserArgumentProvider(out var argumentProvider))
                     {

--- a/src/FakeItEasy/Core/FakeManager.EventRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.EventRule.cs
@@ -7,16 +7,12 @@ namespace FakeItEasy.Core
         {
             private readonly FakeManager fakeManager;
 
-            private EventCallHandler? handler;
-
             public EventRule(FakeManager fakeManager)
             {
                 this.fakeManager = fakeManager;
             }
 
             public int? NumberOfTimesToCall => null;
-
-            private EventCallHandler Handler => this.handler ??= new EventCallHandler(this.fakeManager);
 
             public bool IsApplicableTo(IFakeObjectCall fakeObjectCall)
             {
@@ -29,7 +25,7 @@ namespace FakeItEasy.Core
             {
                 if (EventCall.TryGetEventCall(fakeObjectCall, out var eventCall))
                 {
-                    this.Handler.HandleEventCall(eventCall);
+                    this.fakeManager.EventCallHandler.HandleEventCall(eventCall);
                 }
             }
         }

--- a/src/FakeItEasy/Core/FakeManager.EventRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.EventRule.cs
@@ -1,20 +1,13 @@
 namespace FakeItEasy.Core
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Reflection;
-
-    /// <content>Event rule.</content>
     public partial class FakeManager
     {
-        [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Would provide no benefit since there is no place from where to call the Dispose-method.")]
         private class EventRule
             : IFakeObjectCallRule
         {
             private readonly FakeManager fakeManager;
 
-            private Dictionary<object, Delegate>? registeredEventHandlersField;
+            private EventCallHandler? handler;
 
             public EventRule(FakeManager fakeManager)
             {
@@ -23,18 +16,7 @@ namespace FakeItEasy.Core
 
             public int? NumberOfTimesToCall => null;
 
-            private Dictionary<object, Delegate> RegisteredEventHandlers
-            {
-                get
-                {
-                    if (this.registeredEventHandlersField is null)
-                    {
-                        this.registeredEventHandlersField = new Dictionary<object, Delegate>();
-                    }
-
-                    return this.registeredEventHandlersField;
-                }
-            }
+            private EventCallHandler Handler => this.handler ??= new EventCallHandler(this.fakeManager);
 
             public bool IsApplicableTo(IFakeObjectCall fakeObjectCall)
             {
@@ -47,87 +29,7 @@ namespace FakeItEasy.Core
             {
                 if (EventCall.TryGetEventCall(fakeObjectCall, out var eventCall))
                 {
-                    this.HandleEventCall(eventCall);
-                }
-            }
-
-            private void HandleEventCall(EventCall eventCall)
-            {
-                if (eventCall.IsEventSubscription())
-                {
-                    if (eventCall.TryTakeEventRaiserArgumentProvider(out var argumentProvider))
-                    {
-                        this.RaiseEvent(eventCall, argumentProvider);
-                    }
-                    else
-                    {
-                        this.AddEventListener(eventCall);
-                    }
-                }
-                else
-                {
-                    this.RemoveEventListener(eventCall);
-                }
-            }
-
-            private void RemoveEventListener(EventCall call)
-            {
-                this.RemoveHandler(call.Event, call.EventHandler);
-            }
-
-            private void AddEventListener(EventCall call)
-            {
-                this.AddHandler(call.Event, call.EventHandler);
-            }
-
-            private void AddHandler(object key, Delegate handler)
-            {
-                if (this.RegisteredEventHandlers.TryGetValue(key, out var result))
-                {
-                    result = Delegate.Combine(result, handler);
-                }
-                else
-                {
-                    result = handler;
-                }
-
-                this.RegisteredEventHandlers[key] = result;
-            }
-
-            private void RemoveHandler(object key, Delegate handler)
-            {
-                if (this.RegisteredEventHandlers.TryGetValue(key, out var registration))
-                {
-                    registration = Delegate.Remove(registration, handler);
-
-                    if (registration is not null)
-                    {
-                        this.RegisteredEventHandlers[key] = registration;
-                    }
-                    else
-                    {
-                        this.RegisteredEventHandlers.Remove(key);
-                    }
-                }
-            }
-
-            private void RaiseEvent(EventCall call, IEventRaiserArgumentProvider argumentProvider)
-            {
-                if (this.RegisteredEventHandlers.TryGetValue(call.Event, out var raiseMethod))
-                {
-                    var arguments = argumentProvider.GetEventArguments(this.fakeManager.Object!);
-
-                    try
-                    {
-                        raiseMethod.DynamicInvoke(arguments);
-                    }
-                    catch (TargetInvocationException ex)
-                    {
-                        // Exceptions thrown by event handlers should propagate outward as is, not
-                        // be wrapped in a TargetInvocationException.
-                        ex.InnerException?.Rethrow();
-                        throw;
-                    }
+                    this.Handler.HandleEventCall(eventCall);
                 }
             }
         }

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -29,6 +29,8 @@ namespace FakeItEasy.Core
 
         private readonly LinkedList<CallRuleMetadata> allUserRules;
 
+        private EventCallHandler? eventCallHandler;
+
         private ConcurrentQueue<CompletedFakeObjectCall> recordedCalls;
 
         private int lastSequenceNumber = -1;
@@ -100,6 +102,8 @@ namespace FakeItEasy.Core
             string.IsNullOrEmpty(this.FakeObjectName)
                 ? "Faked " + this.FakeObjectType
                 : this.FakeObjectName!;
+
+        internal EventCallHandler EventCallHandler => this.eventCallHandler ??= new EventCallHandler(this);
 
         /// <summary>
         /// Adds a call rule to the fake object.

--- a/src/FakeItEasy/Core/StrictFakeRule.cs
+++ b/src/FakeItEasy/Core/StrictFakeRule.cs
@@ -1,5 +1,6 @@
 namespace FakeItEasy.Core
 {
+    using System;
     using static FakeItEasy.ObjectMembers;
 
     internal class StrictFakeRule : IFakeObjectCallRule
@@ -40,7 +41,14 @@ namespace FakeItEasy.Core
 
         public void Apply(IInterceptedFakeObjectCall fakeObjectCall)
         {
-            throw new ExpectationException(ExceptionMessages.CallToUnconfiguredMethodOfStrictFake(fakeObjectCall));
+            string message = ExceptionMessages.CallToUnconfiguredMethodOfStrictFake(fakeObjectCall);
+
+            if (EventCall.TryGetEventCall(fakeObjectCall, out _))
+            {
+                message += Environment.NewLine + ExceptionMessages.HandleEventsOnStrictFakes;
+            }
+
+            throw new ExpectationException(message);
         }
 
         private bool HasOption(StrictFakeOptions flag) => (flag & this.options) == flag;

--- a/src/FakeItEasy/Core/StrictFakeRule.cs
+++ b/src/FakeItEasy/Core/StrictFakeRule.cs
@@ -30,6 +30,11 @@ namespace FakeItEasy.Core
                 return !this.HasOption(StrictFakeOptions.AllowToString);
             }
 
+            if (EventCall.TryGetEventCall(fakeObjectCall, out _))
+            {
+                return !this.HasOption(StrictFakeOptions.AllowEvents);
+            }
+
             return true;
         }
 

--- a/src/FakeItEasy/EventAction.cs
+++ b/src/FakeItEasy/EventAction.cs
@@ -1,0 +1,91 @@
+namespace FakeItEasy
+{
+    using FakeItEasy.Core;
+
+    /// <summary>
+    /// Represents subscription to or unsubscription from an event of a fake.
+    /// </summary>
+    /// <remarks>An instance of this class can't be explicitly created. Use the static <c>Add</c> and <c>Remove</c> methods to obtain an instance.</remarks>
+    public abstract class EventAction
+    {
+        private EventAction()
+        {
+        }
+
+        /// <summary>
+        /// Returns an <see cref="EventAction"/> that represents subscription to the specified event of a fake.
+        /// </summary>
+        /// <param name="eventName">Name of the event.</param>
+        /// <returns>An <see cref="EventAction"/> that represents the action.</returns>
+        public static EventAction Add(string eventName) => new AddSpecificEventAction(eventName);
+
+        /// <summary>
+        /// Returns an <see cref="EventAction"/> that represents unsubscription from the specified event of a fake.
+        /// </summary>
+        /// <param name="eventName">Name of the event.</param>
+        /// <returns>An <see cref="EventAction"/> that represents the action.</returns>
+        public static EventAction Remove(string eventName) => new RemoveSpecificEventAction(eventName);
+
+        /// <summary>
+        /// Returns an <see cref="EventAction"/> that represents subscription to any event of a fake.
+        /// </summary>
+        /// <returns>An <see cref="EventAction"/> that represents the action.</returns>
+        public static EventAction Add() => new AddAnyEventAction();
+
+        /// <summary>
+        /// Returns an <see cref="EventAction"/> that represents unsubscription from any event of a fake.
+        /// </summary>
+        /// <returns>An <see cref="EventAction"/> that represents the action.</returns>
+        public static EventAction Remove() => new RemoveAnyEventAction();
+
+        internal bool Matches(IFakeObjectCall call) => EventCall.TryGetEventCall(call, out var eventCall) && this.Matches(eventCall);
+
+        internal void WriteDescription(object fake, IOutputWriter writer) => this.WriteDescription(Fake.GetFakeManager(fake).FakeObjectDisplayName, writer);
+
+        private protected abstract bool Matches(EventCall eventCall);
+
+        private protected abstract void WriteDescription(string fakeDisplayName, IOutputWriter writer);
+
+        private class AddAnyEventAction : EventAction
+        {
+            private protected override bool Matches(EventCall eventCall) => eventCall.IsEventSubscription() && !eventCall.IsEventRaiser();
+
+            private protected override void WriteDescription(string fakeDisplayName, IOutputWriter writer) => writer.Write($"Subscription to any event of {fakeDisplayName}");
+        }
+
+        private class RemoveAnyEventAction : EventAction
+        {
+            private protected override bool Matches(EventCall eventCall) => eventCall.IsEventUnsubscription();
+
+            private protected override void WriteDescription(string fakeDisplayName, IOutputWriter writer) => writer.Write($"Unsubscription from any event of {fakeDisplayName}");
+        }
+
+        private class AddSpecificEventAction : EventAction
+        {
+            private readonly string eventName;
+
+            public AddSpecificEventAction(string eventName)
+            {
+                this.eventName = eventName;
+            }
+
+            private protected override bool Matches(EventCall eventCall) => eventCall.Event.Name == this.eventName && eventCall.IsEventSubscription() && !eventCall.IsEventRaiser();
+
+            private protected override void WriteDescription(string fakeDisplayName, IOutputWriter writer) => writer.Write($"Subscription to event '{this.eventName}' of {fakeDisplayName}");
+        }
+
+        private class RemoveSpecificEventAction : EventAction
+        {
+            private readonly string eventName;
+
+            public RemoveSpecificEventAction(string eventName)
+            {
+                this.eventName = eventName;
+            }
+
+            private protected override bool Matches(EventCall eventCall) => eventCall.Event.Name == this.eventName && eventCall.IsEventUnsubscription();
+
+            private protected override void WriteDescription(string fakeDisplayName, IOutputWriter writer) => writer.Write($"Unsubscription from event '{this.eventName}' of {fakeDisplayName}");
+        }
+    }
+}

--- a/src/FakeItEasy/ExceptionMessages.cs
+++ b/src/FakeItEasy/ExceptionMessages.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy
 {
     using System;
     using System.Text;
+    using FakeItEasy.Configuration;
     using FakeItEasy.Core;
 
     internal static class ExceptionMessages
@@ -62,6 +63,12 @@ namespace FakeItEasy
 
         public static string CannotRaiseEventWhenCallingBaseMethod =>
             "The fake cannot raise the event because event subscription calls the base implementation.";
+
+        public static string HandleEventsOnStrictFakes =>
+            $@"Strict fakes don't handle calls to event accessors unless configured to do so. If you want the fake to handle these calls, you can either:
+- configure the calls explicitly;
+- create the fake with the {nameof(StrictFakeOptions)}.{nameof(StrictFakeOptions.AllowEvents)} flag;
+- or use {nameof(Manage)}.{nameof(Manage.Event)}(eventName).{nameof(IManageEventConfiguration.Of)}(fake) or {nameof(Manage)}.{nameof(Manage.AllEvents)}.{nameof(IManageEventConfiguration.Of)}(fake) to enable automatic event management.";
 
         public static string WrongConstructorExpressionType(Type actualConstructorType, Type expectedConstructorType) =>
             $"Supplied constructor is for type {actualConstructorType}, but must be for {expectedConstructorType}.";

--- a/src/FakeItEasy/Fake.of.T.cs
+++ b/src/FakeItEasy/Fake.of.T.cs
@@ -105,6 +105,16 @@ namespace FakeItEasy
             return this.StartConfiguration.AnyCall();
         }
 
+        /// <summary>
+        /// Configures subscription to or unsubscription from an event of the fake object.
+        /// </summary>
+        /// <param name="action">An <see cref="EventAction"/> that represents the action to configure.</param>
+        /// <returns>A configuration object.</returns>
+        public IAnyCallConfigurationWithVoidReturnType CallsTo(EventAction action)
+        {
+            return this.AnyCall().MatchingEventAction(this.FakedObject, action);
+        }
+
         private static T CreateFake(Action<IFakeOptions<T>> optionsBuilder)
         {
             Guard.AgainstNull(optionsBuilder, nameof(optionsBuilder));

--- a/src/FakeItEasy/Manage.cs
+++ b/src/FakeItEasy/Manage.cs
@@ -28,7 +28,7 @@ namespace FakeItEasy
         {
             Guard.AgainstNull(fake, nameof(fake));
 
-            var handler = new EventCallHandler(Fake.GetFakeManager(fake));
+            var manager = Fake.GetFakeManager(fake);
             A.CallTo(fake)
                 .WithVoidReturnType()
                 .Where(
@@ -38,7 +38,7 @@ namespace FakeItEasy
                 {
                     if (EventCall.TryGetEventCall(call, out var eventCall))
                     {
-                        handler.HandleEventCall(eventCall);
+                        manager.EventCallHandler.HandleEventCall(eventCall);
                     }
                 });
         }

--- a/src/FakeItEasy/Manage.cs
+++ b/src/FakeItEasy/Manage.cs
@@ -1,0 +1,64 @@
+namespace FakeItEasy
+{
+    using System;
+    using FakeItEasy.Configuration;
+    using FakeItEasy.Core;
+
+    /// <summary>
+    /// Provides methods for managing fake events automatically.
+    /// </summary>
+    public static class Manage
+    {
+        /// <summary>
+        /// Specifies all events of the fake.
+        /// </summary>
+        /// <returns>A fluent configuration object to specify the fake.</returns>
+#pragma warning disable SA1623 // PropertySummaryDocumentationMustMatchAccessors
+        public static IManageEventConfiguration AllEvents => new ManageAllEventsConfiguration();
+#pragma warning restore SA1623 // PropertySummaryDocumentationMustMatchAccessors
+
+        /// <summary>
+        /// Specifies a named event of the fake.
+        /// </summary>
+        /// <param name="eventName">The name of the event.</param>
+        /// <returns>A fluent configuration object to specify the fake.</returns>
+        public static IManageEventConfiguration Event(string eventName) => new ManageNamedEventConfiguration(eventName);
+
+        private static void ManageEvents(object fake, Func<EventCall, bool> eventCallPredicate)
+        {
+            Guard.AgainstNull(fake, nameof(fake));
+
+            var handler = new EventCallHandler(Fake.GetFakeManager(fake));
+            A.CallTo(fake)
+                .WithVoidReturnType()
+                .Where(
+                    call => EventCall.TryGetEventCall(call, out var eventCall) && eventCallPredicate(eventCall),
+                    writer => { }) // This call spec will never be asserted, so we don't need to write a description
+                .Invokes(call =>
+                {
+                    if (EventCall.TryGetEventCall(call, out var eventCall))
+                    {
+                        handler.HandleEventCall(eventCall);
+                    }
+                });
+        }
+
+        private class ManageNamedEventConfiguration : IManageEventConfiguration
+        {
+            private readonly string eventName;
+
+            public ManageNamedEventConfiguration(string eventName)
+            {
+                Guard.AgainstNull(eventName, nameof(eventName));
+                this.eventName = eventName;
+            }
+
+            public void Of(object fake) => ManageEvents(fake, e => e.Event.Name == this.eventName);
+        }
+
+        private class ManageAllEventsConfiguration : IManageEventConfiguration
+        {
+            public void Of(object fake) => ManageEvents(fake, _ => true);
+        }
+    }
+}

--- a/src/FakeItEasy/StrictFakeOptions.cs
+++ b/src/FakeItEasy/StrictFakeOptions.cs
@@ -32,6 +32,11 @@ namespace FakeItEasy
         /// <summary>
         /// Calls to all methods inherited from <see cref="object"/> are allowed, and behave as if the fake weren't strict.
         /// </summary>
-        AllowObjectMethods = AllowEquals | AllowGetHashCode | AllowToString
+        AllowObjectMethods = AllowEquals | AllowGetHashCode | AllowToString,
+
+        /// <summary>
+        /// Calls to event accessors are allowed, and behave as if the fake weren't not strict.
+        /// </summary>
+        AllowEvents = 8
     }
 }

--- a/tests/FakeItEasy.Specs/EventActionSpecs.cs
+++ b/tests/FakeItEasy.Specs/EventActionSpecs.cs
@@ -1,0 +1,216 @@
+namespace FakeItEasy.Specs
+{
+    using System;
+    using FluentAssertions;
+    using Xbehave;
+
+    public class EventActionSpecs
+    {
+        public interface IFoo
+        {
+            event EventHandler Bar;
+
+            event EventHandler Baz;
+        }
+
+        [Scenario]
+        public void AddSpecificEvent(IFoo fake, EventHandler barHandler, EventHandler bazHandler, EventHandler handlers)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And event handlers for Bar and Baz"
+                .x(() => (barHandler, bazHandler) = (A.Fake<EventHandler>(), A.Fake<EventHandler>()));
+
+            "And subscription to the Bar event of the fake is configured to update a delegate"
+                .x(() => A.CallTo(fake, EventAction.Add(nameof(IFoo.Bar))).Invokes((EventHandler h) => handlers += h));
+
+            "When the handler for Bar is subscribed to the Bar event"
+                .x(() => fake.Bar += barHandler);
+
+            "And the handler for Baz is subscribed to the Baz event"
+                .x(() => fake.Baz += bazHandler);
+
+            "Then the handler list contains the handler for Bar"
+                .x(() => handlers.GetInvocationList().Should().Contain(barHandler));
+
+            "And the handler list doesn't contain the handler for Baz"
+                .x(() => handlers.GetInvocationList().Should().NotContain(bazHandler));
+        }
+
+        [Scenario]
+        public void AddAnyEvent(IFoo fake, EventHandler barHandler, EventHandler bazHandler, EventHandler handlers)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And event handlers for Bar and Baz"
+                .x(() => (barHandler, bazHandler) = (A.Fake<EventHandler>(), A.Fake<EventHandler>()));
+
+            "And subscription to any event of the fake is configured to update a delegate"
+                .x(() => A.CallTo(fake, EventAction.Add()).Invokes((EventHandler h) => handlers += h));
+
+            "When the handler for Bar is subscribed to the Bar event"
+                .x(() => fake.Bar += barHandler);
+
+            "And the handler for Baz is subscribed to the Baz event"
+                .x(() => fake.Baz += bazHandler);
+
+            "Then the handler list contains the handler for Bar"
+                .x(() => handlers.GetInvocationList().Should().Contain(barHandler));
+
+            "And the handler list contains the handler for Baz"
+                .x(() => handlers.GetInvocationList().Should().Contain(bazHandler));
+        }
+
+        [Scenario]
+        public void RemoveSpecificEvent(IFoo fake, EventHandler barHandler, EventHandler bazHandler, EventHandler removedHandlers)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And event handlers for Bar and Baz"
+                .x(() => (barHandler, bazHandler) = (A.Fake<EventHandler>(), A.Fake<EventHandler>()));
+
+            "And unsubscription from the Bar event of the fake is configured to update a delegate"
+                .x(() => A.CallTo(fake, EventAction.Remove(nameof(IFoo.Bar))).Invokes((EventHandler h) => removedHandlers += h));
+
+            "When the handler for Bar is unsubscribed from the Bar event"
+                .x(() => fake.Bar -= barHandler);
+
+            "And the handler for Baz is unsubscribed from the Baz event"
+                .x(() => fake.Baz -= bazHandler);
+
+            "Then the removed handler list contains the handler for Bar"
+                .x(() => removedHandlers.GetInvocationList().Should().Contain(barHandler));
+
+            "And the removed handler list doesn't contain the handler for Baz"
+                .x(() => removedHandlers.GetInvocationList().Should().NotContain(bazHandler));
+        }
+
+        [Scenario]
+        public void RemoveAnyEvent(IFoo fake, EventHandler barHandler, EventHandler bazHandler, EventHandler removedHandlers)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And event handlers for Bar and Baz"
+                .x(() => (barHandler, bazHandler) = (A.Fake<EventHandler>(), A.Fake<EventHandler>()));
+
+            "And unsubscription from any event of the fake is configured to update a delegate"
+                .x(() => A.CallTo(fake, EventAction.Remove()).Invokes((EventHandler h) => removedHandlers += h));
+
+            "When the handler for Bar is unsubscribed from the Bar event"
+                .x(() => fake.Bar -= barHandler);
+
+            "And the handler for Baz is unsubscribed from the Baz event"
+                .x(() => fake.Baz -= bazHandler);
+
+            "Then the removed handler list contains the handler for Bar"
+                .x(() => removedHandlers.GetInvocationList().Should().Contain(barHandler));
+
+            "And the removed handler list contains the handler for Baz"
+                .x(() => removedHandlers.GetInvocationList().Should().Contain(bazHandler));
+        }
+
+        [Scenario]
+        public void UnnaturalFakeAddSpecificEvent(Fake<IFoo> fake, EventHandler barHandler, EventHandler bazHandler, EventHandler handlers)
+        {
+            "Given a fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And event handlers for Bar and Baz"
+                .x(() => (barHandler, bazHandler) = (A.Fake<EventHandler>(), A.Fake<EventHandler>()));
+
+            "And subscription to the Bar event of the fake is configured to update a delegate"
+                .x(() => fake.CallsTo(EventAction.Add(nameof(IFoo.Bar))).Invokes((EventHandler h) => handlers += h));
+
+            "When the handler for Bar is subscribed to the Bar event"
+                .x(() => fake.FakedObject.Bar += barHandler);
+
+            "And the handler for Baz is subscribed to the Baz event"
+                .x(() => fake.FakedObject.Baz += bazHandler);
+
+            "Then the handler list contains the handler for Bar"
+                .x(() => handlers.GetInvocationList().Should().Contain(barHandler));
+
+            "And the handler list doesn't contain the handler for Baz"
+                .x(() => handlers.GetInvocationList().Should().NotContain(bazHandler));
+        }
+
+        [Scenario]
+        public void UnnaturalFakeAddAnyEvent(Fake<IFoo> fake, EventHandler barHandler, EventHandler bazHandler, EventHandler handlers)
+        {
+            "Given a fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And event handlers for Bar and Baz"
+                .x(() => (barHandler, bazHandler) = (A.Fake<EventHandler>(), A.Fake<EventHandler>()));
+
+            "And subscription to any event of the fake is configured to update a delegate"
+                .x(() => fake.CallsTo(EventAction.Add()).Invokes((EventHandler h) => handlers += h));
+
+            "When the handler for Bar is subscribed to the Bar event"
+                .x(() => fake.FakedObject.Bar += barHandler);
+
+            "And the handler for Baz is subscribed to the Baz event"
+                .x(() => fake.FakedObject.Baz += bazHandler);
+
+            "Then the handler list contains the handler for Bar"
+                .x(() => handlers.GetInvocationList().Should().Contain(barHandler));
+
+            "And the handler list contains the handler for Baz"
+                .x(() => handlers.GetInvocationList().Should().Contain(bazHandler));
+        }
+
+        [Scenario]
+        public void UnnaturalFakeRemoveSpecificEvent(Fake<IFoo> fake, EventHandler barHandler, EventHandler bazHandler, EventHandler removedHandlers)
+        {
+            "Given a fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And event handlers for Bar and Baz"
+                .x(() => (barHandler, bazHandler) = (A.Fake<EventHandler>(), A.Fake<EventHandler>()));
+
+            "And unsubscription from the Bar event of the fake is configured to update a delegate"
+                .x(() => fake.CallsTo(EventAction.Remove(nameof(IFoo.Bar))).Invokes((EventHandler h) => removedHandlers += h));
+
+            "When the handler for Bar is unsubscribed from the Bar event"
+                .x(() => fake.FakedObject.Bar -= barHandler);
+
+            "And the handler for Baz is unsubscribed from the Baz event"
+                .x(() => fake.FakedObject.Baz -= bazHandler);
+
+            "Then the removed handler list contains the handler for Bar"
+                .x(() => removedHandlers.GetInvocationList().Should().Contain(barHandler));
+
+            "And the removed handler list doesn't contain the handler for Baz"
+                .x(() => removedHandlers.GetInvocationList().Should().NotContain(bazHandler));
+        }
+
+        [Scenario]
+        public void UnnaturalFakeRemoveAnyEvent(Fake<IFoo> fake, EventHandler barHandler, EventHandler bazHandler, EventHandler removedHandlers)
+        {
+            "Given a fake"
+                .x(() => fake = new Fake<IFoo>());
+
+            "And event handlers for Bar and Baz"
+                .x(() => (barHandler, bazHandler) = (A.Fake<EventHandler>(), A.Fake<EventHandler>()));
+
+            "And unsubscription from any event of the fake is configured to update a delegate"
+                .x(() => fake.CallsTo(EventAction.Remove()).Invokes((EventHandler h) => removedHandlers += h));
+
+            "When the handler for Bar is unsubscribed from the Bar event"
+                .x(() => fake.FakedObject.Bar -= barHandler);
+
+            "And the handler for Baz is unsubscribed from the Baz event"
+                .x(() => fake.FakedObject.Baz -= bazHandler);
+
+            "Then the removed handler list contains the handler for Bar"
+                .x(() => removedHandlers.GetInvocationList().Should().Contain(barHandler));
+
+            "And the removed handler list contains the handler for Baz"
+                .x(() => removedHandlers.GetInvocationList().Should().Contain(bazHandler));
+        }
+    }
+}

--- a/tests/FakeItEasy.Specs/ManageEventsSpecs.cs
+++ b/tests/FakeItEasy.Specs/ManageEventsSpecs.cs
@@ -1,0 +1,115 @@
+namespace FakeItEasy.Specs
+{
+    using System;
+    using FakeItEasy.Tests.TestHelpers;
+    using FluentAssertions;
+    using Xbehave;
+    using Xunit;
+
+    public class ManageEventsSpecs
+    {
+        public interface IFoo
+        {
+            event EventHandler<int> Bar;
+
+            event EventHandler<int> Baz;
+        }
+
+        [Scenario]
+        public void ManageSpecificEvent(IFoo fake, EventHandler<int> handler)
+        {
+            "Given a strict fake"
+                .x(() => fake = A.Fake<IFoo>(o => o.Strict()));
+
+            "And an event handler"
+                .x(() => handler = A.Fake<EventHandler<int>>());
+
+            "And the fake is configured to manage the Bar event"
+                .x(() => Manage.Event(nameof(IFoo.Bar)).Of(fake));
+
+            "When the handler is subscribed to the Bar event"
+                .x(() => fake.Bar += handler);
+
+            "And the Bar event is raised using Raise"
+                .x(() => fake.Bar += Raise.With(1));
+
+            "Then the handler is called"
+                .x(() => A.CallTo(() => handler(fake, 1)).MustHaveHappened());
+        }
+
+        [Scenario]
+        public void ManageSpecificEventUnsubscribe(IFoo fake, EventHandler<int> handler)
+        {
+            "Given a strict fake"
+                .x(() => fake = A.Fake<IFoo>(o => o.Strict()));
+
+            "And an event handler"
+                .x(() => handler = A.Fake<EventHandler<int>>());
+
+            "And the fake is configured to manage the Bar event"
+                .x(() => Manage.Event(nameof(IFoo.Bar)).Of(fake));
+
+            "When the handler is subscribed to the Bar event"
+                .x(() => fake.Bar += handler);
+
+            "And the handler is unsubscribed from the Bar event"
+                .x(() => fake.Bar -= handler);
+
+            "And the Bar event is raised using Raise"
+                .x(() => fake.Bar += Raise.With(1));
+
+            "Then the handler is not called"
+                .x(() => A.CallTo(handler).MustNotHaveHappened());
+        }
+
+        [Scenario]
+        public void ManageSpecificEventDoesntHandlerOtherEvents(IFoo fake, EventHandler<int> handler, Exception exception)
+        {
+            "Given a strict fake"
+                .x(() => fake = A.Fake<IFoo>(o => o.Strict()));
+
+            "And an event handler"
+                .x(() => handler = A.Fake<EventHandler<int>>());
+
+            "And the fake is configured to manage the Bar event"
+                .x(() => Manage.Event(nameof(IFoo.Bar)).Of(fake));
+
+            "When the handler is subscribed to the Baz event"
+                .x(() => exception = Record.Exception(() => fake.Baz += handler));
+
+            "Then it throws an ExpectationException"
+                .x(() => exception.Should().BeAnExceptionOfType<ExpectationException>());
+        }
+
+        [Scenario]
+        public void ManageAllEvents(IFoo fake, EventHandler<int> barHandler, EventHandler<int> bazHandler)
+        {
+            "Given a strict fake"
+                .x(() => fake = A.Fake<IFoo>(o => o.Strict()));
+
+            "And event handlers for Bar and Baz"
+                .x(() => (barHandler, bazHandler) = (A.Fake<EventHandler<int>>(), A.Fake<EventHandler<int>>()));
+
+            "And the fake is configured to manage any event"
+                .x(() => Manage.AllEvents.Of(fake));
+
+            "When the handler for Bar is subscribed to the Bar event"
+                .x(() => fake.Bar += barHandler);
+
+            "And the handler for Baz is subscribed to the Baz event"
+                .x(() => fake.Baz += bazHandler);
+
+            "And the Bar event is raised using Raise"
+                .x(() => fake.Bar += Raise.With(1));
+
+            "And the Baz event is raised using Raise"
+                .x(() => fake.Baz += Raise.With(2));
+
+            "Then the handler for Bar is called"
+                .x(() => A.CallTo(() => barHandler(fake, 1)).MustHaveHappened());
+
+            "And the handler for Baz is called"
+                .x(() => A.CallTo(() => bazHandler(fake, 2)).MustHaveHappened());
+        }
+    }
+}

--- a/tests/FakeItEasy.Specs/ManageEventsSpecs.cs
+++ b/tests/FakeItEasy.Specs/ManageEventsSpecs.cs
@@ -111,5 +111,30 @@ namespace FakeItEasy.Specs
             "And the handler for Baz is called"
                 .x(() => A.CallTo(() => bazHandler(fake, 2)).MustHaveHappened());
         }
+
+        [Scenario]
+        public void MultipleCallsToManageEvent(IFoo fake, EventHandler<int> handler)
+        {
+            "Given a strict fake"
+                .x(() => fake = A.Fake<IFoo>(o => o.Strict()));
+
+            "And an event handler"
+                .x(() => handler = A.Fake<EventHandler<int>>());
+
+            "When the fake is configured to manage the Bar event"
+                .x(() => Manage.Event(nameof(IFoo.Bar)).Of(fake));
+
+            "And the handler is subscribed to the Bar event"
+                .x(() => fake.Bar += handler);
+
+            "And the fake is configured again to manage the Bar event"
+                .x(() => Manage.Event(nameof(IFoo.Bar)).Of(fake));
+
+            "And the Bar event is raised using Raise"
+                .x(() => fake.Bar += Raise.With(1));
+
+            "Then the handler is called"
+                .x(() => A.CallTo(() => handler(fake, 1)).MustHaveHappened());
+        }
     }
 }

--- a/tests/FakeItEasy.Specs/StrictFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/StrictFakeSpecs.cs
@@ -13,6 +13,8 @@ namespace FakeItEasy.Specs
             void DoIt(Guid id);
 
             Guid MakeIt(string name);
+
+            event EventHandler Event;
         }
 
         [Scenario]
@@ -135,6 +137,46 @@ namespace FakeItEasy.Specs
                     () => fake.ToString()));
 
             "Then it should throw an exception"
+                .x(() => exception.Should().BeAnExceptionOfType<ExpectationException>());
+        }
+
+        [Scenario]
+        public static void EventsManaged(IMyInterface fake, EventHandler handler)
+        {
+            "Given a strict fake that manages events"
+                .x(() => fake = A.Fake<IMyInterface>(options =>
+                    options.Strict(StrictFakeOptions.AllowEvents)));
+
+            "And an event handler"
+                .x(() => handler = A.Fake<EventHandler>());
+
+            "When the handler is subscribed to the fake's event"
+                .x(() => fake.Event += handler);
+
+            "And the event is raised using Raise"
+                .x(() => fake.Event += Raise.WithEmpty());
+
+            "Then the handler is called"
+                .x(() => A.CallTo(handler).MustHaveHappened());
+        }
+
+        [Scenario]
+        public static void EventsNotManaged(
+            IMyInterface fake,
+            EventHandler handler,
+            Exception exception)
+        {
+            "Given a strict fake that doesn't manages events"
+                .x(() => fake = A.Fake<IMyInterface>(options =>
+                    options.Strict(StrictFakeOptions.None)));
+
+            "And an event handler"
+                .x(() => handler = A.Fake<EventHandler>());
+
+            "When the handler is subscribed to the fake's event"
+                .x(() => exception = Record.Exception(() => fake.Event += handler));
+
+            "Then an exception is thrown"
                 .x(() => exception.Should().BeAnExceptionOfType<ExpectationException>());
         }
 

--- a/tests/FakeItEasy.Specs/StrictFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/StrictFakeSpecs.cs
@@ -178,6 +178,9 @@ namespace FakeItEasy.Specs
 
             "Then an exception is thrown"
                 .x(() => exception.Should().BeAnExceptionOfType<ExpectationException>());
+
+            "And the exception message directs the user to Manage.Event"
+                .x(() => exception.Message.Should().Contain("Manage.Event"));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
@@ -362,6 +362,7 @@ namespace FakeItEasy
         AllowGetHashCode = 2,
         AllowToString = 4,
         AllowObjectMethods = 7,
+        AllowEvents = 8,
     }
     public abstract class Times
     {

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
@@ -281,6 +281,11 @@ namespace FakeItEasy
         FakeItEasy.IOutputWriter Write(string value);
         FakeItEasy.IOutputWriter WriteArgumentValue(object? value);
     }
+    public static class Manage
+    {
+        public static FakeItEasy.Configuration.IManageEventConfiguration AllEvents { get; }
+        public static FakeItEasy.Configuration.IManageEventConfiguration Event(string eventName) { }
+    }
     public static class OutAndRefParametersConfigurationExtensions
     {
         public static FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> AssignsOutAndRefParameters<TInterface>(this FakeItEasy.Configuration.IOutAndRefParametersConfiguration<TInterface> configuration, params object?[] values) { }
@@ -446,6 +451,10 @@ namespace FakeItEasy.Configuration
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6>(System.Func<T1, T2, T3, T4, T5, T6, System.Exception> exceptionFactory);
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6, T7>(System.Func<T1, T2, T3, T4, T5, T6, T7, System.Exception> exceptionFactory);
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(System.Func<T1, T2, T3, T4, T5, T6, T7, T8, System.Exception> exceptionFactory);
+    }
+    public interface IManageEventConfiguration
+    {
+        void Of(object fake);
     }
     public interface IOrderableCallAssertion : FakeItEasy.IHideObjectMembers
     {

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.approved.txt
@@ -12,6 +12,7 @@ namespace FakeItEasy
     {
         public static FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallTo(System.Linq.Expressions.Expression<System.Action> callSpecification) { }
         public static FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified CallTo(object fake) { }
+        public static FakeItEasy.Configuration.IAnyCallConfigurationWithVoidReturnType CallTo(object fake, FakeItEasy.EventAction action) { }
         public static FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<T> CallTo<T>(System.Linq.Expressions.Expression<System.Func<T>> callSpecification) { }
         public static FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallToSet<TValue>(System.Linq.Expressions.Expression<System.Func<TValue>> propertySpecification) { }
         public static System.Collections.Generic.IList<T> CollectionOfDummy<T>(int numberOfDummies) { }
@@ -169,6 +170,13 @@ namespace FakeItEasy
         protected abstract T Create();
         public object? Create(System.Type type) { }
     }
+    public abstract class EventAction
+    {
+        public static FakeItEasy.EventAction Add() { }
+        public static FakeItEasy.EventAction Add(string eventName) { }
+        public static FakeItEasy.EventAction Remove() { }
+        public static FakeItEasy.EventAction Remove(string eventName) { }
+    }
     public static class ExceptionThrowerConfigurationExtensions
     {
         public static FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<TInterface>(this FakeItEasy.Configuration.IExceptionThrowerConfiguration<TInterface> configuration, System.Exception exception) { }
@@ -225,6 +233,7 @@ namespace FakeItEasy
         public T FakedObject { get; }
         public System.Collections.Generic.IEnumerable<FakeItEasy.Core.ICompletedFakeObjectCall> RecordedCalls { get; }
         public FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified AnyCall() { }
+        public FakeItEasy.Configuration.IAnyCallConfigurationWithVoidReturnType CallsTo(FakeItEasy.EventAction action) { }
         public FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallsTo(System.Linq.Expressions.Expression<System.Action<T>> callSpecification) { }
         public FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<TMember> CallsTo<TMember>(System.Linq.Expressions.Expression<System.Func<T, TMember>> callSpecification) { }
         public FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallsToSet<TValue>(System.Linq.Expressions.Expression<System.Func<T, TValue>> propertySpecification) { }

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.approved.txt
@@ -281,6 +281,11 @@ namespace FakeItEasy
         FakeItEasy.IOutputWriter Write(string value);
         FakeItEasy.IOutputWriter WriteArgumentValue(object? value);
     }
+    public static class Manage
+    {
+        public static FakeItEasy.Configuration.IManageEventConfiguration AllEvents { get; }
+        public static FakeItEasy.Configuration.IManageEventConfiguration Event(string eventName) { }
+    }
     public static class OutAndRefParametersConfigurationExtensions
     {
         public static FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> AssignsOutAndRefParameters<TInterface>(this FakeItEasy.Configuration.IOutAndRefParametersConfiguration<TInterface> configuration, params object?[] values) { }
@@ -485,6 +490,10 @@ namespace FakeItEasy.Configuration
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6>(System.Func<T1, T2, T3, T4, T5, T6, System.Exception> exceptionFactory);
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6, T7>(System.Func<T1, T2, T3, T4, T5, T6, T7, System.Exception> exceptionFactory);
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(System.Func<T1, T2, T3, T4, T5, T6, T7, T8, System.Exception> exceptionFactory);
+    }
+    public interface IManageEventConfiguration
+    {
+        void Of(object fake);
     }
     public interface IOrderableCallAssertion : FakeItEasy.IHideObjectMembers
     {

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.approved.txt
@@ -362,6 +362,7 @@ namespace FakeItEasy
         AllowGetHashCode = 2,
         AllowToString = 4,
         AllowObjectMethods = 7,
+        AllowEvents = 8,
     }
     public abstract class Times
     {

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.approved.txt
@@ -12,6 +12,7 @@ namespace FakeItEasy
     {
         public static FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallTo(System.Linq.Expressions.Expression<System.Action> callSpecification) { }
         public static FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified CallTo(object fake) { }
+        public static FakeItEasy.Configuration.IAnyCallConfigurationWithVoidReturnType CallTo(object fake, FakeItEasy.EventAction action) { }
         public static FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<T> CallTo<T>(System.Linq.Expressions.Expression<System.Func<T>> callSpecification) { }
         public static FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallToSet<TValue>(System.Linq.Expressions.Expression<System.Func<TValue>> propertySpecification) { }
         public static System.Collections.Generic.IList<T> CollectionOfDummy<T>(int numberOfDummies) { }
@@ -169,6 +170,13 @@ namespace FakeItEasy
         protected abstract T Create();
         public object? Create(System.Type type) { }
     }
+    public abstract class EventAction
+    {
+        public static FakeItEasy.EventAction Add() { }
+        public static FakeItEasy.EventAction Add(string eventName) { }
+        public static FakeItEasy.EventAction Remove() { }
+        public static FakeItEasy.EventAction Remove(string eventName) { }
+    }
     public static class ExceptionThrowerConfigurationExtensions
     {
         public static FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<TInterface>(this FakeItEasy.Configuration.IExceptionThrowerConfiguration<TInterface> configuration, System.Exception exception) { }
@@ -225,6 +233,7 @@ namespace FakeItEasy
         public T FakedObject { get; }
         public System.Collections.Generic.IEnumerable<FakeItEasy.Core.ICompletedFakeObjectCall> RecordedCalls { get; }
         public FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified AnyCall() { }
+        public FakeItEasy.Configuration.IAnyCallConfigurationWithVoidReturnType CallsTo(FakeItEasy.EventAction action) { }
         public FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallsTo(System.Linq.Expressions.Expression<System.Action<T>> callSpecification) { }
         public FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<TMember> CallsTo<TMember>(System.Linq.Expressions.Expression<System.Func<T, TMember>> callSpecification) { }
         public FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallsToSet<TValue>(System.Linq.Expressions.Expression<System.Func<T, TValue>> propertySpecification) { }

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
@@ -362,6 +362,7 @@ namespace FakeItEasy
         AllowGetHashCode = 2,
         AllowToString = 4,
         AllowObjectMethods = 7,
+        AllowEvents = 8,
     }
     public abstract class Times
     {

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
@@ -281,6 +281,11 @@ namespace FakeItEasy
         FakeItEasy.IOutputWriter Write(string value);
         FakeItEasy.IOutputWriter WriteArgumentValue(object? value);
     }
+    public static class Manage
+    {
+        public static FakeItEasy.Configuration.IManageEventConfiguration AllEvents { get; }
+        public static FakeItEasy.Configuration.IManageEventConfiguration Event(string eventName) { }
+    }
     public static class OutAndRefParametersConfigurationExtensions
     {
         public static FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> AssignsOutAndRefParameters<TInterface>(this FakeItEasy.Configuration.IOutAndRefParametersConfiguration<TInterface> configuration, params object?[] values) { }
@@ -446,6 +451,10 @@ namespace FakeItEasy.Configuration
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6>(System.Func<T1, T2, T3, T4, T5, T6, System.Exception> exceptionFactory);
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6, T7>(System.Func<T1, T2, T3, T4, T5, T6, T7, System.Exception> exceptionFactory);
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(System.Func<T1, T2, T3, T4, T5, T6, T7, T8, System.Exception> exceptionFactory);
+    }
+    public interface IManageEventConfiguration
+    {
+        void Of(object fake);
     }
     public interface IOrderableCallAssertion : FakeItEasy.IHideObjectMembers
     {

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.approved.txt
@@ -12,6 +12,7 @@ namespace FakeItEasy
     {
         public static FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallTo(System.Linq.Expressions.Expression<System.Action> callSpecification) { }
         public static FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified CallTo(object fake) { }
+        public static FakeItEasy.Configuration.IAnyCallConfigurationWithVoidReturnType CallTo(object fake, FakeItEasy.EventAction action) { }
         public static FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<T> CallTo<T>(System.Linq.Expressions.Expression<System.Func<T>> callSpecification) { }
         public static FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallToSet<TValue>(System.Linq.Expressions.Expression<System.Func<TValue>> propertySpecification) { }
         public static System.Collections.Generic.IList<T> CollectionOfDummy<T>(int numberOfDummies) { }
@@ -169,6 +170,13 @@ namespace FakeItEasy
         protected abstract T Create();
         public object? Create(System.Type type) { }
     }
+    public abstract class EventAction
+    {
+        public static FakeItEasy.EventAction Add() { }
+        public static FakeItEasy.EventAction Add(string eventName) { }
+        public static FakeItEasy.EventAction Remove() { }
+        public static FakeItEasy.EventAction Remove(string eventName) { }
+    }
     public static class ExceptionThrowerConfigurationExtensions
     {
         public static FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<TInterface>(this FakeItEasy.Configuration.IExceptionThrowerConfiguration<TInterface> configuration, System.Exception exception) { }
@@ -225,6 +233,7 @@ namespace FakeItEasy
         public T FakedObject { get; }
         public System.Collections.Generic.IEnumerable<FakeItEasy.Core.ICompletedFakeObjectCall> RecordedCalls { get; }
         public FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified AnyCall() { }
+        public FakeItEasy.Configuration.IAnyCallConfigurationWithVoidReturnType CallsTo(FakeItEasy.EventAction action) { }
         public FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallsTo(System.Linq.Expressions.Expression<System.Action<T>> callSpecification) { }
         public FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<TMember> CallsTo<TMember>(System.Linq.Expressions.Expression<System.Func<T, TMember>> callSpecification) { }
         public FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallsToSet<TValue>(System.Linq.Expressions.Expression<System.Func<T, TValue>> propertySpecification) { }

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
@@ -281,6 +281,11 @@ namespace FakeItEasy
         FakeItEasy.IOutputWriter Write(string value);
         FakeItEasy.IOutputWriter WriteArgumentValue(object? value);
     }
+    public static class Manage
+    {
+        public static FakeItEasy.Configuration.IManageEventConfiguration AllEvents { get; }
+        public static FakeItEasy.Configuration.IManageEventConfiguration Event(string eventName) { }
+    }
     public static class OutAndRefParametersConfigurationExtensions
     {
         public static FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> AssignsOutAndRefParameters<TInterface>(this FakeItEasy.Configuration.IOutAndRefParametersConfiguration<TInterface> configuration, params object?[] values) { }
@@ -485,6 +490,10 @@ namespace FakeItEasy.Configuration
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6>(System.Func<T1, T2, T3, T4, T5, T6, System.Exception> exceptionFactory);
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6, T7>(System.Func<T1, T2, T3, T4, T5, T6, T7, System.Exception> exceptionFactory);
         FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(System.Func<T1, T2, T3, T4, T5, T6, T7, T8, System.Exception> exceptionFactory);
+    }
+    public interface IManageEventConfiguration
+    {
+        void Of(object fake);
     }
     public interface IOrderableCallAssertion : FakeItEasy.IHideObjectMembers
     {

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
@@ -362,6 +362,7 @@ namespace FakeItEasy
         AllowGetHashCode = 2,
         AllowToString = 4,
         AllowObjectMethods = 7,
+        AllowEvents = 8,
     }
     public abstract class Times
     {

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.approved.txt
@@ -12,6 +12,7 @@ namespace FakeItEasy
     {
         public static FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallTo(System.Linq.Expressions.Expression<System.Action> callSpecification) { }
         public static FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified CallTo(object fake) { }
+        public static FakeItEasy.Configuration.IAnyCallConfigurationWithVoidReturnType CallTo(object fake, FakeItEasy.EventAction action) { }
         public static FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<T> CallTo<T>(System.Linq.Expressions.Expression<System.Func<T>> callSpecification) { }
         public static FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallToSet<TValue>(System.Linq.Expressions.Expression<System.Func<TValue>> propertySpecification) { }
         public static System.Collections.Generic.IList<T> CollectionOfDummy<T>(int numberOfDummies) { }
@@ -169,6 +170,13 @@ namespace FakeItEasy
         protected abstract T Create();
         public object? Create(System.Type type) { }
     }
+    public abstract class EventAction
+    {
+        public static FakeItEasy.EventAction Add() { }
+        public static FakeItEasy.EventAction Add(string eventName) { }
+        public static FakeItEasy.EventAction Remove() { }
+        public static FakeItEasy.EventAction Remove(string eventName) { }
+    }
     public static class ExceptionThrowerConfigurationExtensions
     {
         public static FakeItEasy.Configuration.IAfterCallConfiguredConfiguration<TInterface> Throws<TInterface>(this FakeItEasy.Configuration.IExceptionThrowerConfiguration<TInterface> configuration, System.Exception exception) { }
@@ -225,6 +233,7 @@ namespace FakeItEasy
         public T FakedObject { get; }
         public System.Collections.Generic.IEnumerable<FakeItEasy.Core.ICompletedFakeObjectCall> RecordedCalls { get; }
         public FakeItEasy.Configuration.IAnyCallConfigurationWithNoReturnTypeSpecified AnyCall() { }
+        public FakeItEasy.Configuration.IAnyCallConfigurationWithVoidReturnType CallsTo(FakeItEasy.EventAction action) { }
         public FakeItEasy.Configuration.IVoidArgumentValidationConfiguration CallsTo(System.Linq.Expressions.Expression<System.Action<T>> callSpecification) { }
         public FakeItEasy.Configuration.IReturnValueArgumentValidationConfiguration<TMember> CallsTo<TMember>(System.Linq.Expressions.Expression<System.Func<T, TMember>> callSpecification) { }
         public FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration<TValue> CallsToSet<TValue>(System.Linq.Expressions.Expression<System.Func<T, TValue>> propertySpecification) { }


### PR DESCRIPTION
Fixes #1841 

This PR contains 3 separate (but related) features. We might keep all of them, or none...

07e9d4a4: Update .editorconfig to add C# style rules. Not related to the rest of this PR, but I was getting tired of fighting Visual Studio defaults... I can move it to a separate PR if you prefer.

f4a2950b, 84d77c8d, 297ea48e, 27d2d1cf : API to simplify configuration of event accessors

6c6758cc, df35a992, 6651ce52, b8f82063 : API to enable default event behavior on a fake

a3d91e0c, 13935d3e, d560a346: add StrictFakeOptions.ManageEvents

EDIT: added two more commits:
- 3b4b1e23: add a more detailed exception message when fake accessors are called on a strict fake
- 6bed3ed4: use a single EventCallHandler per fake so that multiple calls to `Manage.Event` don't cause unexpected behavior.

I'll reorder the commits before merge, but for now I'm leaving them as they are to avoid changing the SHA1s of the other commits...