### PR TITLE
Optimize method comparison

### DIFF
--- a/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.ObjectMemberRule.cs
@@ -1,6 +1,6 @@
 namespace FakeItEasy.Core
 {
-    using static FakeItEasy.ObjectMembers;
+    using static FakeItEasy.ObjectMethod;
 
     /// <content>Object member rule.</content>
     public partial class FakeManager
@@ -9,60 +9,39 @@ namespace FakeItEasy.Core
             : SharedFakeObjectCallRule
         {
             public override bool IsApplicableTo(IFakeObjectCall fakeObjectCall) =>
-                fakeObjectCall.Method.HasSameBaseMethodAs(EqualsMethod) ||
-                fakeObjectCall.Method.HasSameBaseMethodAs(ToStringMethod) ||
-                fakeObjectCall.Method.HasSameBaseMethodAs(GetHashCodeMethod);
+                fakeObjectCall.Method.GetObjectMethod() != None;
 
             public override void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
                 var fakeManager = Fake.GetFakeManager(fakeObjectCall.FakedObject);
-                if (TryHandleToString(fakeObjectCall, fakeManager))
+                switch (fakeObjectCall.Method.GetObjectMethod())
                 {
-                    return;
-                }
+                    case ToStringMethod:
+                        HandleToString(fakeObjectCall, fakeManager);
+                        return;
 
-                if (TryHandleGetHashCode(fakeObjectCall, fakeManager))
-                {
-                    return;
-                }
+                    case GetHashCodeMethod:
+                        HandleGetHashCode(fakeObjectCall, fakeManager);
+                        return;
 
-                if (TryHandleEquals(fakeObjectCall, fakeManager))
-                {
-                    return;
+                    case EqualsMethod:
+                        HandleEquals(fakeObjectCall, fakeManager);
+                        return;
                 }
             }
 
-            private static bool TryHandleGetHashCode(IInterceptedFakeObjectCall fakeObjectCall, FakeManager fakeManager)
+            private static void HandleGetHashCode(IInterceptedFakeObjectCall fakeObjectCall, FakeManager fakeManager)
             {
-                if (!fakeObjectCall.Method.HasSameBaseMethodAs(GetHashCodeMethod))
-                {
-                    return false;
-                }
-
                 fakeObjectCall.SetReturnValue(fakeManager.GetHashCode());
-
-                return true;
             }
 
-            private static bool TryHandleToString(IInterceptedFakeObjectCall fakeObjectCall, FakeManager fakeManager)
+            private static void HandleToString(IInterceptedFakeObjectCall fakeObjectCall, FakeManager fakeManager)
             {
-                if (!fakeObjectCall.Method.HasSameBaseMethodAs(ToStringMethod))
-                {
-                    return false;
-                }
-
                 fakeObjectCall.SetReturnValue(fakeManager.FakeObjectDisplayName);
-
-                return true;
             }
 
-            private static bool TryHandleEquals(IInterceptedFakeObjectCall fakeObjectCall, FakeManager fakeManager)
+            private static void HandleEquals(IInterceptedFakeObjectCall fakeObjectCall, FakeManager fakeManager)
             {
-                if (!fakeObjectCall.Method.HasSameBaseMethodAs(EqualsMethod))
-                {
-                    return false;
-                }
-
                 var argument = fakeObjectCall.Arguments[0];
                 if (argument is not null)
                 {
@@ -74,8 +53,6 @@ namespace FakeItEasy.Core
                 {
                     fakeObjectCall.SetReturnValue(false);
                 }
-
-                return true;
             }
         }
     }

