### PR TITLE
Fix pack build target to support spaces in path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .githubtoken
 .vs
+.idea
 [Oo]bj
 [Bb]in
 artifacts

--- a/tools/FakeItEasy.Build/Program.cs
+++ b/tools/FakeItEasy.Build/Program.cs
@@ -50,7 +50,7 @@ Target(
     "pack",
     DependsOn("build"),
     forEach: projectsToPack,
-    action: project => Run("dotnet", $"pack {project.Path} --configuration Release --no-build --nologo --output {Path.GetFullPath("artifacts/output")}"));
+    action: project => Run("dotnet", $"pack {project.Path} --configuration Release --no-build --nologo --output \"{Path.GetFullPath("artifacts/output")}\""));
 
 Target(
     "force-approve",


### PR DESCRIPTION
The `pack` target was failing because I have a space in the path to the repo. Adding double-quotes fixes the problem.