### PR TITLE
Use CallerArgumentExpression in Guard.AgainstNull 

### DIFF
--- a/how_to_build.md
+++ b/how_to_build.md
@@ -3,7 +3,7 @@
 These instructions are *only* for building from the command line, which includes compilation, test execution and packaging. This is the simplest way to build.
 It also replicates the build on the Continuous Integration build server and is the best indicator of whether a pull request will build.
 
-You can also build the solution using Visual Studio 2019 16.8 or later, but this doesn't provide the same assurances as the command line build.
+You can also build the solution using Visual Studio 2022 17.0 or later, but this doesn't provide the same assurances as the command line build.
 
 At the time of writing the full build (including all target frameworks) can only run on Windows.
 
@@ -19,17 +19,23 @@ The default [build profile](#building-only-a-subset-of-the-supported-target-fram
 
 Ensure that the following are installed:
 
-1. a recent version of Visual Studio 2019 (currently this means 16.8 or later) or the Build Tools for Visual Studio 2019
+1. The .NET Core 2.1 and 3.1 runtimes
 
-2. The .NET Core 2.1 and 3.1 runtimes
+2. The .NET 5.0 runtime
 
 3. The .NET Framework 4.6.1 or higher
 
-4. The targeting pack for .NET Framework 4.5
-
-5. An up-to-date version of the .NET 5.0 SDK (currently this means 5.0.100 or later)
+4. An up-to-date version of the .NET 6.0 SDK (currently this means 6.0.100 or later)
 
 You might not need everything to run a [partial build](#building-only-a-subset-of-the-supported-target-frameworks).
+
+In order to build from Visual Studio, you will also need:
+
+1. Visual Studio 2022 (17.0 or later)
+2. The .NET Framework 4.5 targeting pack. Unfortunately, this targeting pack is no longer available for download from Microsoft. As a workaround, you can get the necessary files from the `Microsoft.NETFramework.ReferenceAssemblies.net45` package:
+   1. Download the [Microsoft.NETFramework.ReferenceAssemblies.net45](https://www.nuget.org/packages/Microsoft.NETFramework.ReferenceAssemblies.net45/) package from NuGet
+   2. Open it as a ZIP
+   3. Extract the contents of `build\.NETFramework\v4.5` to the `C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5` directory
 
 ### On Linux
 
@@ -39,7 +45,9 @@ Ensure the following are installed:
 
 1. The .NET Core 2.1 and 3.1 runtimes
 
-2. A recent version of the .NET Core 5.0 SDK (currently this means 5.0.100 or later)
+2. The .NET 5.0 runtime
+
+3. An up-to-date version of the .NET 6.0 SDK (currently this means 6.0.100 or later)
 
 ## Building
 
@@ -108,7 +116,7 @@ build.cmd initialize-user-properties
 
 Thereafter
 you can switch profiles by replacing the contents of the `BuildProfile` element
-either by editing the file by hand or via a build target (which will actually 
+either by editing the file by hand or via a build target (which will actually
 create the file if it doesn't already exist). For example:
 
 ```

--- a/src/FakeItEasy/A.cs
+++ b/src/FakeItEasy/A.cs
@@ -41,7 +41,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Used to specify the type of fake.")]
         public static T Fake<T>(Action<IFakeOptions<T>> optionsBuilder) where T : class
         {
-            Guard.AgainstNull(optionsBuilder, nameof(optionsBuilder));
+            Guard.AgainstNull(optionsBuilder);
 
             return (T)FakeAndDummyManager.CreateFake(
                 typeof(T),

--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -21,7 +21,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsNull<T>(this IArgumentConstraintManager<T> manager) where T : class
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(x => x is null, x => x.Write("NULL"));
         }
@@ -35,7 +35,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design to support the fluent API.")]
         public static T? IsNull<T>(this IArgumentConstraintManager<T?> manager) where T : struct
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(x => x is null, x => x.Write("NULL"));
         }
@@ -48,7 +48,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsNotNull<T>(this INegatableArgumentConstraintManager<T> manager) where T : class
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(x => x is not null, x => x.Write("NOT NULL"));
         }
@@ -62,7 +62,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design to support the fluent API.")]
         public static T? IsNotNull<T>(this INegatableArgumentConstraintManager<T?> manager) where T : struct
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(x => x is not null, x => x.Write("NOT NULL"));
         }
@@ -87,8 +87,8 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static string Contains(this IArgumentConstraintManager<string> manager, string value, StringComparison comparisonType)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(value, nameof(value));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(value);
 
 #if FEATURE_STRING_CONTAINS_COMPARISONTYPE
             return manager.NullCheckedMatches(x => x.Contains(value, comparisonType), x => x.Write("string that contains ").WriteArgumentValue(value));
@@ -106,7 +106,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T Contains<T>(this IArgumentConstraintManager<T> manager, object? value) where T : IEnumerable
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.NullCheckedMatches(
                 x => x.Cast<object>().Contains(value),
@@ -137,8 +137,8 @@ namespace FakeItEasy
             string value,
             StringComparison comparisonType)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(value, nameof(value));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(value);
 
             return manager.NullCheckedMatches(
                 x => x.StartsWith(value, comparisonType),
@@ -154,8 +154,8 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static string EndsWith(this IArgumentConstraintManager<string> manager, string value)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(value, nameof(value));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(value);
 
             return manager.EndsWith(value, StringComparison.Ordinal);
         }
@@ -172,8 +172,8 @@ namespace FakeItEasy
             string value,
             StringComparison comparisonType)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(value, nameof(value));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(value);
 
             return manager.NullCheckedMatches(
                 x => x.EndsWith(value, comparisonType),
@@ -187,7 +187,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static string IsNullOrEmpty(this IArgumentConstraintManager<string> manager)
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(x => string.IsNullOrEmpty(x), "NULL or string.Empty");
         }
@@ -201,7 +201,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsGreaterThan<T>(this IArgumentConstraintManager<T> manager, T value) where T : IComparable
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(x => x.CompareTo(value) > 0, x => x.Write("greater than ").WriteArgumentValue(value));
         }
@@ -216,8 +216,8 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsSameSequenceAs<T>(this IArgumentConstraintManager<T> manager, IEnumerable values) where T : IEnumerable
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(values, nameof(values));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(values);
 
             var list = values.AsList();
             return manager.NullCheckedMatches(
@@ -235,8 +235,8 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsSameSequenceAs<T>(this IArgumentConstraintManager<T> manager, params object?[] values) where T : IEnumerable
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(values, nameof(values));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(values);
 
             return manager.IsSameSequenceAs((IEnumerable)values);
         }
@@ -249,7 +249,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsEmpty<T>(this IArgumentConstraintManager<T> manager) where T : IEnumerable
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.NullCheckedMatches(
                 x => !x.Cast<object>().Any(),
@@ -265,7 +265,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsEqualTo<T>(this IArgumentConstraintManager<T> manager, T value)
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(
                 x => object.Equals(value, x),
@@ -282,8 +282,8 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsEqualTo<T>(this IArgumentConstraintManager<T> manager, T value, IEqualityComparer<T> comparer)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(comparer, nameof(comparer));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(comparer);
 
             return manager.Matches(
                 x => comparer.Equals(value, x),
@@ -299,7 +299,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T IsSameAs<T>(this IArgumentConstraintManager<T> manager, T value)
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(
                 x => object.ReferenceEquals(value, x),
@@ -315,8 +315,8 @@ namespace FakeItEasy
         /// <returns>A dummy value.</returns>
         public static T IsInstanceOf<T>(this IArgumentConstraintManager<T> manager, Type type)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(type, nameof(type));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(type);
 
             return manager.Matches(x => x is not null && type.IsAssignableFrom(x.GetType()), description => description.Write("Instance of ").Write(type.ToString()));
         }
@@ -341,9 +341,9 @@ namespace FakeItEasy
         /// </returns>
         public static T Matches<T>(this IArgumentConstraintManager<T> manager, Func<T, bool> predicate, string description)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(predicate, nameof(predicate));
-            Guard.AgainstNull(description, nameof(description));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(predicate);
+            Guard.AgainstNull(description);
 
             return manager.Matches(predicate, x => x.Write(description));
         }
@@ -371,10 +371,10 @@ namespace FakeItEasy
         /// </returns>
         public static T Matches<T>(this IArgumentConstraintManager<T> manager, Func<T, bool> predicate, string descriptionFormat, params object?[] args)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(predicate, nameof(predicate));
-            Guard.AgainstNull(descriptionFormat, nameof(descriptionFormat));
-            Guard.AgainstNull(args, nameof(args));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(predicate);
+            Guard.AgainstNull(descriptionFormat);
+            Guard.AgainstNull(args);
 
             return manager.Matches(predicate, x => x.Write(descriptionFormat, args));
         }
@@ -397,8 +397,8 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Appropriate for Linq expressions.")]
         public static T Matches<T>(this IArgumentConstraintManager<T> manager, Expression<Func<T, bool>> predicate)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(predicate);
 
             return manager.Matches(predicate.Compile(), predicate.ToString());
         }
@@ -415,9 +415,9 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static T NullCheckedMatches<T>(this IArgumentConstraintManager<T> manager, Func<T, bool> predicate, Action<IOutputWriter> descriptionWriter)
         {
-            Guard.AgainstNull(manager, nameof(manager));
-            Guard.AgainstNull(predicate, nameof(predicate));
-            Guard.AgainstNull(descriptionWriter, nameof(descriptionWriter));
+            Guard.AgainstNull(manager);
+            Guard.AgainstNull(predicate);
+            Guard.AgainstNull(descriptionWriter);
 
             return manager.Matches(
                 x => x is not null && predicate(x),
@@ -431,7 +431,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static CancellationToken IsCanceled(this IArgumentConstraintManager<CancellationToken> manager)
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(
                 token => token.IsCancellationRequested,
@@ -445,7 +445,7 @@ namespace FakeItEasy
         /// <returns>A dummy argument value.</returns>
         public static CancellationToken IsNotCanceled(this INegatableArgumentConstraintManager<CancellationToken> manager)
         {
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(manager);
 
             return manager.Matches(
                 token => !token.IsCancellationRequested,

--- a/src/FakeItEasy/ArgumentValidationConfigurationExtensions.StronglyTyped.cs
+++ b/src/FakeItEasy/ArgumentValidationConfigurationExtensions.StronglyTyped.cs
@@ -26,8 +26,8 @@ namespace FakeItEasy
             this IArgumentValidationConfiguration<TInterface> configuration,
             Func<T1, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(argumentsPredicate);
 
             return configuration.WhenArgumentsMatch(args =>
             {
@@ -53,8 +53,8 @@ namespace FakeItEasy
             this IArgumentValidationConfiguration<TInterface> configuration,
             Func<T1, T2, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(argumentsPredicate);
 
             return configuration.WhenArgumentsMatch(args =>
             {
@@ -81,8 +81,8 @@ namespace FakeItEasy
             this IArgumentValidationConfiguration<TInterface> configuration,
             Func<T1, T2, T3, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(argumentsPredicate);
 
             return configuration.WhenArgumentsMatch(args =>
             {
@@ -110,8 +110,8 @@ namespace FakeItEasy
             this IArgumentValidationConfiguration<TInterface> configuration,
             Func<T1, T2, T3, T4, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(argumentsPredicate);
 
             return configuration.WhenArgumentsMatch(args =>
             {
@@ -140,8 +140,8 @@ namespace FakeItEasy
             this IArgumentValidationConfiguration<TInterface> configuration,
             Func<T1, T2, T3, T4, T5, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(argumentsPredicate);
 
             return configuration.WhenArgumentsMatch(args =>
             {
@@ -171,8 +171,8 @@ namespace FakeItEasy
             this IArgumentValidationConfiguration<TInterface> configuration,
             Func<T1, T2, T3, T4, T5, T6, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(argumentsPredicate);
 
             return configuration.WhenArgumentsMatch(args =>
             {
@@ -203,8 +203,8 @@ namespace FakeItEasy
             this IArgumentValidationConfiguration<TInterface> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(argumentsPredicate);
 
             return configuration.WhenArgumentsMatch(args =>
             {
@@ -236,8 +236,8 @@ namespace FakeItEasy
             this IArgumentValidationConfiguration<TInterface> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(argumentsPredicate);
 
             return configuration.WhenArgumentsMatch(args =>
             {

--- a/src/FakeItEasy/ArgumentValidationConfigurationExtensions.StronglyTyped.tt
+++ b/src/FakeItEasy/ArgumentValidationConfigurationExtensions.StronglyTyped.tt
@@ -44,8 +44,8 @@ namespace FakeItEasy
             this IArgumentValidationConfiguration<TInterface> configuration,
             Func<<#= typeParamList #>, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(argumentsPredicate);
 
             return configuration.WhenArgumentsMatch(args =>
             {

--- a/src/FakeItEasy/ArgumentValidationConfigurationExtensions.cs
+++ b/src/FakeItEasy/ArgumentValidationConfigurationExtensions.cs
@@ -18,7 +18,7 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface WithAnyArguments<TInterface>(this IArgumentValidationConfiguration<TInterface> configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.WhenArgumentsMatch(x => true);
         }

--- a/src/FakeItEasy/AssertConfigurationExtensions.cs
+++ b/src/FakeItEasy/AssertConfigurationExtensions.cs
@@ -14,7 +14,7 @@ namespace FakeItEasy
         /// <returns>An object to assert the call order.</returns>
         public static UnorderedCallAssertion MustHaveHappened(this IAssertConfiguration configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.MustHaveHappened(1, Times.OrMore);
         }
@@ -25,7 +25,7 @@ namespace FakeItEasy
         /// <param name="configuration">The configuration to assert on.</param>
         public static void MustNotHaveHappened(this IAssertConfiguration configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             configuration.MustHaveHappened(0, Times.Exactly);
         }
@@ -37,7 +37,7 @@ namespace FakeItEasy
         /// <returns>An object to assert the call order.</returns>
         public static UnorderedCallAssertion MustHaveHappenedOnceExactly(this IAssertConfiguration configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.MustHaveHappened(1, Times.Exactly);
         }
@@ -49,7 +49,7 @@ namespace FakeItEasy
         /// <returns>An object to assert the call order.</returns>
         public static UnorderedCallAssertion MustHaveHappenedOnceOrMore(this IAssertConfiguration configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.MustHaveHappened(1, Times.OrMore);
         }
@@ -61,7 +61,7 @@ namespace FakeItEasy
         /// <returns>An object to assert the call order.</returns>
         public static UnorderedCallAssertion MustHaveHappenedOnceOrLess(this IAssertConfiguration configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.MustHaveHappened(1, Times.OrLess);
         }
@@ -73,7 +73,7 @@ namespace FakeItEasy
         /// <returns>An object to assert the call order.</returns>
         public static UnorderedCallAssertion MustHaveHappenedTwiceExactly(this IAssertConfiguration configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.MustHaveHappened(2, Times.Exactly);
         }
@@ -85,7 +85,7 @@ namespace FakeItEasy
         /// <returns>An object to assert the call order.</returns>
         public static UnorderedCallAssertion MustHaveHappenedTwiceOrMore(this IAssertConfiguration configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.MustHaveHappened(2, Times.OrMore);
         }
@@ -97,7 +97,7 @@ namespace FakeItEasy
         /// <returns>An object to assert the call order.</returns>
         public static UnorderedCallAssertion MustHaveHappenedTwiceOrLess(this IAssertConfiguration configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.MustHaveHappened(2, Times.OrLess);
         }

--- a/src/FakeItEasy/AsyncReturnValueConfigurationExtensions.StronglyTyped.cs
+++ b/src/FakeItEasy/AsyncReturnValueConfigurationExtensions.StronglyTyped.cs
@@ -27,8 +27,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<T1, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -48,8 +48,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<T1, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1) => TaskHelper.FromException<T>(exceptionFactory(arg1)));
         }
@@ -67,8 +67,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<T1, T2, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -89,8 +89,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<T1, T2, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2) => TaskHelper.FromException<T>(exceptionFactory(arg1, arg2)));
         }
@@ -109,8 +109,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<T1, T2, T3, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -132,8 +132,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<T1, T2, T3, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3) => TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3)));
         }
@@ -153,8 +153,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<T1, T2, T3, T4, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -177,8 +177,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<T1, T2, T3, T4, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4) => TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4)));
         }
@@ -199,8 +199,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -224,8 +224,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4, arg5)));
         }
@@ -247,8 +247,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -273,8 +273,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4, arg5, arg6)));
         }
@@ -297,8 +297,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -324,8 +324,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) => TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4, arg5, arg6, arg7)));
         }
@@ -349,8 +349,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -377,8 +377,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) => TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)));
         }

--- a/src/FakeItEasy/AsyncReturnValueConfigurationExtensions.StronglyTyped.tt
+++ b/src/FakeItEasy/AsyncReturnValueConfigurationExtensions.StronglyTyped.tt
@@ -46,8 +46,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<<#= typeParamList #>, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -74,8 +74,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<<#= typeParamList #>, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((<#= lambdaParamList #>) => TaskHelper.FromException<T>(exceptionFactory(<#= argumentList #>)));
         }

--- a/src/FakeItEasy/AsyncReturnValueConfigurationExtensions.cs
+++ b/src/FakeItEasy/AsyncReturnValueConfigurationExtensions.cs
@@ -22,8 +22,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Exception exception)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exception, nameof(exception));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exception);
 
             return configuration.ReturnsLazily(call => TaskHelper.FromException(exception));
         }
@@ -39,8 +39,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<IFakeObjectCall, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily(call => TaskHelper.FromException(exceptionFactory(call)));
         }
@@ -56,8 +56,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task> configuration,
             Func<Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily(call => TaskHelper.FromException(exceptionFactory()));
         }
@@ -74,8 +74,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Exception exception)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exception, nameof(exception));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exception);
 
             return configuration.ReturnsLazily(call => TaskHelper.FromException<T>(exception));
         }
@@ -92,8 +92,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<IFakeObjectCall, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily(call => TaskHelper.FromException<T>(exceptionFactory(call)));
         }
@@ -110,8 +110,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<Task<T>> configuration,
             Func<Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily(call => TaskHelper.FromException<T>(exceptionFactory()));
         }

--- a/src/FakeItEasy/BehaviorLifetimeConfigurationExtensions.cs
+++ b/src/FakeItEasy/BehaviorLifetimeConfigurationExtensions.cs
@@ -15,7 +15,7 @@ namespace FakeItEasy
         /// <returns>A configuration object that lets you define the subsequent behavior.</returns>
         public static IThenConfiguration<TInterface> Once<TInterface>(this IBehaviorLifetimeConfiguration<TInterface> configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.NumberOfTimes(1);
         }
@@ -28,7 +28,7 @@ namespace FakeItEasy
         /// <returns>A configuration object that lets you define the subsequent behavior.</returns>
         public static IThenConfiguration<TInterface> Twice<TInterface>(this IBehaviorLifetimeConfiguration<TInterface> configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.NumberOfTimes(2);
         }

--- a/src/FakeItEasy/CallbackConfigurationExtensions.StronglyTyped.cs
+++ b/src/FakeItEasy/CallbackConfigurationExtensions.StronglyTyped.cs
@@ -25,8 +25,8 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface Invokes<TInterface, T1>(this ICallbackConfiguration<TInterface> configuration, Action<T1> actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call =>
                 {
@@ -48,8 +48,8 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface Invokes<TInterface, T1, T2>(this ICallbackConfiguration<TInterface> configuration, Action<T1, T2> actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call =>
                 {
@@ -72,8 +72,8 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface Invokes<TInterface, T1, T2, T3>(this ICallbackConfiguration<TInterface> configuration, Action<T1, T2, T3> actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call =>
                 {
@@ -97,8 +97,8 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface Invokes<TInterface, T1, T2, T3, T4>(this ICallbackConfiguration<TInterface> configuration, Action<T1, T2, T3, T4> actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call =>
                 {
@@ -123,8 +123,8 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface Invokes<TInterface, T1, T2, T3, T4, T5>(this ICallbackConfiguration<TInterface> configuration, Action<T1, T2, T3, T4, T5> actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call =>
                 {
@@ -150,8 +150,8 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface Invokes<TInterface, T1, T2, T3, T4, T5, T6>(this ICallbackConfiguration<TInterface> configuration, Action<T1, T2, T3, T4, T5, T6> actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call =>
                 {
@@ -178,8 +178,8 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface Invokes<TInterface, T1, T2, T3, T4, T5, T6, T7>(this ICallbackConfiguration<TInterface> configuration, Action<T1, T2, T3, T4, T5, T6, T7> actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call =>
                 {
@@ -207,8 +207,8 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface Invokes<TInterface, T1, T2, T3, T4, T5, T6, T7, T8>(this ICallbackConfiguration<TInterface> configuration, Action<T1, T2, T3, T4, T5, T6, T7, T8> actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call =>
                 {

--- a/src/FakeItEasy/CallbackConfigurationExtensions.StronglyTyped.tt
+++ b/src/FakeItEasy/CallbackConfigurationExtensions.StronglyTyped.tt
@@ -43,8 +43,8 @@ namespace FakeItEasy
         /// <returns>The configuration object.</returns>
         public static TInterface Invokes<TInterface, <#= typeParamList #>>(this ICallbackConfiguration<TInterface> configuration, Action<<#= typeParamList #>> actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call =>
                 {

--- a/src/FakeItEasy/CallbackConfigurationExtensions.cs
+++ b/src/FakeItEasy/CallbackConfigurationExtensions.cs
@@ -19,8 +19,8 @@ namespace FakeItEasy
         /// <returns>The fake object.</returns>
         public static TInterface Invokes<TInterface>(this ICallbackConfiguration<TInterface> configuration, Action actionToInvoke)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(actionToInvoke, nameof(actionToInvoke));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(actionToInvoke);
 
             return configuration.Invokes(call => actionToInvoke());
         }

--- a/src/FakeItEasy/Compatibility/CallerArgumentExpressionAttribute.cs
+++ b/src/FakeItEasy/Compatibility/CallerArgumentExpressionAttribute.cs
@@ -1,0 +1,15 @@
+﻿#if !FEATURE_CALLERARGUMENTEXPRESSION
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    internal sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            this.ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}
+#endif

--- a/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/CompletedFakeObjectCallExtensions.cs
@@ -25,8 +25,8 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "The compiler would not be able to figure out the type.")]
         public static IEnumerable<ICompletedFakeObjectCall> Matching<TFake>(this IEnumerable<ICompletedFakeObjectCall> calls, Expression<Action<TFake>> callSpecification)
         {
-            Guard.AgainstNull(calls, nameof(calls));
-            Guard.AgainstNull(callSpecification, nameof(callSpecification));
+            Guard.AgainstNull(calls);
+            Guard.AgainstNull(callSpecification);
 
             var factory = ServiceLocator.Resolve<IExpressionCallMatcherFactory>();
             var callExpressionParser = ServiceLocator.Resolve<ICallExpressionParser>();

--- a/src/FakeItEasy/Configuration/AnyCallConfiguration.cs
+++ b/src/FakeItEasy/Configuration/AnyCallConfiguration.cs
@@ -61,21 +61,21 @@ namespace FakeItEasy.Configuration
 
         public UnorderedCallAssertion MustHaveHappened(int numberOfTimes, Times timesOption)
         {
-            Guard.AgainstNull(timesOption, nameof(timesOption));
+            Guard.AgainstNull(timesOption);
 
             return this.VoidConfiguration.MustHaveHappened(numberOfTimes, timesOption);
         }
 
         public UnorderedCallAssertion MustHaveHappenedANumberOfTimesMatching(Expression<Func<int, bool>> predicate)
         {
-            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(predicate);
 
             return this.VoidConfiguration.MustHaveHappenedANumberOfTimesMatching(predicate);
         }
 
         public IAnyCallConfigurationWithNoReturnTypeSpecified Where(Func<IFakeObjectCall, bool> predicate, Action<IOutputWriter> descriptionWriter)
         {
-            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(predicate);
 
             this.configuredRule.ApplyWherePredicate(predicate, descriptionWriter);
             return this;
@@ -83,7 +83,7 @@ namespace FakeItEasy.Configuration
 
         public IVoidConfiguration WhenArgumentsMatch(Func<ArgumentCollection, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(argumentsPredicate);
 
             this.configuredRule.UsePredicateToValidateArguments(argumentsPredicate);
             return this;

--- a/src/FakeItEasy/Configuration/AnyCallConfigurationWithNoReturnTypeSpecifiedExtensions.cs
+++ b/src/FakeItEasy/Configuration/AnyCallConfigurationWithNoReturnTypeSpecifiedExtensions.cs
@@ -7,9 +7,9 @@ namespace FakeItEasy.Configuration
             object fake,
             EventAction action)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(fake, nameof(fake));
-            Guard.AgainstNull(action, nameof(action));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(fake);
+            Guard.AgainstNull(action);
             return configuration.WithVoidReturnType().Where(action.Matches, writer => action.WriteDescription(fake, writer));
         }
     }

--- a/src/FakeItEasy/Configuration/ArgumentCollection.cs
+++ b/src/FakeItEasy/Configuration/ArgumentCollection.cs
@@ -29,8 +29,8 @@ namespace FakeItEasy.Configuration
         [DebuggerStepThrough]
         internal ArgumentCollection(object?[] arguments, MethodInfo method)
         {
-            Guard.AgainstNull(arguments, nameof(arguments));
-            Guard.AgainstNull(method, nameof(method));
+            Guard.AgainstNull(arguments);
+            Guard.AgainstNull(method);
 
             if (arguments.Length != method.GetParameters().Length)
             {
@@ -114,7 +114,7 @@ namespace FakeItEasy.Configuration
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Used to cast the argument to the specified type.")]
         public T Get<T>(string argumentName)
         {
-            Guard.AgainstNull(argumentName, nameof(argumentName));
+            Guard.AgainstNull(argumentName);
 
             var index = this.GetArgumentIndex(argumentName);
             return this.Get<T>(index);

--- a/src/FakeItEasy/Configuration/BuildableCallRule.cs
+++ b/src/FakeItEasy/Configuration/BuildableCallRule.cs
@@ -92,7 +92,7 @@ namespace FakeItEasy.Configuration
 
         public virtual void Apply(IInterceptedFakeObjectCall fakeObjectCall)
         {
-            Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
+            Guard.AgainstNull(fakeObjectCall);
 
             foreach (var action in this.Actions)
             {
@@ -134,7 +134,7 @@ namespace FakeItEasy.Configuration
         /// <param name="writer">The writer to write the description to.</param>
         public void WriteDescriptionOfValidCall(IOutputWriter writer)
         {
-            Guard.AgainstNull(writer, nameof(writer));
+            Guard.AgainstNull(writer);
 
             this.DescribeCallOn(writer);
 

--- a/src/FakeItEasy/Configuration/ExceptionThrower.StronglyTyped.cs
+++ b/src/FakeItEasy/Configuration/ExceptionThrower.StronglyTyped.cs
@@ -139,7 +139,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1>(Func<T1, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -160,7 +160,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2>(Func<T1, T2, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -182,7 +182,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3>(Func<T1, T2, T3, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -205,7 +205,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4>(Func<T1, T2, T3, T4, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -229,7 +229,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -254,7 +254,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -280,7 +280,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7>(Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -307,7 +307,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -329,7 +329,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> Throws<T1>(Func<T1, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -350,7 +350,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> Throws<T1, T2>(Func<T1, T2, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -372,7 +372,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> Throws<T1, T2, T3>(Func<T1, T2, T3, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -395,7 +395,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> Throws<T1, T2, T3, T4>(Func<T1, T2, T3, T4, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -419,7 +419,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> Throws<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -444,7 +444,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> Throws<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -470,7 +470,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> Throws<T1, T2, T3, T4, T5, T6, T7>(Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -497,7 +497,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -524,7 +524,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1>(Func<T1, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -545,7 +545,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2>(Func<T1, T2, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -567,7 +567,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3>(Func<T1, T2, T3, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -590,7 +590,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4>(Func<T1, T2, T3, T4, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -614,7 +614,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -639,7 +639,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -665,7 +665,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7>(Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -692,7 +692,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -718,7 +718,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1>(Func<T1, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -739,7 +739,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2>(Func<T1, T2, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -761,7 +761,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3>(Func<T1, T2, T3, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -784,7 +784,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4>(Func<T1, T2, T3, T4, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -808,7 +808,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -833,7 +833,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -859,7 +859,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7>(Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -886,7 +886,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {
@@ -908,7 +908,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1>(Func<T1, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -929,7 +929,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2>(Func<T1, T2, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -951,7 +951,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3>(Func<T1, T2, T3, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -974,7 +974,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4>(Func<T1, T2, T3, T4, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -998,7 +998,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1023,7 +1023,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1049,7 +1049,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7>(Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1076,7 +1076,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1100,7 +1100,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1>(Func<T1, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1121,7 +1121,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2>(Func<T1, T2, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1143,7 +1143,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3>(Func<T1, T2, T3, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1166,7 +1166,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4>(Func<T1, T2, T3, T4, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1190,7 +1190,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1215,7 +1215,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1241,7 +1241,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7>(Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {
@@ -1268,7 +1268,7 @@ namespace FakeItEasy.Configuration
             /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
             public IAfterCallConfiguredConfiguration<IPropertySetterConfiguration> Throws<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
             {
-                Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+                Guard.AgainstNull(exceptionFactory);
     
                 return this.Throws((IFakeObjectCall call) =>
                 {

--- a/src/FakeItEasy/Configuration/ExceptionThrower.StronglyTyped.tt
+++ b/src/FakeItEasy/Configuration/ExceptionThrower.StronglyTyped.tt
@@ -115,7 +115,7 @@ void GenerateMethodImplementations(string configurationInterface, string indent 
         /// <exception cref="FakeConfigurationException">The signatures of the faked method and the <paramref name="exceptionFactory"/> do not match.</exception>
         public IAfterCallConfiguredConfiguration<<#= configurationInterface #>> Throws<<#= typeParamList #>>(Func<<#= typeParamList #>, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             return this.Throws((IFakeObjectCall call) =>
             {

--- a/src/FakeItEasy/Configuration/FakeConfigurationManager.cs
+++ b/src/FakeItEasy/Configuration/FakeConfigurationManager.cs
@@ -24,7 +24,7 @@ namespace FakeItEasy.Configuration
 
         public IVoidArgumentValidationConfiguration CallTo(Expression<Action> callSpecification)
         {
-            Guard.AgainstNull(callSpecification, nameof(callSpecification));
+            Guard.AgainstNull(callSpecification);
 
             var parsedCallExpression = this.callExpressionParser.Parse(callSpecification);
             GuardAgainstNonFake(parsedCallExpression.CallTarget);
@@ -39,7 +39,7 @@ namespace FakeItEasy.Configuration
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design when using the Expression-, Action- and Func-types.")]
         public IReturnValueArgumentValidationConfiguration<T> CallTo<T>(Expression<Func<T>> callSpecification)
         {
-            Guard.AgainstNull(callSpecification, nameof(callSpecification));
+            Guard.AgainstNull(callSpecification);
 
             var parsedCallExpression = this.callExpressionParser.Parse(callSpecification);
             GuardAgainstNonFake(parsedCallExpression.CallTarget);
@@ -62,7 +62,7 @@ namespace FakeItEasy.Configuration
 
         public IPropertySetterAnyValueConfiguration<TValue> CallToSet<TValue>(Expression<Func<TValue>> propertySpecification)
         {
-            Guard.AgainstNull(propertySpecification, nameof(propertySpecification));
+            Guard.AgainstNull(propertySpecification);
             var parsedCallExpression = this.callExpressionParser.Parse(propertySpecification);
             GuardAgainstNonFake(parsedCallExpression.CallTarget);
             this.AssertThatMemberCanBeIntercepted(parsedCallExpression);

--- a/src/FakeItEasy/Configuration/OutAndRefParameters.StronglyTyped.cs
+++ b/src/FakeItEasy/Configuration/OutAndRefParameters.StronglyTyped.cs
@@ -174,7 +174,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1>(Func<T1, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -200,7 +200,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2>(Func<T1, T2, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -227,7 +227,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3>(Func<T1, T2, T3, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -255,7 +255,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4>(Func<T1, T2, T3, T4, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -284,7 +284,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -314,7 +314,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -345,7 +345,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5, T6, T7>(Func<T1, T2, T3, T4, T5, T6, T7, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -377,7 +377,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -405,7 +405,7 @@ namespace FakeItEasy.Configuration
             /// </exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> AssignsOutAndRefParametersLazily<T1>(Func<T1, object?[]> valueProducer)
             {
-                Guard.AgainstNull(valueProducer, nameof(valueProducer));
+                Guard.AgainstNull(valueProducer);
     
                 return this.AssignsOutAndRefParametersLazily(call =>
                 {
@@ -431,7 +431,7 @@ namespace FakeItEasy.Configuration
             /// </exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> AssignsOutAndRefParametersLazily<T1, T2>(Func<T1, T2, object?[]> valueProducer)
             {
-                Guard.AgainstNull(valueProducer, nameof(valueProducer));
+                Guard.AgainstNull(valueProducer);
     
                 return this.AssignsOutAndRefParametersLazily(call =>
                 {
@@ -458,7 +458,7 @@ namespace FakeItEasy.Configuration
             /// </exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> AssignsOutAndRefParametersLazily<T1, T2, T3>(Func<T1, T2, T3, object?[]> valueProducer)
             {
-                Guard.AgainstNull(valueProducer, nameof(valueProducer));
+                Guard.AgainstNull(valueProducer);
     
                 return this.AssignsOutAndRefParametersLazily(call =>
                 {
@@ -486,7 +486,7 @@ namespace FakeItEasy.Configuration
             /// </exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> AssignsOutAndRefParametersLazily<T1, T2, T3, T4>(Func<T1, T2, T3, T4, object?[]> valueProducer)
             {
-                Guard.AgainstNull(valueProducer, nameof(valueProducer));
+                Guard.AgainstNull(valueProducer);
     
                 return this.AssignsOutAndRefParametersLazily(call =>
                 {
@@ -515,7 +515,7 @@ namespace FakeItEasy.Configuration
             /// </exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, object?[]> valueProducer)
             {
-                Guard.AgainstNull(valueProducer, nameof(valueProducer));
+                Guard.AgainstNull(valueProducer);
     
                 return this.AssignsOutAndRefParametersLazily(call =>
                 {
@@ -545,7 +545,7 @@ namespace FakeItEasy.Configuration
             /// </exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, object?[]> valueProducer)
             {
-                Guard.AgainstNull(valueProducer, nameof(valueProducer));
+                Guard.AgainstNull(valueProducer);
     
                 return this.AssignsOutAndRefParametersLazily(call =>
                 {
@@ -576,7 +576,7 @@ namespace FakeItEasy.Configuration
             /// </exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5, T6, T7>(Func<T1, T2, T3, T4, T5, T6, T7, object?[]> valueProducer)
             {
-                Guard.AgainstNull(valueProducer, nameof(valueProducer));
+                Guard.AgainstNull(valueProducer);
     
                 return this.AssignsOutAndRefParametersLazily(call =>
                 {
@@ -608,7 +608,7 @@ namespace FakeItEasy.Configuration
             /// </exception>
             public IAfterCallConfiguredConfiguration<IReturnValueConfiguration<TMember>> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, object?[]> valueProducer)
             {
-                Guard.AgainstNull(valueProducer, nameof(valueProducer));
+                Guard.AgainstNull(valueProducer);
     
                 return this.AssignsOutAndRefParametersLazily(call =>
                 {
@@ -640,7 +640,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1>(Func<T1, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -666,7 +666,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2>(Func<T1, T2, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -693,7 +693,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3>(Func<T1, T2, T3, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -721,7 +721,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4>(Func<T1, T2, T3, T4, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -750,7 +750,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -780,7 +780,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5, T6>(Func<T1, T2, T3, T4, T5, T6, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -811,7 +811,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5, T6, T7>(Func<T1, T2, T3, T4, T5, T6, T7, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {
@@ -843,7 +843,7 @@ namespace FakeItEasy.Configuration
         /// </exception>
         public IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {

--- a/src/FakeItEasy/Configuration/OutAndRefParameters.StronglyTyped.tt
+++ b/src/FakeItEasy/Configuration/OutAndRefParameters.StronglyTyped.tt
@@ -107,7 +107,7 @@ void GenerateMethodImplementations(string configurationInterface, string indent 
         /// </exception>
         public IAfterCallConfiguredConfiguration<<#= configurationInterface #>> AssignsOutAndRefParametersLazily<<#= typeParamList #>>(Func<<#= typeParamList #>, object?[]> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             return this.AssignsOutAndRefParametersLazily(call =>
             {

--- a/src/FakeItEasy/Configuration/PropertySetterConfiguration.cs
+++ b/src/FakeItEasy/Configuration/PropertySetterConfiguration.cs
@@ -26,7 +26,7 @@ namespace FakeItEasy.Configuration
 
         public IPropertySetterConfiguration To(Expression<Func<TValue>> valueConstraint)
         {
-            Guard.AgainstNull(valueConstraint, nameof(valueConstraint));
+            Guard.AgainstNull(valueConstraint);
 
             var newSetterExpression = this.CreateSetterExpressionWithNewValue(valueConstraint);
             var voidArgumentValidationConfiguration = this.CreateArgumentValidationConfiguration(newSetterExpression);
@@ -58,14 +58,14 @@ namespace FakeItEasy.Configuration
 
         public UnorderedCallAssertion MustHaveHappened(int numberOfTimes, Times timesOption)
         {
-            Guard.AgainstNull(timesOption, nameof(timesOption));
+            Guard.AgainstNull(timesOption);
 
             return this.CreateArgumentValidationConfiguration(this.parsedSetterExpression).MustHaveHappened(numberOfTimes, timesOption);
         }
 
         public UnorderedCallAssertion MustHaveHappenedANumberOfTimesMatching(Expression<Func<int, bool>> predicate)
         {
-            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(predicate);
 
             return this.CreateArgumentValidationConfiguration(this.parsedSetterExpression).MustHaveHappenedANumberOfTimesMatching(predicate);
         }
@@ -134,14 +134,14 @@ namespace FakeItEasy.Configuration
 
             public UnorderedCallAssertion MustHaveHappened(int numberOfTimes, Times timesOption)
             {
-                Guard.AgainstNull(timesOption, nameof(timesOption));
+                Guard.AgainstNull(timesOption);
 
                 return this.voidConfiguration.MustHaveHappened(numberOfTimes, timesOption);
             }
 
             public UnorderedCallAssertion MustHaveHappenedANumberOfTimesMatching(Expression<Func<int, bool>> predicate)
             {
-                Guard.AgainstNull(predicate, nameof(predicate));
+                Guard.AgainstNull(predicate);
 
                 return this.voidConfiguration.MustHaveHappenedANumberOfTimesMatching(predicate);
             }

--- a/src/FakeItEasy/Configuration/RuleBuilder.cs
+++ b/src/FakeItEasy/Configuration/RuleBuilder.cs
@@ -69,7 +69,7 @@ namespace FakeItEasy.Configuration
 
         public virtual IAfterCallConfiguredConfiguration<IVoidConfiguration> Throws(Func<IFakeObjectCall, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(exceptionFactory);
 
             this.AddRuleIfNeeded();
             this.RuleBeingBuilt.UseApplicator(call => throw exceptionFactory(call));
@@ -81,7 +81,7 @@ namespace FakeItEasy.Configuration
 
         public IVoidConfiguration WhenArgumentsMatch(Func<ArgumentCollection, bool> argumentsPredicate)
         {
-            Guard.AgainstNull(argumentsPredicate, nameof(argumentsPredicate));
+            Guard.AgainstNull(argumentsPredicate);
 
             this.RuleBeingBuilt.UsePredicateToValidateArguments(argumentsPredicate);
             return this;
@@ -96,7 +96,7 @@ namespace FakeItEasy.Configuration
 
         public virtual IVoidAfterCallbackConfiguredConfiguration Invokes(Action<IFakeObjectCall> action)
         {
-            Guard.AgainstNull(action, nameof(action));
+            Guard.AgainstNull(action);
 
             this.AddRuleIfNeeded();
             this.RuleBeingBuilt.Actions.Add(action);
@@ -131,7 +131,7 @@ namespace FakeItEasy.Configuration
 
         public virtual IAfterCallConfiguredConfiguration<IVoidConfiguration> AssignsOutAndRefParametersLazily(Func<IFakeObjectCall, ICollection<object?>> valueProducer)
         {
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(valueProducer);
 
             this.AddRuleIfNeeded();
             this.RuleBeingBuilt.SetOutAndRefParametersValueProducer(valueProducer);
@@ -141,22 +141,22 @@ namespace FakeItEasy.Configuration
 
         public UnorderedCallAssertion MustHaveHappened(int numberOfTimes, Times timesOption)
         {
-            Guard.AgainstNull(timesOption, nameof(timesOption));
+            Guard.AgainstNull(timesOption);
 
             return this.MustHaveHappened(timesOption.ToCallCountConstraint(numberOfTimes));
         }
 
         public UnorderedCallAssertion MustHaveHappenedANumberOfTimesMatching(Expression<Func<int, bool>> predicate)
         {
-            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(predicate);
 
             return this.MustHaveHappened(new CallCountConstraint(predicate.Compile(), $"a number of times matching the predicate '{predicate}'"));
         }
 
         public IAnyCallConfigurationWithVoidReturnType Where(Func<IFakeObjectCall, bool> predicate, Action<IOutputWriter> descriptionWriter)
         {
-            Guard.AgainstNull(predicate, nameof(predicate));
-            Guard.AgainstNull(descriptionWriter, nameof(descriptionWriter));
+            Guard.AgainstNull(predicate);
+            Guard.AgainstNull(descriptionWriter);
 
             this.RuleBeingBuilt.ApplyWherePredicate(predicate, descriptionWriter);
             return this;
@@ -218,7 +218,7 @@ namespace FakeItEasy.Configuration
 
             public IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TMember>> ReturnsLazily(Func<IFakeObjectCall, TMember> valueProducer)
             {
-                Guard.AgainstNull(valueProducer, nameof(valueProducer));
+                Guard.AgainstNull(valueProducer);
 
                 this.ParentConfiguration.AddRuleIfNeeded();
                 this.ParentConfiguration.RuleBeingBuilt.UseApplicator(call => call.SetReturnValue(valueProducer(call)));
@@ -257,8 +257,8 @@ namespace FakeItEasy.Configuration
 
             public IAnyCallConfigurationWithReturnTypeSpecified<TMember> Where(Func<IFakeObjectCall, bool> predicate, Action<IOutputWriter> descriptionWriter)
             {
-                Guard.AgainstNull(predicate, nameof(predicate));
-                Guard.AgainstNull(descriptionWriter, nameof(descriptionWriter));
+                Guard.AgainstNull(predicate);
+                Guard.AgainstNull(descriptionWriter);
 
                 this.ParentConfiguration.RuleBeingBuilt.ApplyWherePredicate(predicate, descriptionWriter);
                 return this;
@@ -289,7 +289,7 @@ namespace FakeItEasy.Configuration
 
             public bool Matches(IFakeObjectCall call)
             {
-                Guard.AgainstNull(call, nameof(call));
+                Guard.AgainstNull(call);
 
                 return this.builder.RuleBeingBuilt.IsApplicableTo(call) &&
                        ReferenceEquals(this.builder.manager.Object, call.FakedObject);

--- a/src/FakeItEasy/Configuration/StartConfiguration.cs
+++ b/src/FakeItEasy/Configuration/StartConfiguration.cs
@@ -24,7 +24,7 @@ namespace FakeItEasy.Configuration
 
         public IReturnValueArgumentValidationConfiguration<TMember> CallsTo<TMember>(Expression<Func<TFake, TMember>> callSpecification)
         {
-            Guard.AgainstNull(callSpecification, nameof(callSpecification));
+            Guard.AgainstNull(callSpecification);
 
             var parsedCallExpression = this.expressionParser.Parse(callSpecification, this.manager.Object!);
             this.GuardAgainstWrongFake(parsedCallExpression.CallTarget);
@@ -36,7 +36,7 @@ namespace FakeItEasy.Configuration
 
         public IVoidArgumentValidationConfiguration CallsTo(Expression<Action<TFake>> callSpecification)
         {
-            Guard.AgainstNull(callSpecification, nameof(callSpecification));
+            Guard.AgainstNull(callSpecification);
 
             var parsedCallExpression = this.expressionParser.Parse(callSpecification, this.manager.Object!);
             this.GuardAgainstWrongFake(parsedCallExpression.CallTarget);
@@ -48,7 +48,7 @@ namespace FakeItEasy.Configuration
 
         public IPropertySetterAnyValueConfiguration<TValue> CallsToSet<TValue>(Expression<Func<TFake, TValue>> propertySpecification)
         {
-            Guard.AgainstNull(propertySpecification, nameof(propertySpecification));
+            Guard.AgainstNull(propertySpecification);
 
             var parsedCallExpression = this.expressionParser.Parse(propertySpecification, this.manager.Object!);
             this.GuardAgainstWrongFake(parsedCallExpression.CallTarget);

--- a/src/FakeItEasy/Configuration/UnorderedCallAssertion.cs
+++ b/src/FakeItEasy/Configuration/UnorderedCallAssertion.cs
@@ -29,7 +29,7 @@ namespace FakeItEasy.Configuration
         /// <exception cref="ExpectationException">The call was not made in the expected order.</exception>
         public IOrderableCallAssertion Then(UnorderedCallAssertion nextAssertion)
         {
-            Guard.AgainstNull(nextAssertion, nameof(nextAssertion));
+            Guard.AgainstNull(nextAssertion);
 
             var context = ServiceLocator.Resolve<SequentialCallContext.Factory>().Invoke();
             this.CheckCallHappenedInOrder(context);
@@ -52,7 +52,7 @@ namespace FakeItEasy.Configuration
 
             public IOrderableCallAssertion Then(UnorderedCallAssertion nextAssertion)
             {
-                Guard.AgainstNull(nextAssertion, nameof(nextAssertion));
+                Guard.AgainstNull(nextAssertion);
 
                 nextAssertion.CheckCallHappenedInOrder(this.context);
                 return this;

--- a/src/FakeItEasy/Core/ArgumentValueFormatter.cs
+++ b/src/FakeItEasy/Core/ArgumentValueFormatter.cs
@@ -94,7 +94,7 @@ namespace FakeItEasy.Core
 
             protected override string GetStringValue(object argumentValue)
             {
-                Guard.AgainstNull(argumentValue, nameof(argumentValue));
+                Guard.AgainstNull(argumentValue);
 
                 return Fake.TryGetFakeManager(argumentValue, out var manager)
                     ? manager.FakeObjectDisplayName
@@ -116,7 +116,7 @@ namespace FakeItEasy.Core
 
             protected override string GetStringValue(IEnumerable argumentValue)
             {
-                Guard.AgainstNull(argumentValue, nameof(argumentValue));
+                Guard.AgainstNull(argumentValue);
 
                 var writer = new StringBuilderOutputWriter(this.formatter);
                 writer.Write("[");
@@ -133,7 +133,7 @@ namespace FakeItEasy.Core
 
             protected override string GetStringValue(string argumentValue)
             {
-                Guard.AgainstNull(argumentValue, nameof(argumentValue));
+                Guard.AgainstNull(argumentValue);
 
                 if (argumentValue.Length == 0)
                 {

--- a/src/FakeItEasy/Core/AssemblyExtensions.cs
+++ b/src/FakeItEasy/Core/AssemblyExtensions.cs
@@ -12,7 +12,7 @@ namespace FakeItEasy.Core
         /// <returns>Whether or not the assembly references FakeItEasy.</returns>
         public static bool ReferencesFakeItEasy(this Assembly assembly)
         {
-            Guard.AgainstNull(assembly, nameof(assembly));
+            Guard.AgainstNull(assembly);
 
             return assembly.GetReferencedAssemblies().Any(r => r.FullName == TypeCatalogue.FakeItEasyAssembly.FullName);
         }

--- a/src/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
+++ b/src/FakeItEasy/Core/DefaultFakeManagerAccessor.cs
@@ -19,7 +19,7 @@ namespace FakeItEasy.Core
         /// <exception cref="ArgumentException">If <paramref name="proxy"/> is not actually a faked object.</exception>
         public FakeManager GetFakeManager(object proxy)
         {
-            Guard.AgainstNull(proxy, nameof(proxy));
+            Guard.AgainstNull(proxy);
 
             FakeManager? result = this.TryGetFakeManager(proxy);
 
@@ -38,7 +38,7 @@ namespace FakeItEasy.Core
         /// <returns>The fake manager, or <c>null</c> if <paramref name="proxy"/> is not actually a faked object.</returns>
         public FakeManager? TryGetFakeManager(object proxy)
         {
-            Guard.AgainstNull(proxy, nameof(proxy));
+            Guard.AgainstNull(proxy);
 
             FakeManagers.TryGetValue(proxy, out FakeManager? fakeManager);
             return fakeManager;
@@ -46,8 +46,8 @@ namespace FakeItEasy.Core
 
         public void SetFakeManager(object proxy, FakeManager manager)
         {
-            Guard.AgainstNull(proxy, nameof(proxy));
-            Guard.AgainstNull(manager, nameof(manager));
+            Guard.AgainstNull(proxy);
+            Guard.AgainstNull(manager);
 
             FakeManagers.Add(proxy, manager);
         }

--- a/src/FakeItEasy/Core/DelegateRaiser.cs
+++ b/src/FakeItEasy/Core/DelegateRaiser.cs
@@ -39,7 +39,7 @@ namespace FakeItEasy.Core
         [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates", Justification = "Provides the event raising syntax.")]
         public static implicit operator TEventHandler(DelegateRaiser<TEventHandler> raiser)
         {
-            Guard.AgainstNull(raiser, nameof(raiser));
+            Guard.AgainstNull(raiser);
 
             return raiser.EventHandler;
         }

--- a/src/FakeItEasy/Core/FakeAsserter.cs
+++ b/src/FakeItEasy/Core/FakeAsserter.cs
@@ -14,8 +14,8 @@ namespace FakeItEasy.Core
 
         public FakeAsserter(IEnumerable<CompletedFakeObjectCall> calls, int lastSequenceNumber, CallWriter callWriter, StringBuilderOutputWriter.Factory outputWriterFactory)
         {
-            Guard.AgainstNull(calls, nameof(calls));
-            Guard.AgainstNull(callWriter, nameof(callWriter));
+            Guard.AgainstNull(calls);
+            Guard.AgainstNull(callWriter);
 
             this.calls = calls;
             this.lastSequenceNumber = lastSequenceNumber;

--- a/src/FakeItEasy/Core/FakeCallEqualityComparer.cs
+++ b/src/FakeItEasy/Core/FakeCallEqualityComparer.cs
@@ -8,8 +8,8 @@ namespace FakeItEasy.Core
     {
         public bool Equals(IFakeObjectCall? x, IFakeObjectCall? y)
         {
-            Guard.AgainstNull(x, nameof(x));
-            Guard.AgainstNull(y, nameof(y));
+            Guard.AgainstNull(x);
+            Guard.AgainstNull(y);
 
             return x.Method.Equals(y.Method)
                 && object.ReferenceEquals(x.FakedObject, y.FakedObject)
@@ -19,7 +19,7 @@ namespace FakeItEasy.Core
         // NOTE (adamralph): based on https://stackoverflow.com/a/263416/49241
         public int GetHashCode(IFakeObjectCall obj)
         {
-            Guard.AgainstNull(obj, nameof(obj));
+            Guard.AgainstNull(obj);
 
             var hash = 17;
             unchecked

--- a/src/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.AutoFakePropertyRule.cs
@@ -10,14 +10,14 @@ namespace FakeItEasy.Core
         {
             public override bool IsApplicableTo(IFakeObjectCall fakeObjectCall)
             {
-                Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
+                Guard.AgainstNull(fakeObjectCall);
 
                 return PropertyBehaviorRule.IsPropertyGetter(fakeObjectCall.Method);
             }
 
             public override void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
-                Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
+                Guard.AgainstNull(fakeObjectCall);
 
                 var newRule = CallRuleMetadata.CalledOnce(
                     new PropertyBehaviorRule(fakeObjectCall.Method)

--- a/src/FakeItEasy/Core/FakeManager.CancellationRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.CancellationRule.cs
@@ -14,7 +14,7 @@ namespace FakeItEasy.Core
 
             public override void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
-                Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
+                Guard.AgainstNull(fakeObjectCall);
 
                 var returnType = fakeObjectCall.Method.ReturnType;
                 if (typeof(Task).IsAssignableFrom(returnType))

--- a/src/FakeItEasy/Core/FakeManager.DefaultReturnValueRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.DefaultReturnValueRule.cs
@@ -10,7 +10,7 @@ namespace FakeItEasy.Core
 
             public override void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
-                Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
+                Guard.AgainstNull(fakeObjectCall);
 
                 fakeObjectCall.SetReturnValue(fakeObjectCall.GetDefaultReturnValue());
             }

--- a/src/FakeItEasy/Core/FakeManager.EventRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.EventRule.cs
@@ -16,7 +16,7 @@ namespace FakeItEasy.Core
 
             public bool IsApplicableTo(IFakeObjectCall fakeObjectCall)
             {
-                Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
+                Guard.AgainstNull(fakeObjectCall);
 
                 return EventCall.TryGetEventCall(fakeObjectCall, out _);
             }

--- a/src/FakeItEasy/Core/FakeManager.PropertyBehaviorRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.PropertyBehaviorRule.cs
@@ -47,7 +47,7 @@ namespace FakeItEasy.Core
 
             public void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
-                Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
+                Guard.AgainstNull(fakeObjectCall);
 
                 fakeObjectCall.SetReturnValue(this.Value);
             }

--- a/src/FakeItEasy/Core/FakeManager.PropertySetterRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.PropertySetterRule.cs
@@ -10,14 +10,14 @@ namespace FakeItEasy.Core
         {
             public override bool IsApplicableTo(IFakeObjectCall fakeObjectCall)
             {
-                Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
+                Guard.AgainstNull(fakeObjectCall);
 
                 return PropertyBehaviorRule.IsPropertySetter(fakeObjectCall.Method);
             }
 
             public override void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
-                Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
+                Guard.AgainstNull(fakeObjectCall);
 
                 Fake.GetFakeManager(fakeObjectCall.FakedObject).MutateUserRules(allUserRules =>
                 {

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -43,8 +43,8 @@ namespace FakeItEasy.Core
         /// <param name="fakeObjectName">The name of the fake object.</param>
         internal FakeManager(Type fakeObjectType, object proxy, string? fakeObjectName)
         {
-            Guard.AgainstNull(fakeObjectType, nameof(fakeObjectType));
-            Guard.AgainstNull(proxy, nameof(proxy));
+            Guard.AgainstNull(fakeObjectType);
+            Guard.AgainstNull(proxy);
 
             this.objectReference = new WeakReference(proxy);
             this.FakeObjectType = fakeObjectType;
@@ -111,7 +111,7 @@ namespace FakeItEasy.Core
         /// <param name="rule">The rule to add.</param>
         public virtual void AddRuleFirst(IFakeObjectCallRule rule)
         {
-            Guard.AgainstNull(rule, nameof(rule));
+            Guard.AgainstNull(rule);
 
             lock (this.allUserRules)
             {
@@ -125,7 +125,7 @@ namespace FakeItEasy.Core
         /// <param name="rule">The rule to add.</param>
         public virtual void AddRuleLast(IFakeObjectCallRule rule)
         {
-            Guard.AgainstNull(rule, nameof(rule));
+            Guard.AgainstNull(rule);
 
             lock (this.allUserRules)
             {
@@ -139,7 +139,7 @@ namespace FakeItEasy.Core
         /// <param name="rule">The rule to remove.</param>
         public virtual void RemoveRule(IFakeObjectCallRule rule)
         {
-            Guard.AgainstNull(rule, nameof(rule));
+            Guard.AgainstNull(rule);
 
             lock (this.allUserRules)
             {
@@ -157,7 +157,7 @@ namespace FakeItEasy.Core
         /// <param name="listener">The listener to add.</param>
         public void AddInterceptionListener(IInterceptionListener listener)
         {
-            Guard.AgainstNull(listener, nameof(listener));
+            Guard.AgainstNull(listener);
 
             this.interceptionListeners.AddFirst(listener);
         }

--- a/src/FakeItEasy/Core/FakeManagerProvider.cs
+++ b/src/FakeItEasy/Core/FakeManagerProvider.cs
@@ -28,10 +28,10 @@ namespace FakeItEasy.Core
                 Type typeOfFake,
                 IProxyOptions proxyOptions)
         {
-            Guard.AgainstNull(fakeManagerFactory, nameof(fakeManagerFactory));
-            Guard.AgainstNull(fakeManagerAccessor, nameof(fakeManagerAccessor));
-            Guard.AgainstNull(typeOfFake, nameof(typeOfFake));
-            Guard.AgainstNull(proxyOptions, nameof(proxyOptions));
+            Guard.AgainstNull(fakeManagerFactory);
+            Guard.AgainstNull(fakeManagerAccessor);
+            Guard.AgainstNull(typeOfFake);
+            Guard.AgainstNull(proxyOptions);
 
             this.fakeManagerFactory = fakeManagerFactory;
             this.fakeManagerAccessor = fakeManagerAccessor;
@@ -41,7 +41,7 @@ namespace FakeItEasy.Core
 
         public IFakeCallProcessor Fetch(object proxy)
         {
-            Guard.AgainstNull(proxy, nameof(proxy));
+            Guard.AgainstNull(proxy);
 
             lock (this.initializedFakeManagerLock)
             {
@@ -53,7 +53,7 @@ namespace FakeItEasy.Core
 
         public void EnsureInitialized(object proxy)
         {
-            Guard.AgainstNull(proxy, nameof(proxy));
+            Guard.AgainstNull(proxy);
 
             lock (this.initializedFakeManagerLock)
             {

--- a/src/FakeItEasy/Core/InterceptedFakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/Core/InterceptedFakeObjectCallExtensions.cs
@@ -15,8 +15,8 @@ namespace FakeItEasy.Core
 
         public static void CallWrappedMethod(this IInterceptedFakeObjectCall fakeObjectCall, object wrappedObject)
         {
-            Guard.AgainstNull(fakeObjectCall, nameof(fakeObjectCall));
-            Guard.AgainstNull(wrappedObject, nameof(wrappedObject));
+            Guard.AgainstNull(fakeObjectCall);
+            Guard.AgainstNull(wrappedObject);
 
             var parameters = fakeObjectCall.Arguments.GetUnderlyingArgumentsArray();
             object? returnValue;

--- a/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
+++ b/src/FakeItEasy/Core/Raise.of.TEventArgs.cs
@@ -49,7 +49,7 @@ namespace FakeItEasy.Core
         [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates", Justification = "Provides the event raising syntax.")]
         public static implicit operator EventHandler<TEventArgs>(Raise<TEventArgs> raiser)
         {
-            Guard.AgainstNull(raiser, nameof(raiser));
+            Guard.AgainstNull(raiser);
 
             return raiser.Now;
         }
@@ -62,7 +62,7 @@ namespace FakeItEasy.Core
         [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates", Justification = "Provides the event raising syntax.")]
         public static implicit operator EventHandler(Raise<TEventArgs> raiser)
         {
-            Guard.AgainstNull(raiser, nameof(raiser));
+            Guard.AgainstNull(raiser);
 
             return raiser.Now;
         }

--- a/src/FakeItEasy/Core/SequentialCallContext.cs
+++ b/src/FakeItEasy/Core/SequentialCallContext.cs
@@ -14,7 +14,7 @@ namespace FakeItEasy.Core
 
         public SequentialCallContext(CallWriter callWriter, StringBuilderOutputWriter.Factory outputWriterFactory)
         {
-            Guard.AgainstNull(callWriter, nameof(callWriter));
+            Guard.AgainstNull(callWriter);
             this.callWriter = callWriter;
             this.outputWriterFactory = outputWriterFactory;
             this.fakeManagers = new HashSet<FakeManager>();
@@ -30,10 +30,10 @@ namespace FakeItEasy.Core
             Action<IOutputWriter> callDescriber,
             CallCountConstraint callCountConstraint)
         {
-            Guard.AgainstNull(fakeManager, nameof(fakeManager));
-            Guard.AgainstNull(callPredicate, nameof(callPredicate));
-            Guard.AgainstNull(callDescriber, nameof(callDescriber));
-            Guard.AgainstNull(callCountConstraint, nameof(callCountConstraint));
+            Guard.AgainstNull(fakeManager);
+            Guard.AgainstNull(callPredicate);
+            Guard.AgainstNull(callDescriber);
+            Guard.AgainstNull(callCountConstraint);
             this.fakeManagers.Add(fakeManager);
             this.assertedCalls.Add(
                 new AssertedCall { CallDescriber = callDescriber, MatchingCountDescription = callCountConstraint.ToString() });

--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
@@ -22,10 +22,10 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
             IEnumerable<Expression<Func<Attribute>>> attributes,
             IFakeCallProcessorProvider fakeCallProcessorProvider)
         {
-            Guard.AgainstNull(typeOfProxy, nameof(typeOfProxy));
-            Guard.AgainstNull(additionalInterfacesToImplement, nameof(additionalInterfacesToImplement));
-            Guard.AgainstNull(attributes, nameof(attributes));
-            Guard.AgainstNull(fakeCallProcessorProvider, nameof(fakeCallProcessorProvider));
+            Guard.AgainstNull(typeOfProxy);
+            Guard.AgainstNull(additionalInterfacesToImplement);
+            Guard.AgainstNull(attributes);
+            Guard.AgainstNull(fakeCallProcessorProvider);
 
             var options = CreateProxyGenerationOptions();
             foreach (var attribute in attributes)
@@ -64,11 +64,11 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
             IEnumerable<Expression<Func<Attribute>>> attributes,
             IFakeCallProcessorProvider fakeCallProcessorProvider)
         {
-            Guard.AgainstNull(typeOfProxy, nameof(typeOfProxy));
-            Guard.AgainstNull(additionalInterfacesToImplement, nameof(additionalInterfacesToImplement));
-            Guard.AgainstNull(attributes, nameof(attributes));
-            Guard.AgainstNull(argumentsForConstructor, nameof(argumentsForConstructor));
-            Guard.AgainstNull(fakeCallProcessorProvider, nameof(fakeCallProcessorProvider));
+            Guard.AgainstNull(typeOfProxy);
+            Guard.AgainstNull(additionalInterfacesToImplement);
+            Guard.AgainstNull(attributes);
+            Guard.AgainstNull(argumentsForConstructor);
+            Guard.AgainstNull(fakeCallProcessorProvider);
 
             if (!CanGenerateProxy(typeOfProxy, out string? failReason))
             {
@@ -181,7 +181,7 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
 
             public void Intercept(IInvocation invocation)
             {
-                Guard.AgainstNull(invocation, nameof(invocation));
+                Guard.AgainstNull(invocation);
                 var call = new CastleInvocationCallAdapter(invocation);
                 this.fakeCallProcessorProvider.Fetch(invocation.Proxy).Process(call);
             }

--- a/src/FakeItEasy/Creation/CreationResult.cs
+++ b/src/FakeItEasy/Creation/CreationResult.cs
@@ -83,7 +83,7 @@ namespace FakeItEasy.Creation
 
             public override CreationResult MergeIntoDummyResult(CreationResult other)
             {
-                Guard.AgainstNull(other, "other");
+                Guard.AgainstNull(other);
 
                 if (other.WasSuccessful)
                 {

--- a/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyGenerator.cs
@@ -21,7 +21,7 @@ namespace FakeItEasy.Creation.DelegateProxies
             Type typeOfProxy,
             IFakeCallProcessorProvider fakeCallProcessorProvider)
         {
-            Guard.AgainstNull(typeOfProxy, nameof(typeOfProxy));
+            Guard.AgainstNull(typeOfProxy);
 
             var invokeMethod = typeOfProxy.GetMethod("Invoke")!;
 

--- a/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyInterceptionValidator.cs
+++ b/src/FakeItEasy/Creation/DelegateProxies/DelegateProxyInterceptionValidator.cs
@@ -7,7 +7,7 @@ namespace FakeItEasy.Creation.DelegateProxies
     {
         public virtual bool MethodCanBeInterceptedOnInstance(MethodInfo method, object? callTarget, [NotNullWhen(false)]out string? failReason)
         {
-            Guard.AgainstNull(method, nameof(method));
+            Guard.AgainstNull(method);
 
             if (method.Name != "Invoke")
             {

--- a/src/FakeItEasy/Creation/FakeOptions.cs
+++ b/src/FakeItEasy/Creation/FakeOptions.cs
@@ -17,7 +17,7 @@ namespace FakeItEasy.Creation
 
         IFakeOptions IFakeOptions.ConfigureFake(Action<object> action)
         {
-            Guard.AgainstNull(action, nameof(action));
+            Guard.AgainstNull(action);
 
             return (IFakeOptions)this.ConfigureFake(fake => action(fake));
         }
@@ -49,14 +49,14 @@ namespace FakeItEasy.Creation
 
         public IFakeOptions<T> WithArgumentsForConstructor(Expression<Func<T>> constructorCall)
         {
-            Guard.AgainstNull(constructorCall, nameof(constructorCall));
+            Guard.AgainstNull(constructorCall);
 
             return this.WithArgumentsForConstructor(GetConstructorArgumentsFromExpression(constructorCall));
         }
 
         IFakeOptions IFakeOptions.WithArgumentsForConstructor<TConstructor>(Expression<Func<TConstructor>> constructorCall)
         {
-            Guard.AgainstNull(constructorCall, nameof(constructorCall));
+            Guard.AgainstNull(constructorCall);
 
             return (IFakeOptions)this.WithArgumentsForConstructor(GetConstructorArgumentsFromExpression(constructorCall));
         }
@@ -68,7 +68,7 @@ namespace FakeItEasy.Creation
 
         public IFakeOptions<T> WithArgumentsForConstructor(IEnumerable<object?> argumentsForConstructor)
         {
-            Guard.AgainstNull(argumentsForConstructor, nameof(argumentsForConstructor));
+            Guard.AgainstNull(argumentsForConstructor);
 
             this.proxyOptions.ArgumentsForConstructor = argumentsForConstructor;
             return this;
@@ -77,7 +77,7 @@ namespace FakeItEasy.Creation
         public IFakeOptions<T> WithAttributes(
             params Expression<Func<Attribute>>[] attributes)
         {
-            Guard.AgainstNull(attributes, nameof(attributes));
+            Guard.AgainstNull(attributes);
 
             foreach (var attribute in attributes)
             {
@@ -89,7 +89,7 @@ namespace FakeItEasy.Creation
 
         public IFakeOptions<T> Wrapping(T wrappedInstance)
         {
-            Guard.AgainstNull(wrappedInstance, nameof(wrappedInstance));
+            Guard.AgainstNull(wrappedInstance);
 
             this.ConfigureFake(fake => ConfigureFakeToWrap(fake, wrappedInstance));
             return this;
@@ -97,7 +97,7 @@ namespace FakeItEasy.Creation
 
         public IFakeOptions<T> Implements(Type interfaceType)
         {
-            Guard.AgainstNull(interfaceType, nameof(interfaceType));
+            Guard.AgainstNull(interfaceType);
 
             this.proxyOptions.AddInterfaceToImplement(interfaceType);
             return this;
@@ -105,7 +105,7 @@ namespace FakeItEasy.Creation
 
         public IFakeOptions<T> ConfigureFake(Action<T> action)
         {
-            Guard.AgainstNull(action, nameof(action));
+            Guard.AgainstNull(action);
 
             this.proxyOptions.AddProxyConfigurationAction(proxy => action((T)proxy));
             return this;
@@ -113,7 +113,7 @@ namespace FakeItEasy.Creation
 
         public IFakeOptions<T> Named(string name)
         {
-            Guard.AgainstNull(name, nameof(name));
+            Guard.AgainstNull(name);
 
             this.proxyOptions.Name = name;
             return this;

--- a/src/FakeItEasy/Creation/ProxyGeneratorResult.cs
+++ b/src/FakeItEasy/Creation/ProxyGeneratorResult.cs
@@ -18,7 +18,7 @@ namespace FakeItEasy.Creation
         /// </param>
         public ProxyGeneratorResult(string reasonForFailure)
         {
-            Guard.AgainstNull(reasonForFailure, nameof(reasonForFailure));
+            Guard.AgainstNull(reasonForFailure);
 
             this.ReasonForFailure = reasonForFailure;
         }
@@ -36,8 +36,8 @@ namespace FakeItEasy.Creation
         /// </param>
         public ProxyGeneratorResult(string reasonForFailure, Exception exception)
         {
-            Guard.AgainstNull(reasonForFailure, nameof(reasonForFailure));
-            Guard.AgainstNull(exception, nameof(exception));
+            Guard.AgainstNull(reasonForFailure);
+            Guard.AgainstNull(exception);
 
             if (exception is TargetInvocationException && exception.InnerException is not null)
             {
@@ -64,7 +64,7 @@ namespace FakeItEasy.Creation
         /// </param>
         public ProxyGeneratorResult(object generatedProxy)
         {
-            Guard.AgainstNull(generatedProxy, nameof(generatedProxy));
+            Guard.AgainstNull(generatedProxy);
 
             this.GeneratedProxy = generatedProxy;
         }

--- a/src/FakeItEasy/Creation/ProxyOptions.cs
+++ b/src/FakeItEasy/Creation/ProxyOptions.cs
@@ -27,7 +27,7 @@ namespace FakeItEasy.Creation
 
         public void AddInterfaceToImplement(Type interfaceType)
         {
-            Guard.AgainstNull(interfaceType, nameof(interfaceType));
+            Guard.AgainstNull(interfaceType);
 
             if (!interfaceType.IsInterface)
             {

--- a/src/FakeItEasy/DefaultOutputWriter.cs
+++ b/src/FakeItEasy/DefaultOutputWriter.cs
@@ -23,7 +23,7 @@ namespace FakeItEasy
 
         public IOutputWriter Write(string value)
         {
-            Guard.AgainstNull(value, nameof(value));
+            Guard.AgainstNull(value);
 
             foreach (var character in value)
             {

--- a/src/FakeItEasy/ExceptionThrowerConfigurationExtensions.cs
+++ b/src/FakeItEasy/ExceptionThrowerConfigurationExtensions.cs
@@ -19,8 +19,8 @@ namespace FakeItEasy
         /// <returns>Configuration object.</returns>
         public static IAfterCallConfiguredConfiguration<TInterface> Throws<TInterface>(this IExceptionThrowerConfiguration<TInterface> configuration, Exception exception)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exception, nameof(exception));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exception);
 
             return configuration.Throws(_ => exception);
         }
@@ -35,8 +35,8 @@ namespace FakeItEasy
         /// <returns>Configuration object.</returns>
         public static IAfterCallConfiguredConfiguration<TInterface> Throws<TInterface>(this IExceptionThrowerConfiguration<TInterface> configuration, Func<Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.Throws(_ => exceptionFactory());
         }
@@ -52,7 +52,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "By design.")]
         internal static IAfterCallConfiguredConfiguration<TInterface> Throws<TInterface, T>(this IExceptionThrowerConfiguration<TInterface> configuration) where T : Exception, new()
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.Throws(_ => new T());
         }

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/RefArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/RefArgumentConstraint.cs
@@ -14,7 +14,7 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
         /// <param name="value">The value to be used when implicitly assigning values to a call's ref parameter.</param>
         public RefArgumentConstraint(IArgumentConstraint baseConstraint, object? value)
         {
-            Guard.AgainstNull(baseConstraint, nameof(baseConstraint));
+            Guard.AgainstNull(baseConstraint);
 
             this.baseConstraint = baseConstraint;
             this.Value = value;

--- a/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallMatcher.cs
@@ -55,7 +55,7 @@ namespace FakeItEasy.Expressions
         /// <returns>True if the call is matched by the expression.</returns>
         public virtual bool Matches(IFakeObjectCall call)
         {
-            Guard.AgainstNull(call, nameof(call));
+            Guard.AgainstNull(call);
 
             return this.InvokesSameMethodOnTarget(call.FakedObject.GetType(), call.Method, this.Method)
                 && this.ArgumentsMatches(call.Arguments);

--- a/src/FakeItEasy/Expressions/ExpressionCallRule.cs
+++ b/src/FakeItEasy/Expressions/ExpressionCallRule.cs
@@ -17,7 +17,7 @@ namespace FakeItEasy.Expressions
         /// <param name="expressionMatcher">The expression matcher to use.</param>
         public ExpressionCallRule(ExpressionCallMatcher expressionMatcher)
         {
-            Guard.AgainstNull(expressionMatcher, nameof(expressionMatcher));
+            Guard.AgainstNull(expressionMatcher);
 
             this.ExpressionMatcher = expressionMatcher;
             this.OutAndRefParametersValueProducer = expressionMatcher.GetOutAndRefParametersValueProducer();

--- a/src/FakeItEasy/Fake.cs
+++ b/src/FakeItEasy/Fake.cs
@@ -23,7 +23,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "object", Justification = "The term fake object does not refer to the type System.Object.")]
         public static FakeManager GetFakeManager(object fakedObject)
         {
-            Guard.AgainstNull(fakedObject, nameof(fakedObject));
+            Guard.AgainstNull(fakedObject);
 
             return FakeManagerAccessor.GetFakeManager(fakedObject);
         }
@@ -37,7 +37,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "object", Justification = "The term fake object does not refer to the type System.Object.")]
         public static IEnumerable<ICompletedFakeObjectCall> GetCalls(object fakedObject)
         {
-            Guard.AgainstNull(fakedObject, nameof(fakedObject));
+            Guard.AgainstNull(fakedObject);
 
             return FakeManagerAccessor.GetFakeManager(fakedObject).GetRecordedCalls();
         }
@@ -50,7 +50,7 @@ namespace FakeItEasy
         [Obsolete("ClearConfiguration will be removed in version 8.0.0. Prefer to discard the fake and create a new one.")]
         public static void ClearConfiguration(object fakedObject)
         {
-            Guard.AgainstNull(fakedObject, nameof(fakedObject));
+            Guard.AgainstNull(fakedObject);
 
             var manager = FakeManagerAccessor.GetFakeManager(fakedObject);
             manager.ClearUserRules();
@@ -63,7 +63,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "object", Justification = "The term fake object does not refer to the type System.Object.")]
         public static void ClearRecordedCalls(object fakedObject)
         {
-            Guard.AgainstNull(fakedObject, nameof(fakedObject));
+            Guard.AgainstNull(fakedObject);
 
             var manager = FakeManagerAccessor.GetFakeManager(fakedObject);
             manager.ClearRecordedCalls();
@@ -78,7 +78,7 @@ namespace FakeItEasy
         [DebuggerStepThrough]
         public static bool TryGetFakeManager(object potentialFake, [NotNullWhen(true)] out FakeManager? fakeManager)
         {
-            Guard.AgainstNull(potentialFake, nameof(potentialFake));
+            Guard.AgainstNull(potentialFake);
 
             fakeManager = FakeManagerAccessor.TryGetFakeManager(potentialFake);
             return fakeManager is not null;
@@ -92,7 +92,7 @@ namespace FakeItEasy
         [DebuggerStepThrough]
         public static bool IsFake(object potentialFake)
         {
-            Guard.AgainstNull(potentialFake, nameof(potentialFake));
+            Guard.AgainstNull(potentialFake);
 
             return TryGetFakeManager(potentialFake, out _);
         }

--- a/src/FakeItEasy/Fake.of.T.cs
+++ b/src/FakeItEasy/Fake.of.T.cs
@@ -34,7 +34,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design when using the Expression-, Action- and Func-types.")]
         public Fake(Action<IFakeOptions<T>> optionsBuilder)
         {
-            Guard.AgainstNull(optionsBuilder, nameof(optionsBuilder));
+            Guard.AgainstNull(optionsBuilder);
 
             this.FakedObject = CreateFake(optionsBuilder);
         }
@@ -117,7 +117,7 @@ namespace FakeItEasy
 
         private static T CreateFake(Action<IFakeOptions<T>> optionsBuilder)
         {
-            Guard.AgainstNull(optionsBuilder, nameof(optionsBuilder));
+            Guard.AgainstNull(optionsBuilder);
 
             return (T)FakeAndDummyManager.CreateFake(
                 typeof(T),

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -25,7 +25,7 @@
   <!-- .NET 5.0 -->
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <DefineConstants>$(DefineConstants);FEATURE_STRING_CONTAINS_COMPARISONTYPE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRING_CONTAINS_COMPARISONTYPE;FEATURE_CALLERARGUMENTEXPRESSION</DefineConstants>
   </PropertyGroup>
 
   <!-- .NET Standard 2.1 -->

--- a/src/FakeItEasy/FakeObjectCallExtensions.cs
+++ b/src/FakeItEasy/FakeObjectCallExtensions.cs
@@ -21,7 +21,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Generic argument is used to cast the result.")]
         public static T GetArgument<T>(this IFakeObjectCall call, int argumentIndex)
         {
-            Guard.AgainstNull(call, nameof(call));
+            Guard.AgainstNull(call);
 
             return call.Arguments.Get<T>(argumentIndex);
         }
@@ -38,8 +38,8 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Generic argument is used to cast the result.")]
         public static T GetArgument<T>(this IFakeObjectCall call, string argumentName)
         {
-            Guard.AgainstNull(call, nameof(call));
-            Guard.AgainstNull(argumentName, nameof(argumentName));
+            Guard.AgainstNull(call);
+            Guard.AgainstNull(argumentName);
 
             return call.Arguments.Get<T>(argumentName);
         }

--- a/src/FakeItEasy/FakeOptionsExtensions.cs
+++ b/src/FakeItEasy/FakeOptionsExtensions.cs
@@ -32,7 +32,7 @@ namespace FakeItEasy
         /// <returns>An options object.</returns>
         public static IFakeOptions<T> Strict<T>(this IFakeOptions<T> options, StrictFakeOptions strictOptions) where T : class
         {
-            Guard.AgainstNull(options, nameof(options));
+            Guard.AgainstNull(options);
 
             return options.ConfigureFake(fake =>
             {
@@ -63,7 +63,7 @@ namespace FakeItEasy
         /// <returns>An options object.</returns>
         public static IFakeOptions Strict(this IFakeOptions options, StrictFakeOptions strictOptions)
         {
-            Guard.AgainstNull(options, nameof(options));
+            Guard.AgainstNull(options);
 
             return options.ConfigureFake(fake =>
             {
@@ -80,7 +80,7 @@ namespace FakeItEasy
         /// <returns>An options object.</returns>
         public static IFakeOptions<T> CallsBaseMethods<T>(this IFakeOptions<T> options) where T : class
         {
-            Guard.AgainstNull(options, nameof(options));
+            Guard.AgainstNull(options);
 
             return options.ConfigureFake(fake => A.CallTo(fake)
                                                   .Where(call => !call.Method.IsAbstract)
@@ -94,7 +94,7 @@ namespace FakeItEasy
         /// <returns>An options object.</returns>
         public static IFakeOptions CallsBaseMethods(this IFakeOptions options)
         {
-            Guard.AgainstNull(options, nameof(options));
+            Guard.AgainstNull(options);
 
             return options.ConfigureFake(fake => A.CallTo(fake)
                                                   .Where(call => !call.Method.IsAbstract)

--- a/src/FakeItEasy/Guard.cs
+++ b/src/FakeItEasy/Guard.cs
@@ -3,6 +3,7 @@ namespace FakeItEasy
     using System;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     /// Provides methods for guarding method arguments.
@@ -16,7 +17,7 @@ namespace FakeItEasy
         /// <param name="argumentName">Name of the argument.</param>
         /// <exception cref="ArgumentNullException">The specified argument was null.</exception>
         [DebuggerStepThrough]
-        public static void AgainstNull([ValidatedNotNull, NotNull] object? argument, string argumentName)
+        public static void AgainstNull([ValidatedNotNull, NotNull] object? argument, [CallerArgumentExpression("argument")] string argumentName = null!)
         {
             if (argument is null)
             {

--- a/src/FakeItEasy/Manage.cs
+++ b/src/FakeItEasy/Manage.cs
@@ -26,7 +26,7 @@ namespace FakeItEasy
 
         private static void ManageEvents(object fake, Func<EventCall, bool> eventCallPredicate)
         {
-            Guard.AgainstNull(fake, nameof(fake));
+            Guard.AgainstNull(fake);
 
             var manager = Fake.GetFakeManager(fake);
             A.CallTo(fake)
@@ -49,7 +49,7 @@ namespace FakeItEasy
 
             public ManageNamedEventConfiguration(string eventName)
             {
-                Guard.AgainstNull(eventName, nameof(eventName));
+                Guard.AgainstNull(eventName);
                 this.eventName = eventName;
             }
 

--- a/src/FakeItEasy/OutAndRefParametersConfigurationExtensions.cs
+++ b/src/FakeItEasy/OutAndRefParametersConfigurationExtensions.cs
@@ -21,8 +21,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredConfiguration<TInterface> AssignsOutAndRefParameters<TInterface>(
             this IOutAndRefParametersConfiguration<TInterface> configuration, params object?[] values)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(values, nameof(values));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(values);
 
             return configuration.AssignsOutAndRefParametersLazily(x => values);
         }

--- a/src/FakeItEasy/OutputWriterExtensions.cs
+++ b/src/FakeItEasy/OutputWriterExtensions.cs
@@ -16,7 +16,7 @@ namespace FakeItEasy
         /// <returns>The writer.</returns>
         public static IOutputWriter WriteLine(this IOutputWriter writer)
         {
-            Guard.AgainstNull(writer, nameof(writer));
+            Guard.AgainstNull(writer);
 
             writer.Write(Environment.NewLine);
             return writer;
@@ -31,9 +31,9 @@ namespace FakeItEasy
         /// <returns>The writer.</returns>
         public static IOutputWriter Write(this IOutputWriter writer, string format, params object?[] args)
         {
-            Guard.AgainstNull(writer, nameof(writer));
-            Guard.AgainstNull(format, nameof(format));
-            Guard.AgainstNull(args, nameof(args));
+            Guard.AgainstNull(writer);
+            Guard.AgainstNull(format);
+            Guard.AgainstNull(args);
 
             writer.Write(string.Format(format, args));
             return writer;
@@ -47,8 +47,8 @@ namespace FakeItEasy
         /// <returns>The writer.</returns>
         public static IOutputWriter Write(this IOutputWriter writer, object value)
         {
-            Guard.AgainstNull(writer, nameof(writer));
-            Guard.AgainstNull(value, nameof(value));
+            Guard.AgainstNull(writer);
+            Guard.AgainstNull(value);
 
             writer.Write(value.ToString() ?? string.Empty);
             return writer;
@@ -62,8 +62,8 @@ namespace FakeItEasy
         /// <returns>The writer.</returns>
         internal static IOutputWriter WriteArgumentValues(this IOutputWriter writer, IEnumerable values)
         {
-            Guard.AgainstNull(writer, nameof(writer));
-            Guard.AgainstNull(values, nameof(values));
+            Guard.AgainstNull(writer);
+            Guard.AgainstNull(values);
 
             var list = values.AsList();
             if (list.Count <= 5)

--- a/src/FakeItEasy/ReturnValueConfigurationExtensions.StronglyTyped.cs
+++ b/src/FakeItEasy/ReturnValueConfigurationExtensions.StronglyTyped.cs
@@ -31,8 +31,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TReturnType>>
             ReturnsLazily<TReturnType, T1>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -57,8 +57,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<TReturnType>>>
             ReturnsLazily<TReturnType, T1>(this IReturnValueConfiguration<Task<TReturnType>> configuration, Func<T1, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -84,8 +84,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TReturnType>>
             ReturnsLazily<TReturnType, T1, T2>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -111,8 +111,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2>(this IReturnValueConfiguration<Task<TReturnType>> configuration, Func<T1, T2, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -139,8 +139,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TReturnType>>
             ReturnsLazily<TReturnType, T1, T2, T3>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -167,8 +167,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3>(this IReturnValueConfiguration<Task<TReturnType>> configuration, Func<T1, T2, T3, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -196,8 +196,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TReturnType>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -225,8 +225,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4>(this IReturnValueConfiguration<Task<TReturnType>> configuration, Func<T1, T2, T3, T4, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -255,8 +255,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TReturnType>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, T5, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -285,8 +285,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5>(this IReturnValueConfiguration<Task<TReturnType>> configuration, Func<T1, T2, T3, T4, T5, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -316,8 +316,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TReturnType>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, T5, T6, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -347,8 +347,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6>(this IReturnValueConfiguration<Task<TReturnType>> configuration, Func<T1, T2, T3, T4, T5, T6, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -379,8 +379,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TReturnType>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6, T7>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, T5, T6, T7, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -411,8 +411,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6, T7>(this IReturnValueConfiguration<Task<TReturnType>> configuration, Func<T1, T2, T3, T4, T5, T6, T7, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -444,8 +444,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TReturnType>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6, T7, T8>(this IReturnValueConfiguration<TReturnType> configuration, Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -477,8 +477,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6, T7, T8>(this IReturnValueConfiguration<Task<TReturnType>> configuration, Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {

--- a/src/FakeItEasy/ReturnValueConfigurationExtensions.StronglyTyped.tt
+++ b/src/FakeItEasy/ReturnValueConfigurationExtensions.StronglyTyped.tt
@@ -49,8 +49,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<TReturnType>>
             ReturnsLazily<TReturnType, <#= typeParamList #>>(this IReturnValueConfiguration<TReturnType> configuration, Func<<#= typeParamList #>, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
                 {
@@ -82,8 +82,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<TReturnType>>>
             ReturnsLazily<TReturnType, <#= typeParamList #>>(this IReturnValueConfiguration<Task<TReturnType>> configuration, Func<<#= typeParamList #>, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {

--- a/src/FakeItEasy/ReturnValueConfigurationExtensions.cs
+++ b/src/FakeItEasy/ReturnValueConfigurationExtensions.cs
@@ -24,7 +24,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design to support the fluent API.")]
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<T>> Returns<T>(this IReturnValueConfiguration<T> configuration, T value)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.ReturnsLazily(x => value);
         }
@@ -40,7 +40,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Necessary to support special handling of Task<T> return values.")]
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<T>>> Returns<T>(this IReturnValueConfiguration<Task<T>> configuration, T value)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.ReturnsLazily(() => value);
         }
@@ -57,8 +57,8 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is by design to support the fluent API.")]
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<T>> ReturnsLazily<T>(this IReturnValueConfiguration<T> configuration, Func<T> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(x => valueProducer());
         }
@@ -75,8 +75,8 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Necessary to support special handling of Task<T> return values.")]
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<Task<T>>> ReturnsLazily<T>(this IReturnValueConfiguration<Task<T>> configuration, Func<T> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(x => TaskHelper.FromResult(valueProducer()));
         }
@@ -90,8 +90,8 @@ namespace FakeItEasy
         /// <param name="values">The values to return in sequence.</param>
         public static void ReturnsNextFromSequence<T>(this IReturnValueConfiguration<T> configuration, params T[] values)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(values, nameof(values));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(values);
 
             configuration.ReturnsNextFromQueue(new ConcurrentQueue<T>(values));
         }
@@ -108,8 +108,8 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Necessary to support special handling of Task<T> return values.")]
         public static void ReturnsNextFromSequence<T>(this IReturnValueConfiguration<Task<T>> configuration, params T[] values)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(values, nameof(values));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(values);
 
             configuration.ReturnsNextFromQueue(new ConcurrentQueue<Task<T>>(values.Select(TaskHelper.FromResult)));
         }
@@ -121,7 +121,7 @@ namespace FakeItEasy
         /// <returns>A configuration object.</returns>
         public static IAfterCallConfiguredConfiguration<IReturnValueConfiguration<Task>> DoesNothing(this IReturnValueConfiguration<Task> configuration)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.Returns(TaskHelper.CompletedTask);
         }

--- a/src/FakeItEasy/Sdk/Create.cs
+++ b/src/FakeItEasy/Sdk/Create.cs
@@ -21,7 +21,7 @@ namespace FakeItEasy.Sdk
         /// <returns>A fake object.</returns>
         public static object Fake(Type typeOfFake)
         {
-            Guard.AgainstNull(typeOfFake, nameof(typeOfFake));
+            Guard.AgainstNull(typeOfFake);
 
             return FakeAndDummyManager.CreateFake(typeOfFake, new LoopDetectingResolutionContext());
         }
@@ -34,8 +34,8 @@ namespace FakeItEasy.Sdk
         /// <returns>A fake object.</returns>
         public static object Fake(Type typeOfFake, Action<IFakeOptions> optionsBuilder)
         {
-            Guard.AgainstNull(typeOfFake, nameof(typeOfFake));
-            Guard.AgainstNull(optionsBuilder, nameof(optionsBuilder));
+            Guard.AgainstNull(typeOfFake);
+            Guard.AgainstNull(optionsBuilder);
 
             return FakeAndDummyManager.CreateFake(typeOfFake, optionsBuilder, new LoopDetectingResolutionContext());
         }
@@ -91,7 +91,7 @@ namespace FakeItEasy.Sdk
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static object? Dummy(Type typeOfDummy)
         {
-            Guard.AgainstNull(typeOfDummy, nameof(typeOfDummy));
+            Guard.AgainstNull(typeOfDummy);
 
             return FakeAndDummyManager.CreateDummy(typeOfDummy, new LoopDetectingResolutionContext());
         }

--- a/src/FakeItEasy/ValueTaskAsyncReturnValueConfigurationExtensions.StronglyTyped.cs
+++ b/src/FakeItEasy/ValueTaskAsyncReturnValueConfigurationExtensions.StronglyTyped.cs
@@ -27,8 +27,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<T1, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -48,8 +48,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<T1, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1) => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(arg1))));
         }
@@ -67,8 +67,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<T1, T2, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -89,8 +89,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<T1, T2, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2) => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(arg1, arg2))));
         }
@@ -109,8 +109,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<T1, T2, T3, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -132,8 +132,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<T1, T2, T3, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3) => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3))));
         }
@@ -153,8 +153,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<T1, T2, T3, T4, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -177,8 +177,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<T1, T2, T3, T4, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4) => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4))));
         }
@@ -199,8 +199,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -224,8 +224,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<T1, T2, T3, T4, T5, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4, arg5))));
         }
@@ -247,8 +247,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -273,8 +273,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<T1, T2, T3, T4, T5, T6, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4, arg5, arg6))));
         }
@@ -297,8 +297,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -324,8 +324,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4, arg5, arg6, arg7))));
         }
@@ -349,8 +349,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -377,8 +377,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8))));
         }

--- a/src/FakeItEasy/ValueTaskAsyncReturnValueConfigurationExtensions.StronglyTyped.tt
+++ b/src/FakeItEasy/ValueTaskAsyncReturnValueConfigurationExtensions.StronglyTyped.tt
@@ -46,8 +46,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<<#= typeParamList #>, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return
                 configuration.ReturnsLazily(
@@ -74,8 +74,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<<#= typeParamList #>, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily((<#= lambdaParamList #>) => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(<#= argumentList #>))));
         }

--- a/src/FakeItEasy/ValueTaskAsyncReturnValueConfigurationExtensions.cs
+++ b/src/FakeItEasy/ValueTaskAsyncReturnValueConfigurationExtensions.cs
@@ -22,8 +22,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Exception exception)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exception, nameof(exception));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exception);
 
             return configuration.ReturnsLazily(call => new ValueTask(TaskHelper.FromException(exception)));
         }
@@ -39,8 +39,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<IFakeObjectCall, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily(call => new ValueTask(TaskHelper.FromException(exceptionFactory(call))));
         }
@@ -56,8 +56,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask> configuration,
             Func<Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily(call => new ValueTask(TaskHelper.FromException(exceptionFactory())));
         }
@@ -74,8 +74,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Exception exception)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exception, nameof(exception));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exception);
 
             return configuration.ReturnsLazily(call => new ValueTask<T>(TaskHelper.FromException<T>(exception)));
         }
@@ -92,8 +92,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<IFakeObjectCall, Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily(call => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory(call))));
         }
@@ -110,8 +110,8 @@ namespace FakeItEasy
             this IReturnValueConfiguration<ValueTask<T>> configuration,
             Func<Exception> exceptionFactory)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(exceptionFactory, nameof(exceptionFactory));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(exceptionFactory);
 
             return configuration.ReturnsLazily(call => new ValueTask<T>(TaskHelper.FromException<T>(exceptionFactory())));
         }

--- a/src/FakeItEasy/ValueTaskReturnValueConfigurationExtensions.StronglyTyped.cs
+++ b/src/FakeItEasy/ValueTaskReturnValueConfigurationExtensions.StronglyTyped.cs
@@ -33,8 +33,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<TReturnType>>>
             ReturnsLazily<TReturnType, T1>(this IReturnValueConfiguration<ValueTask<TReturnType>> configuration, Func<T1, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -60,8 +60,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2>(this IReturnValueConfiguration<ValueTask<TReturnType>> configuration, Func<T1, T2, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -88,8 +88,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3>(this IReturnValueConfiguration<ValueTask<TReturnType>> configuration, Func<T1, T2, T3, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -117,8 +117,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4>(this IReturnValueConfiguration<ValueTask<TReturnType>> configuration, Func<T1, T2, T3, T4, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -147,8 +147,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5>(this IReturnValueConfiguration<ValueTask<TReturnType>> configuration, Func<T1, T2, T3, T4, T5, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -178,8 +178,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6>(this IReturnValueConfiguration<ValueTask<TReturnType>> configuration, Func<T1, T2, T3, T4, T5, T6, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -210,8 +210,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6, T7>(this IReturnValueConfiguration<ValueTask<TReturnType>> configuration, Func<T1, T2, T3, T4, T5, T6, T7, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {
@@ -243,8 +243,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<TReturnType>>>
             ReturnsLazily<TReturnType, T1, T2, T3, T4, T5, T6, T7, T8>(this IReturnValueConfiguration<ValueTask<TReturnType>> configuration, Func<T1, T2, T3, T4, T5, T6, T7, T8, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {

--- a/src/FakeItEasy/ValueTaskReturnValueConfigurationExtensions.StronglyTyped.tt
+++ b/src/FakeItEasy/ValueTaskReturnValueConfigurationExtensions.StronglyTyped.tt
@@ -51,8 +51,8 @@ namespace FakeItEasy
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<TReturnType>>>
             ReturnsLazily<TReturnType, <#= typeParamList #>>(this IReturnValueConfiguration<ValueTask<TReturnType>> configuration, Func<<#= typeParamList #>, TReturnType> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(call =>
             {

--- a/src/FakeItEasy/ValueTaskReturnValueConfigurationExtensions.cs
+++ b/src/FakeItEasy/ValueTaskReturnValueConfigurationExtensions.cs
@@ -23,7 +23,7 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Necessary to support special handling of ValueTask<T> return values.")]
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<T>>> Returns<T>(this IReturnValueConfiguration<ValueTask<T>> configuration, T value)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
+            Guard.AgainstNull(configuration);
 
             return configuration.ReturnsLazily(() => value);
         }
@@ -40,8 +40,8 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Necessary to support special handling of ValueTask<T> return values.")]
         public static IAfterCallConfiguredWithOutAndRefParametersConfiguration<IReturnValueConfiguration<ValueTask<T>>> ReturnsLazily<T>(this IReturnValueConfiguration<ValueTask<T>> configuration, Func<T> valueProducer)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(valueProducer, nameof(valueProducer));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(valueProducer);
 
             return configuration.ReturnsLazily(x => new ValueTask<T>(valueProducer()));
         }
@@ -58,8 +58,8 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Necessary to support special handling of ValueTask<T> return values.")]
         public static void ReturnsNextFromSequence<T>(this IReturnValueConfiguration<ValueTask<T>> configuration, params T[] values)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(values, nameof(values));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(values);
 
             configuration.ReturnsNextFromQueue(new ConcurrentQueue<ValueTask<T>>(values.Select(value => new ValueTask<T>(value))));
         }

--- a/src/FakeItEasy/WhereConfigurationExtensions.cs
+++ b/src/FakeItEasy/WhereConfigurationExtensions.cs
@@ -21,8 +21,8 @@ namespace FakeItEasy
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Appropriate for expressions.")]
         public static T Where<T>(this IWhereConfiguration<T> configuration, Expression<Func<IFakeObjectCall, bool>> predicate)
         {
-            Guard.AgainstNull(configuration, nameof(configuration));
-            Guard.AgainstNull(predicate, nameof(predicate));
+            Guard.AgainstNull(configuration);
+            Guard.AgainstNull(predicate);
 
             return configuration.Where(predicate.Compile(), x => x.Write(predicate.ToString()));
         }

--- a/tests/FakeItEasy.Tests/ActionOverWriterValueFormatter.cs
+++ b/tests/FakeItEasy.Tests/ActionOverWriterValueFormatter.cs
@@ -7,7 +7,7 @@ namespace FakeItEasy.Tests
     {
         protected override string GetStringValue(Action<IOutputWriter> argumentValue)
         {
-            Guard.AgainstNull(argumentValue, nameof(argumentValue));
+            Guard.AgainstNull(argumentValue);
 
             var writer = ServiceLocator.Resolve<StringBuilderOutputWriter.Factory>().Invoke();
             argumentValue.Invoke(writer);

--- a/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/DerivedTypeArgumentTests.cs
+++ b/tests/FakeItEasy.Tests/ArgumentConstraintManagerExtensions/DerivedTypeArgumentTests.cs
@@ -40,7 +40,7 @@ namespace FakeItEasy.Tests.ArgumentConstraintManagerExtensions
 
         protected override void CreateConstraint(INegatableArgumentConstraintManager<string> scope)
         {
-            Guard.AgainstNull(scope, nameof(scope));
+            Guard.AgainstNull(scope);
 
             scope.Matches(x => x is null || x == "foo", x => x.Write("string that is \"foo\" or is empty"));
         }

--- a/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidatorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidatorTests.cs
@@ -64,7 +64,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
         [MemberData(nameof(NonInterceptableMembers))]
         public void Should_fail_for_non_interceptable_methods(NonInterceptableTestCase testCase)
         {
-            Guard.AgainstNull(testCase, nameof(testCase));
+            Guard.AgainstNull(testCase);
 
             // Arrange
 
@@ -80,7 +80,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
         [MemberData(nameof(InterceptableMethods))]
         public void Should_succeed_for_interceptable_methods(InterceptionTestCase testCase)
         {
-            Guard.AgainstNull(testCase, nameof(testCase));
+            Guard.AgainstNull(testCase);
 
             // Arrange
 

--- a/tests/FakeItEasy.Tests/Creation/DummyValueResolverTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/DummyValueResolverTests.cs
@@ -44,7 +44,7 @@ namespace FakeItEasy.Tests.Creation
         [MemberData(nameof(DummiesInContainer))]
         public void Should_return_dummy_from_container_when_available(object dummyForContainer)
         {
-            Guard.AgainstNull(dummyForContainer, nameof(dummyForContainer));
+            Guard.AgainstNull(dummyForContainer);
 
             // Arrange
             var resolver = new DummyValueResolver(

--- a/tests/FakeItEasy.Tests/NullGuardedAssertion.cs
+++ b/tests/FakeItEasy.Tests/NullGuardedAssertion.cs
@@ -25,7 +25,7 @@ namespace FakeItEasy.Tests
 
             internal NullGuardedConstraint(Expression<Action> call)
             {
-                Guard.AgainstNull(call, nameof(call));
+                Guard.AgainstNull(call);
                 this.call = call;
             }
 


### PR DESCRIPTION
And remove redundant param names in calls to Guard.AgainstNull
(that part is going to be pretty boring to review, so I put it in a separate commit)