--- a/src/FakeItEasy/Core/InterceptedFakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/Core/InterceptedFakeObjectCallExtensions.cs
@@ -2,7 +2,7 @@ namespace FakeItEasy.Core
 {
     using System.Reflection;
     using FakeItEasy.Creation;
-    using static FakeItEasy.ObjectMembers;
+    using static FakeItEasy.ObjectMethod;
 
     internal static class InterceptedFakeObjectCallExtensions
     {
@@ -22,7 +22,7 @@ namespace FakeItEasy.Core
             object? returnValue;
             try
             {
-                if (fakeObjectCall.Method.HasSameBaseMethodAs(EqualsMethod))
+                if (fakeObjectCall.Method.GetObjectMethod() == EqualsMethod)
                 {
                     var arg = parameters[0];
                     if (ReferenceEquals(arg, fakeObjectCall.FakedObject))

--- a/src/FakeItEasy/Core/StrictFakeRule.cs
+++ b/src/FakeItEasy/Core/StrictFakeRule.cs
@@ -1,7 +1,7 @@
 namespace FakeItEasy.Core
 {
     using System;
-    using static FakeItEasy.ObjectMembers;
+    using static FakeItEasy.ObjectMethod;
 
     internal class StrictFakeRule : IFakeObjectCallRule
     {
@@ -16,17 +16,19 @@ namespace FakeItEasy.Core
 
         public bool IsApplicableTo(IFakeObjectCall fakeObjectCall)
         {
-            if (fakeObjectCall.Method.HasSameBaseMethodAs(EqualsMethod))
+            var objectMethod = fakeObjectCall.Method.GetObjectMethod();
+
+            if (objectMethod == EqualsMethod)
             {
                 return !this.HasOption(StrictFakeOptions.AllowEquals);
             }
 
-            if (fakeObjectCall.Method.HasSameBaseMethodAs(GetHashCodeMethod))
+            if (objectMethod == GetHashCodeMethod)
             {
                 return !this.HasOption(StrictFakeOptions.AllowGetHashCode);
             }
 
-            if (fakeObjectCall.Method.HasSameBaseMethodAs(ToStringMethod))
+            if (objectMethod == ToStringMethod)
             {
                 return !this.HasOption(StrictFakeOptions.AllowToString);
             }

--- a/src/FakeItEasy/Core/WrappedObjectRule.cs
+++ b/src/FakeItEasy/Core/WrappedObjectRule.cs
@@ -1,8 +1,6 @@
 namespace FakeItEasy.Core
 {
     using System;
-    using System.Reflection;
-    using static FakeItEasy.ObjectMembers;
 
     /// <summary>
     /// A call rule that applies to any call and just delegates the

--- a/src/FakeItEasy/ObjectMethod.cs
+++ b/src/FakeItEasy/ObjectMethod.cs
@@ -1,0 +1,28 @@
+namespace FakeItEasy
+{
+    /// <summary>
+    /// Convenient identifiers for the <see cref="object"/> method a particular method might correspond to.
+    /// </summary>
+    internal enum ObjectMethod
+    {
+        /// <summary>
+        /// Corresponds to no object method.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Corresponds to <see cref="object.Equals(object)"/>.
+        /// </summary>
+        EqualsMethod,
+
+        /// <summary>
+        /// Corresponds to <see cref="object.ToString"/>.
+        /// </summary>
+        ToStringMethod,
+
+        /// <summary>
+        /// Corresponds to <see cref="object.GetHashCode"/>.
+        /// </summary>
+        GetHashCodeMethod,
+    }
+}


### PR DESCRIPTION
Connects to #1848.

I hesitate to say fix, but it addresses at least one area of slowness identified there.

Has this affect on runtimes (6.1.0 is the build before we changed a lot of method comparisons to see if a call had the same base method as a given method).

 Method |             Job |      Mean |     Error |    StdDev | Ratio | RatioSD |
------- |---------------- |----------:|----------:|----------:|------:|--------:|
 Equals |           6.1.0 |  4.738 us | 0.3711 us | 0.2208 us |  1.00 |    0.00 |
 Equals |           7.1.0 | 11.110 us | 0.6914 us | 0.4115 us |  2.35 |    0.14 |
 Equals | 7.1.1-alpha.0.5 |  4.340 us | 0.3255 us | 0.2153 us |  0.91 |    0.08 |

![image](https://user-images.githubusercontent.com/3275797/123670617-67a46900-d80b-11eb-9f92-3045c579a2d2.png)

and

 Method                 |             Job |     Mean |     Error |    StdDev | Ratio | RatioSD |
----------------------- |---------------- |---------:|----------:|----------:|------:|--------:|
 UnconfiguredBoolMethod |           6.1.0 | 5.421 us | 0.4837 us | 0.3199 us |  1.00 |    0.00 |
 UnconfiguredBoolMethod |           7.1.0 | 7.421 us | 0.3595 us | 0.2139 us |  1.38 |    0.10 |
 UnconfiguredBoolMethod | 7.1.1-alpha.0.5 | 4.998 us | 0.3071 us | 0.2032 us |  0.92 |    0.05 |
 
![image](https://user-images.githubusercontent.com/3275797/123670668-72f79480-d80b-11eb-89d9-5291d05e6dab.png)

 
 