### PR TITLE
Modernize build script by using C# 9 & 10 features

### DIFF
--- a/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
+++ b/tools/FakeItEasy.Build/FakeItEasy.Build.csproj
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn),SA0001,CA1014</NoWarn>
+    <NoWarn>$(NoWarn),SA0001,SA1200,SA1649,CA1014,CA1812</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/FakeItEasy.Build/Program.cs
+++ b/tools/FakeItEasy.Build/Program.cs
@@ -1,136 +1,119 @@
-namespace FakeItEasy.Build
+using System.Text;
+using System.Xml.Linq;
+using SimpleExec;
+using static Bullseye.Targets;
+using static SimpleExec.Command;
+
+Project[] projectsToPack =
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Text;
-    using System.Xml.Linq;
-    using SimpleExec;
-    using static Bullseye.Targets;
-    using static SimpleExec.Command;
+    "src/FakeItEasy/FakeItEasy.csproj",
+    "src/FakeItEasy.Extensions.ValueTask/FakeItEasy.Extensions.ValueTask.csproj"
+};
 
-    public static class Program
+var testSuites = new Dictionary<string, string[]>
+{
+    ["unit"] = new[]
     {
-        private static readonly Project[] ProjectsToPack =
-        {
-            "src/FakeItEasy/FakeItEasy.csproj",
-            "src/FakeItEasy.Extensions.ValueTask/FakeItEasy.Extensions.ValueTask.csproj"
-        };
-
-        private static readonly IReadOnlyDictionary<string, string[]> TestSuites = new Dictionary<string, string[]>
-        {
-            ["unit"] = new[]
-            {
-                "tests/FakeItEasy.Tests"
-            },
-            ["integ"] = new[]
-            {
-                "tests/FakeItEasy.IntegrationTests",
-                "tests/FakeItEasy.IntegrationTests.VB",
-            },
-            ["spec"] = new[]
-            {
-                "tests/FakeItEasy.Specs"
-            },
-            ["approve"] = new[]
-            {
-                "tests/FakeItEasy.Tests.Approval"
-            }
-        };
-
-        public static void Main(string[] args)
-        {
-            Target("default", DependsOn("unit", "integ", "spec", "approve", "pack"));
-
-            Target(
-                "build",
-                () => Run("dotnet", "build FakeItEasy.sln -c Release /maxcpucount /nr:false /verbosity:minimal /nologo /bl:artifacts/logs/build.binlog"));
-
-            foreach (var testSuite in TestSuites)
-            {
-                Target(
-                    testSuite.Key,
-                    DependsOn("build"),
-                    forEach: testSuite.Value,
-                    action: testDirectory => Run("dotnet", "test --configuration Release --no-build --nologo -- RunConfiguration.NoAutoReporters=true", testDirectory));
-            }
-
-            Target(
-                "pack",
-                DependsOn("build"),
-                forEach: ProjectsToPack,
-                action: project => Run("dotnet", $"pack {project.Path} --configuration Release --no-build --nologo --output {Path.GetFullPath("artifacts/output")}"));
-
-            Target(
-                "force-approve",
-                () =>
-                    {
-                        foreach (var received in Directory.EnumerateFiles("tests/FakeItEasy.Tests.Approval/ApprovedApi", "*.received.txt", SearchOption.AllDirectories))
-                        {
-                            File.Copy(received, received.Replace(".received.txt", ".approved.txt", StringComparison.OrdinalIgnoreCase), overwrite: true);
-                        }
-                    });
-
-            Target(
-                "initialize-user-properties",
-                () =>
-                    {
-                        if (!File.Exists("FakeItEasy.user.props"))
-                        {
-                            var defaultUserProps = @"
-<Project>
-  <PropertyGroup>
-    <BuildProfile></BuildProfile>
-  </PropertyGroup>
-</Project>".Trim();
-                            File.WriteAllText("FakeItEasy.user.props", defaultUserProps, Encoding.UTF8);
-                        }
-                    });
-
-            foreach (var profile in Directory.EnumerateFiles("profiles", "*.props").Select(Path.GetFileNameWithoutExtension))
-            {
-                Target(
-                    "use-profile-" + profile,
-                    DependsOn("initialize-user-properties"),
-                    () =>
-                        {
-                            var xmlDoc = XDocument.Load("FakeItEasy.user.props");
-
-                            var buildProfileElement = xmlDoc.Root.Elements("PropertyGroup").Elements("BuildProfile").FirstOrDefault();
-                            if (buildProfileElement is null)
-                            {
-                                var propertyGroupElement = xmlDoc.Root.Element("PropertyGroup");
-                                if (propertyGroupElement is null)
-                                {
-                                    propertyGroupElement = new XElement("PropertyGroup");
-                                    xmlDoc.Root.Add(propertyGroupElement);
-                                }
-
-                                buildProfileElement = new XElement("BuildProfile");
-                                propertyGroupElement.Add(buildProfileElement);
-                            }
-
-                            if (buildProfileElement.Value != profile)
-                            {
-                                buildProfileElement.Value = profile;
-                                xmlDoc.Save("FakeItEasy.user.props");
-                            }
-                        });
-            }
-
-            RunTargetsAndExit(args, messageOnly: ex => ex is NonZeroExitCodeException);
-        }
-
-        private class Project
-        {
-            public Project(string path) => this.Path = path;
-
-            public string Path { get; set; }
-
-            public static implicit operator Project(string path) => new Project(path);
-
-            public override string ToString() => this.Path.Split('/').Last();
-        }
+        "tests/FakeItEasy.Tests"
+    },
+    ["integ"] = new[]
+    {
+        "tests/FakeItEasy.IntegrationTests",
+        "tests/FakeItEasy.IntegrationTests.VB",
+    },
+    ["spec"] = new[]
+    {
+        "tests/FakeItEasy.Specs"
+    },
+    ["approve"] = new[]
+    {
+        "tests/FakeItEasy.Tests.Approval"
     }
+};
+
+Target("default", DependsOn("unit", "integ", "spec", "approve", "pack"));
+
+Target(
+    "build",
+    () => Run("dotnet", "build FakeItEasy.sln -c Release /maxcpucount /nr:false /verbosity:minimal /nologo /bl:artifacts/logs/build.binlog"));
+
+foreach (var testSuite in testSuites)
+{
+    Target(
+        testSuite.Key,
+        DependsOn("build"),
+        forEach: testSuite.Value,
+        action: testDirectory => Run("dotnet", "test --configuration Release --no-build --nologo -- RunConfiguration.NoAutoReporters=true", testDirectory));
+}
+
+Target(
+    "pack",
+    DependsOn("build"),
+    forEach: projectsToPack,
+    action: project => Run("dotnet", $"pack {project.Path} --configuration Release --no-build --nologo --output {Path.GetFullPath("artifacts/output")}"));
+
+Target(
+    "force-approve",
+    () =>
+    {
+        foreach (var received in Directory.EnumerateFiles("tests/FakeItEasy.Tests.Approval/ApprovedApi", "*.received.txt", SearchOption.AllDirectories))
+        {
+            File.Copy(received, received.Replace(".received.txt", ".approved.txt", StringComparison.OrdinalIgnoreCase), overwrite: true);
+        }
+    });
+
+Target(
+    "initialize-user-properties",
+    () =>
+    {
+        if (!File.Exists("FakeItEasy.user.props"))
+        {
+            var defaultUserProps = @"
+<Project>
+<PropertyGroup>
+<BuildProfile></BuildProfile>
+</PropertyGroup>
+</Project>".Trim();
+            File.WriteAllText("FakeItEasy.user.props", defaultUserProps, Encoding.UTF8);
+        }
+    });
+
+foreach (var profile in Directory.EnumerateFiles("profiles", "*.props").Select(Path.GetFileNameWithoutExtension))
+{
+    Target(
+        "use-profile-" + profile,
+        DependsOn("initialize-user-properties"),
+        () =>
+        {
+            var xmlDoc = XDocument.Load("FakeItEasy.user.props");
+
+            var buildProfileElement = xmlDoc.Root!.Elements("PropertyGroup").Elements("BuildProfile").FirstOrDefault();
+            if (buildProfileElement is null)
+            {
+                var propertyGroupElement = xmlDoc.Root.Element("PropertyGroup");
+                if (propertyGroupElement is null)
+                {
+                    propertyGroupElement = new XElement("PropertyGroup");
+                    xmlDoc.Root.Add(propertyGroupElement);
+                }
+
+                buildProfileElement = new XElement("BuildProfile");
+                propertyGroupElement.Add(buildProfileElement);
+            }
+
+            if (buildProfileElement.Value != profile)
+            {
+                buildProfileElement.Value = profile!;
+                xmlDoc.Save("FakeItEasy.user.props");
+            }
+        });
+}
+
+RunTargetsAndExit(args, messageOnly: ex => ex is NonZeroExitCodeException);
+
+record Project(string Path)
+{
+    public static implicit operator Project(string path) => new Project(path);
+
+    public override string ToString() => this.Path.Split('/').Last();
 }


### PR DESCRIPTION
- Use of top-level statements leads to reduced indentation (no namespace, no Program class, no Main method). Note that the code is now in the global namespace, but it doesn't matter in this case.
- Implicit usings leads to less using directives
- Converting  `Project` to a record makes it more concise

I'm not sure yet if I like it better or not...