### PR TITLE
Re-enable and fix integration test in net461

### DIFF
--- a/tests/FakeItEasy.IntegrationTests/FakeItEasy.IntegrationTests.csproj
+++ b/tests/FakeItEasy.IntegrationTests/FakeItEasy.IntegrationTests.csproj
@@ -18,7 +18,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CONTAINS_COMPARISONTYPE;REQUIRES_NETSTANDARD_REFERENCE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>$(DefineConstants);THROWS_ON_DUPLICATE_ASSEMBLY_LOAD</DefineConstants>
   </PropertyGroup>
 

--- a/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/TypeCatalogueTests.cs
@@ -31,9 +31,8 @@ namespace FakeItEasy.IntegrationTests
         public void Should_warn_of_duplicate_input_assemblies_with_different_paths()
         {
             // Arrange
-            var expectedMessageFormat =
-@"*Warning: FakeItEasy failed to load assembly '*{0}' while scanning for extension points. Any IArgumentValueFormatters, IDummyFactories, and IFakeOptionsBuilders in that assembly will not be available.*";
-            var expectedMessage = string.Format(expectedMessageFormat, this.externalAssemblyGenerator.AssemblyCopyPath);
+            var expectedMessage =
+@"*Warning: FakeItEasy failed to load assembly 'FakeItEasy.ExtensionPoints.External*' while scanning for extension points. Any IArgumentValueFormatters, IDummyFactories, and IFakeOptionsBuilders in that assembly will not be available.*";
 
             var catalogue = new TypeCatalogue();
 


### PR DESCRIPTION
Completely unrelated to other ongoing work. I noticed that this test was skipped for all frameworks, but it was supposed to run for net461. This was due to an incorrect TFM in a MSBuild condition.

In addition, just re-enabling the test made it fail, because the exception message no longer contains the path to the assembly, it just contains its full assembly name.