### PR TITLE
Improve in-article tables of contents

### DIFF
--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -5,7 +5,7 @@ the arguments of the call can be constrained so that only calls to the
 configured method where the arguments matches the constraint are
 selected.
 
-# Matching values exactly
+## Matching values exactly
 
 Assume the following interface exists:
 ```csharp
@@ -35,8 +35,8 @@ be _the same object_ in order to match, and this sometimes produces
 unexpected results. When in doubt, verify the type's `Equals`
 behavior manually.
 
-# Other matchers
-## Ignoring arguments
+## Other matchers
+### Ignoring arguments
 
 Suppose the value of the integer in the `Bar` call wasn't important,
 but the string was. Then the following constraint could be used:
@@ -53,7 +53,7 @@ An underscore (`_`) can be used as a shorthand for `Ignored` as well:
 A.CallTo(() => foo.Bar("hello", A<int>._)).MustHaveHappened();
 ```
 
-## More convenience matchers
+### More convenience matchers
 
 If more complicated constraints are needed, the `That` method can be
 used. There are a few built-in matchers:
@@ -79,7 +79,7 @@ used. There are a few built-in matchers:
 |IsSameSequenceAs(value1, value2, ...)|sequence equality, like `System.Linq.Enumerable.SequenceEqual`|
 |Not|inverts the sense of the matcher|
 
-## Custom matching
+### Custom matching
 
 If none of the canned matchers are sufficient, you can provide a
 predicate to perform custom matching using `That.Matches`. Like in
@@ -99,7 +99,7 @@ a `Func`.
 For another example of using `That.Matches`, see Jonathan Channon's
 [Comparing object instances with FakeItEasy](https://blog.jonathanchannon.com/2013/09/11/comparing-object-instances-with-fakeiteasy).
 
-## Always place `Ignored` and `That` inside `A.CallTo`
+### Always place `Ignored` and `That` inside `A.CallTo`
 
 The `Ignored` (and `_`) and `That` matchers must be placed within the
 expression inside the `A.CallTo` call. This is because these special
@@ -125,7 +125,7 @@ An<Apple>.That.Matches(a => a.Color == "Red")
 `A<T>` and `An<T>` are exact synonyms and can be used exactly the same
 way.
 
-# `out` parameters
+## `out` parameters
 
 The incoming argument value of `out` parameters is ignored when matching
 calls. The incoming value of an `out` parameter can't be seen by the
@@ -148,7 +148,7 @@ See
 [Implicitly Assigning `out` Parameter Values](assigning-out-and-ref-parameters#implicitly-assigning-out-parameter-values)
 to learn how the initial `configurationValue` is used in this case.
 
-# `ref` parameters
+## `ref` parameters
 
 Due to the limitations of working with `ref` parameters in C#, only exact-value matching is possible using argument constraints,
 and the argument value must be compared against a local variable or a field:
@@ -164,7 +164,7 @@ or `WhenArgumentsMatch`, described below.
 In addition to constraining by `ref` argument values, calls can be explicitly configured to
 [assign outgoing `ref` argument values](assigning-out-and-ref-parameters).
 
-# Overriding argument matchers
+## Overriding argument matchers
 
 Sometimes individually constraining arguments isn't sufficient. In
 such a case, other methods may be used to determine which calls match
@@ -208,7 +208,7 @@ A.CallTo(() => fake.Bar(null, 0))
     .Throws<Exception>();
 ```
 
-# Nested argument constraints
+## Nested argument constraints
 
 Note that an argument constraint cannot be "nested" in an argument; the
 constraint has to be the whole argument. For instance, the following call

--- a/docs/assertion.md
+++ b/docs/assertion.md
@@ -12,7 +12,7 @@ Arguments are constrained using
 [Argument Constraints](argument-constraints.md) just like when
 configuring calls.
 
-# Syntax
+## Syntax
 
 ```csharp
 A.CallTo(() => foo.Bar()).MustHaveHappened();
@@ -33,7 +33,7 @@ A.CallTo(() => foo.Bar()).MustHaveHappened(7, Times.OrLess);
 A.CallTo(() => foo.Bar()).MustHaveHappenedANumberOfTimesMatching(n => n % 2 == 0);
 ```
 
-# Asserting Calls Made with Mutable Arguments
+## Asserting Calls Made with Mutable Arguments
 
 When FakeItEasy records a method (or property) call, it remembers
 which objects were used as argument, but does not take a snapshot of
@@ -81,11 +81,11 @@ aList.Add(4);
 Assert.That(capturedList, Is.EqualTo(new List<int> {1, 2, 3}));
 ```
 
-# More advanced assertions
+## More advanced assertions
 
 If the built-in assertion API isn't sufficient, you can also examine the list of recorded calls directly, as described in [Getting the list of calls made on a fake](advanced-usage.md#getting-the-list-of-calls-made-on-a-fake).
 
-# VB.NET
+## VB.NET
 
 ```
 ' Functions and Subs can be asserted using their respective keywords

--- a/docs/assigning-out-and-ref-parameters.md
+++ b/docs/assigning-out-and-ref-parameters.md
@@ -59,7 +59,7 @@ The `IFakeObjectCall` object provides access to
 * the `Arguments`, accessed by position or name, and
 * the original `FakedObject`
 
-# Implicitly Assigning `out` Parameter Values
+## Implicitly Assigning `out` Parameter Values
 
 Any `Expression`-based `A.CallTo` configuration that's made on a
 method that has an `out` parameter will cause the value of the variable

--- a/docs/assigning-out-and-ref-parameters.md
+++ b/docs/assigning-out-and-ref-parameters.md
@@ -22,7 +22,7 @@ without a `Returns`, the return value will be a [Dummy](dummies.md).
 When both `Returns` and `AssignsOutAndRefParameters` are used,
 `Returns` must be specified first.
 
-##Assigning Values Calculated at Call Time
+## Assigning Values Calculated at Call Time
 
 When `out` or `ref` parameter values aren't known until the method is
 called, `AssignsOutAndRefParametersLazily` can be used.

--- a/docs/creating-fakes.md
+++ b/docs/creating-fakes.md
@@ -1,6 +1,6 @@
 # Creating Fakes
 
-##Natural fakes
+## Natural fakes
 The common way to create a fake object is by using the `A.Fake` syntax, for example:
 
 ```csharp
@@ -27,7 +27,7 @@ object fake = Create.Fake(type);
 IList<object> fakes = Create.CollectionOfFake(type, 10);
 ```
 
-##Explicit Creation Options
+## Explicit Creation Options
 When creating fakes you can, through a fluent interface, specify options for how the fake should be created, depending on the type of fake being made:
 
 | Option                                                                                            | Applies to    |
@@ -74,13 +74,13 @@ var foo = A.Fake<IFoo>(x => x.Wrapping(wrapped));
 var foo = A.Fake<IFoo>(x => x.Named("Foo #1"));
 ```
 
-##Implicit Creation Options
+## Implicit Creation Options
 
 [Implicit creation options](implicit-creation-options.md) are
 available, equivalent in power to the explicit creation options
 mentioned above.
 
-##Unnatural fakes
+## Unnatural fakes
 
 For those accustomed to [Moq](https://www.moqthis.com/) there is an
 alternative way of creating fakes through the `new Fake<T>`

--- a/docs/how-to-fake-internal-types.md
+++ b/docs/how-to-fake-internal-types.md
@@ -3,14 +3,14 @@
 This guide will show you how to set up your project in order to be
 able to fake internal types in your tested system.
 
-#Details
+# Details
 
 The assembly that generates the proxy instances must have access to
 your internal types, therefore a `InternalsVisibleTo` attribute must
 be added to your tested assembly. Note that it is the assembly under
 test, not your test-assembly that needs this attribute.
 
-##Unsigned assemblies
+## Unsigned assemblies
 
 If your assembly is not signed with a strong name it's as easy as
 adding the equivalent of the following to your AssemblyInfo.cs/vb
@@ -20,7 +20,7 @@ file:
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 ```
 
-##Signed assemblies
+## Signed assemblies
 
 For signed assemblies you have to specify the strong name of the
 proxy-generating assembly:

--- a/docs/how-to-fake-internal-types.md
+++ b/docs/how-to-fake-internal-types.md
@@ -3,14 +3,14 @@
 This guide will show you how to set up your project in order to be
 able to fake internal types in your tested system.
 
-# Details
+## Details
 
 The assembly that generates the proxy instances must have access to
 your internal types, therefore a `InternalsVisibleTo` attribute must
 be added to your tested assembly. Note that it is the assembly under
 test, not your test-assembly that needs this attribute.
 
-## Unsigned assemblies
+### Unsigned assemblies
 
 If your assembly is not signed with a strong name it's as easy as
 adding the equivalent of the following to your AssemblyInfo.cs/vb
@@ -20,7 +20,7 @@ file:
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 ```
 
-## Signed assemblies
+### Signed assemblies
 
 For signed assemblies you have to specify the strong name of the
 proxy-generating assembly:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+hide:
+  - toc
+---
 <div id="logo"></div>
 
 FakeItEasy is a .NET dynamic fake library for creating all types of fake objects, mocks, stubs etc.

--- a/docs/ordered-assertions.md
+++ b/docs/ordered-assertions.md
@@ -6,7 +6,7 @@ should be used frequently but there are times when it's really needed.
 Using FakeItEasy you can assert that calls happened in a specific order
 on _one or more_ fake objects.
 
-# Details
+## Details
 
 One area where ordered asserts are useful is when you need to test
 that a call to a fake has happened between two other calls, such as

--- a/docs/ordered-assertions.md
+++ b/docs/ordered-assertions.md
@@ -6,7 +6,7 @@ should be used frequently but there are times when it's really needed.
 Using FakeItEasy you can assert that calls happened in a specific order
 on _one or more_ fake objects.
 
-#Details
+# Details
 
 One area where ordered asserts are useful is when you need to test
 that a call to a fake has happened between two other calls, such as

--- a/docs/specifying-return-values.md
+++ b/docs/specifying-return-values.md
@@ -17,7 +17,7 @@ A `get` property on a Fake can be configured similarly:
 A.CallTo(() => fakeShop.Address).Returns("123 Fake Street");
 ```
 
-##Return Values Calculated at Call Time
+## Return Values Calculated at Call Time
 
 Sometimes a desired return value won't be known at the time the call
 is configured. `ReturnsNextFromSequence` and `ReturnsLazily` can help

--- a/docs/why-was-fakeiteasy-created.md
+++ b/docs/why-was-fakeiteasy-created.md
@@ -1,6 +1,6 @@
 # Why was FakeItEasy created?
 
-#Introduction
+# Introduction
 
 There was a good question on Stack Overflow that asks what
 distinguishes FakeItEasy from other libraries. Creator of FakeItEasy,
@@ -12,7 +12,7 @@ been renamed in newer versions of FakeItEasy.
 The question on Stack Overflow:
 "[Are fakes better than Mocks?](https://stackoverflow.com/questions/4001101/are-fakes-better-than-mocks)"
 
-#Patrik H&auml;gne's answer
+# Patrik H&auml;gne's answer
 
 To be clear, I created FakeItEasy so I'll definitely not say whether
 one framework is better than the other, what I can do is point out

--- a/docs/why-was-fakeiteasy-created.md
+++ b/docs/why-was-fakeiteasy-created.md
@@ -1,6 +1,4 @@
-# Why was FakeItEasy created?
-
-# Introduction
+## Introduction
 
 There was a good question on Stack Overflow that asks what
 distinguishes FakeItEasy from other libraries. Creator of FakeItEasy,
@@ -12,7 +10,7 @@ been renamed in newer versions of FakeItEasy.
 The question on Stack Overflow:
 "[Are fakes better than Mocks?](https://stackoverflow.com/questions/4001101/are-fakes-better-than-mocks)"
 
-# Patrik H&auml;gne's answer
+## Patrik H&auml;gne's answer
 
 To be clear, I created FakeItEasy so I'll definitely not say whether
 one framework is better than the other, what I can do is point out


### PR DESCRIPTION
While looking at the [Argument constraints](https://fakeiteasy.github.io/docs/7.3.1/argument-constraints/) page yesterday, I noticed that unlike many other pages, the subheadings don't appear in the page's table of contents:

![image](https://user-images.githubusercontent.com/3275797/210579014-7135c663-c63e-4d32-bfaa-8d7a557dc173.png)

I found it's because the page uses level 1 headings instead of level 2. Typically in mkdocs, the level 1 heading is used for the page title only. 

This PR attempts to remedy that. And also suppresses the table of contents on the main landing page, as it is not helpful:

![image](https://user-images.githubusercontent.com/3275797/210579354-7ba3012f-d6a0-4261-a8b5-f8ce9910d7a9.png)

