### PR TITLE
Add Faking HttpClient recipe

### DIFF
--- a/FakeItEasy.sln
+++ b/FakeItEasy.sln
@@ -138,6 +138,19 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{101E09
 		tools-shared\README.md = tools-shared\README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Recipes", "Recipes", "{8733C91C-38B3-4105-88A3-11AD82CB78CD}"
+	ProjectSection(SolutionItems) = preProject
+		docs\Recipes\faking-http-client.md = docs\Recipes\faking-http-client.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "recipes", "recipes", "{FFFFB03D-8D02-46C5-BD12-EC176C0E056C}"
+	ProjectSection(SolutionItems) = preProject
+		recipes\.editorconfig = recipes\.editorconfig
+		recipes\Directory.Build.props = recipes\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FakeItEasy.Recipes.CSharp", "recipes\FakeItEasy.Recipes.CSharp\FakeItEasy.Recipes.CSharp.csproj", "{CDA19B53-4E12-456A-ADA7-06654C161D64}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -194,6 +207,10 @@ Global
 		{55451191-0521-41E1-BCCF-6D135D646589}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{55451191-0521-41E1-BCCF-6D135D646589}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{55451191-0521-41E1-BCCF-6D135D646589}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDA19B53-4E12-456A-ADA7-06654C161D64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDA19B53-4E12-456A-ADA7-06654C161D64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDA19B53-4E12-456A-ADA7-06654C161D64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDA19B53-4E12-456A-ADA7-06654C161D64}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -219,6 +236,8 @@ Global
 		{458FBDA4-91F9-4A69-BFBC-5AC3D85D4A03} = {AD790E7D-D664-4B5F-8BE8-01507A2A9F3B}
 		{55451191-0521-41E1-BCCF-6D135D646589} = {AD790E7D-D664-4B5F-8BE8-01507A2A9F3B}
 		{101E0992-8233-42C8-9CAF-FEC799BF5DDB} = {9D99B251-FB4F-49BF-8405-F6E0DE46EB32}
+		{8733C91C-38B3-4105-88A3-11AD82CB78CD} = {072853A5-377B-47C4-8644-AF1F4FD669E2}
+		{CDA19B53-4E12-456A-ADA7-06654C161D64} = {FFFFB03D-8D02-46C5-BD12-EC176C0E056C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E70BBF50-5920-49F2-835D-4A2DBD73F0E1}

--- a/FakeItEasy.sln
+++ b/FakeItEasy.sln
@@ -1,6 +1,7 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29324.140
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A6A7B553-5359-4FB9-B19C-8A23004F49DB}"
 	ProjectSection(SolutionItems) = preProject
@@ -9,8 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		.mailmap = .mailmap
 		build.cmd = build.cmd
-		build.sh = build.sh
 		build.ps1 = build.ps1
+		build.sh = build.sh
 		CONTRIBUTING.md = CONTRIBUTING.md
 		Directory.Build.props = Directory.Build.props
 		how_to_build.md = how_to_build.md
@@ -126,15 +127,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FakeItEasy.Extensions.Value
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FakeItEasy.Tests.TestHelpers", "tests\FakeItEasy.Tests.TestHelpers\FakeItEasy.Tests.TestHelpers.csproj", "{458FBDA4-91F9-4A69-BFBC-5AC3D85D4A03}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FakeItEasy.Tests.ExtensionPoints", "tests\FakeItEasy.Tests.ExtensionPoints\FakeItEasy.Tests.ExtensionPoints.csproj", "{55451191-0521-41E1-BCCF-6D135D646589}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FakeItEasy.Tests.ExtensionPoints", "tests\FakeItEasy.Tests.ExtensionPoints\FakeItEasy.Tests.ExtensionPoints.csproj", "{55451191-0521-41E1-BCCF-6D135D646589}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{101E0992-8233-42C8-9CAF-FEC799BF5DDB}"
 	ProjectSection(SolutionItems) = preProject
+		tools-shared\.editorconfig = tools-shared\.editorconfig
 		tools-shared\.githubtoken = tools-shared\.githubtoken
+		tools-shared\.gitignore = tools-shared\.gitignore
 		tools-shared\Directory.Build.props = tools-shared\Directory.Build.props
 		tools-shared\README.md = tools-shared\README.md
-		tools-shared\.editorconfig = tools-shared\.editorconfig
-		tools-shared\.gitignore = tools-shared\.gitignore
 	EndProjectSection
 EndProject
 Global

--- a/docs/Recipes/faking-http-client.md
+++ b/docs/Recipes/faking-http-client.md
@@ -1,0 +1,78 @@
+
+Let's assume that you want to create a fake `HttpClient` so you can dictate the
+behavior of the
+[GetAsync(String)](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.getasync?view=net-7.0#system-net-http-httpclient-getasync(system-string))
+method. This seems like it would be a
+straightforward task, but it's complicated by the design of `HttpClient`, which
+is not faking-friendly.
+
+## A working Fake
+
+First off, let's look at the declaration of `GetAsync`:
+
+```csharp
+public Task<HttpResponseMessage>GetAsync(string? requestUri)
+```
+
+This method is neither virtual nor abstract, and so [can't be overridden by
+FakeItEasy](../what-can-be-faked.md#what-members-can-be-overridden).
+
+As a workaround, we can look at the [definition of
+GetAsync](https://github.com/dotnet/runtime/blob/ab5e28c1cab305450897749daa7393bef30d7505/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs#L363-L364)
+and see that the method eventually ends up calling
+[HttpMessageHandler.SendAsync(HttpRequestMessage,
+CancellationToken)](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpmessagehandler.sendasync?view=net-7.0#system-net-http-httpmessagehandler-sendasync(system-net-http-httprequestmessage-system-threading-cancellationtoken))
+on an `HttpMessageHandler` that can be supplied via the `HttpClient`
+constructor.
+
+`HttpMessageHandler.SendAsync` is protected, which makes it
+less convenient to override than a public method. We need to specify the call by
+name, and to give FakeItEasy a hint about the return type, as described in
+[Specifying a call to any method or
+property](../specifying-a-call-to-configure.md#specifying-a-call-to-any-method-or-property).
+
+With this knowledge, we can write a passing test:
+
+??? note "This is a simplified example"
+    In the interest of brevity, we create a Fake, exercise it directly, and check
+    its behavior. A more realistic example would create the Fake as a collaborator
+    of some production class (the "system under test") and the Fake would not be
+    called directly from the test code.
+
+```csharp
+--8<--
+recipes/FakeItEasy.Recipes.CSharp/FakingHttpClient.cs:FakeAnyMethodWay
+--8<--
+```
+
+## Easier and safer call configuration
+
+The above code works, but specifying the method name and return type is a little
+awkward. A `FakeableHttpMessageHandler` class can be used to clean things up and
+to also supply a little compile-time safety by ensuring we're configuring the
+expected method.
+
+```csharp
+--8<--
+recipes/FakeItEasy.Recipes.CSharp/FakingHttpClient.cs:FakeableHttpMessageHandler
+
+recipes/FakeItEasy.Recipes.CSharp/FakingHttpClient.cs:FakeByMakingMessageHandlerFakeable
+--8<--
+```
+
+## Faking PostAsync
+
+The techniques above can be used to intercept calls to  methods other than `GetAsync` as well.
+
+Consider this test, which ensures that the correct content is passed to `HttpClient.PostAsync`.
+
+??? bug "Does not work for .NET Framework"
+    When run under .NET Framework, the request content is disposed
+    as soon as the request is made, as explained in
+    [HttpClient source code comments](https://github.com/dotnet/runtime/blob/b0b7aaefb88aa8d01b3d64fb40ac2f73a9d98c3e/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs#L665-L680).
+
+```csharp
+--8<--
+recipes/FakeItEasy.Recipes.CSharp/FakingHttpClient.cs:FakePostAsync
+--8<--
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,8 +41,11 @@ plugins:
 markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
+  - pymdownx.details
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      check_paths: true
+      dedent_subsections: true
   - pymdownx.superfences
   - pymdownx.tilde
 
@@ -80,6 +83,8 @@ nav:
 - Bootstrapper: bootstrapper.md
 - Advanced usage: advanced-usage.md
 - Analyzer Packages: https://fakeiteasy.github.io/docs/analyzers/
+- Recipes:
+  - Faking HttpClient: Recipes/faking-http-client.md
 - Platform support: platform-support.md
 - Source Stepping: source-stepping.md
 - Why was FakeItEasy created?: why-was-fakeiteasy-created.md

--- a/profiles/full.props
+++ b/profiles/full.props
@@ -9,6 +9,7 @@
     <UnitTestsTargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net6.0</UnitTestsTargetFrameworks>
     <TestHelpersTargetFrameworks>net461;netstandard2.0;netstandard2.1;net6.0</TestHelpersTargetFrameworks>
     <ApprovalTestsTargetFrameworks>net6.0</ApprovalTestsTargetFrameworks>
+    <RecipesTargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net6.0</RecipesTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <FakeItEasyTargetFrameworks>netstandard2.0;netstandard2.1;net5.0</FakeItEasyTargetFrameworks>
@@ -19,5 +20,6 @@
     <UnitTestsTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</UnitTestsTargetFrameworks>
     <TestHelpersTargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TestHelpersTargetFrameworks>
     <ApprovalTestsTargetFrameworks>net6.0</ApprovalTestsTargetFrameworks>
+    <RecipesTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</RecipesTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/profiles/net45.props
+++ b/profiles/net45.props
@@ -9,5 +9,6 @@
     <UnitTestsTargetFrameworks>net461</UnitTestsTargetFrameworks>
     <TestHelpersTargetFrameworks>net461</TestHelpersTargetFrameworks>
     <ApprovalTestsTargetFrameworks>net461</ApprovalTestsTargetFrameworks>
+    <RecipesTargetFrameworks>net461</RecipesTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/profiles/net6.0.props
+++ b/profiles/net6.0.props
@@ -9,5 +9,6 @@
     <UnitTestsTargetFrameworks>net6.0</UnitTestsTargetFrameworks>
     <TestHelpersTargetFrameworks>net6.0</TestHelpersTargetFrameworks>
     <ApprovalTestsTargetFrameworks>net6.0</ApprovalTestsTargetFrameworks>
+    <RecipesTargetFrameworks>net6.0</RecipesTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/profiles/netcore2.1.props
+++ b/profiles/netcore2.1.props
@@ -9,5 +9,6 @@
     <UnitTestsTargetFrameworks>netcoreapp2.1</UnitTestsTargetFrameworks>
     <TestHelpersTargetFrameworks>netstandard2.0</TestHelpersTargetFrameworks>
     <ApprovalTestsTargetFrameworks>netcoreapp2.1</ApprovalTestsTargetFrameworks>
+    <RecipesTargetFrameworks>netcoreapp2.1</RecipesTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/profiles/netcore3.1.props
+++ b/profiles/netcore3.1.props
@@ -9,5 +9,6 @@
     <UnitTestsTargetFrameworks>netcoreapp3.1</UnitTestsTargetFrameworks>
     <TestHelpersTargetFrameworks>netstandard2.1</TestHelpersTargetFrameworks>
     <ApprovalTestsTargetFrameworks>netcoreapp3.1</ApprovalTestsTargetFrameworks>
+    <RecipesTargetFrameworks>netcoreapp3.1</RecipesTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/recipes/.editorconfig
+++ b/recipes/.editorconfig
@@ -1,0 +1,4 @@
+[*.{cs,vb}]
+dotnet_diagnostic.CA1034.severity = none # Nested types should not be visible
+dotnet_diagnostic.CA2007.severity = none # Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2234.severity = none # Call 'HttpClient.GetAsync(Uri)' instead of 'HttpClient.GetAsync(string)'

--- a/recipes/Directory.Build.props
+++ b/recipes/Directory.Build.props
@@ -1,0 +1,18 @@
+<Project>
+
+  <Import Project="../Directory.Build.props" />
+
+  <PropertyGroup>
+    <NoWarn>$(NoWarn),SA0001,CA1014</NoWarn>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="xunit.core" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+  </ItemGroup>
+
+</Project>

--- a/recipes/FakeItEasy.Recipes.CSharp/FakeItEasy.Recipes.CSharp.csproj
+++ b/recipes/FakeItEasy.Recipes.CSharp/FakeItEasy.Recipes.CSharp.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(RecipesTargetFrameworks)</TargetFrameworks>
+    <AssemblyName>FakeItEasy.Recipes.CSharp</AssemblyName>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
+      <DefineConstants>$(DefineConstants);LACKS_RETAINED_REQUEST_CONTENT</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/FakeItEasy/FakeItEasy.csproj" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+</Project>

--- a/recipes/FakeItEasy.Recipes.CSharp/FakingHttpClient.cs
+++ b/recipes/FakeItEasy.Recipes.CSharp/FakingHttpClient.cs
@@ -1,0 +1,90 @@
+namespace FakeItEasy.Recipes.CSharp;
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+public class FakingHttpClient
+{
+    //// --8<-- [start:FakeAnyMethodWay]
+    [Fact]
+    public async Task FakeAnyMethodWay()
+    {
+        using var response = new HttpResponseMessage
+        {
+            Content = new StringContent("FakeItEasy is fun")
+        };
+
+        var handler = A.Fake<HttpMessageHandler>();
+        A.CallTo(handler)
+            .WithReturnType<Task<HttpResponseMessage>>()
+            .Where(call => call.Method.Name == "SendAsync")
+            .Returns(response);
+
+        using var client = new HttpClient(handler);
+
+        var result = await client.GetAsync("https://fakeiteasy.github.io/docs/");
+        var content = await result.Content.ReadAsStringAsync();
+        content.Should().Be("FakeItEasy is fun");
+    }
+    //// --8<-- [end:FakeAnyMethodWay]
+
+    //// --8<-- [start:FakeByMakingMessageHandlerFakeable]
+    [Fact]
+    public async Task FakeByMakingMessageHandlerFakeable()
+    {
+        using var response = new HttpResponseMessage
+        {
+            Content = new StringContent("FakeItEasy is fun")
+        };
+
+        var handler = A.Fake<FakeableHttpMessageHandler>();
+        A.CallTo(() => handler.FakeSendAsync(
+                A<HttpRequestMessage>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(response);
+
+        using var client = new HttpClient(handler);
+
+        var result = await client.GetAsync("https://fakeiteasy.github.io/docs/");
+        var content = await result.Content.ReadAsStringAsync();
+        content.Should().Be("FakeItEasy is fun");
+    }
+    //// --8<-- [end:FakeByMakingMessageHandlerFakeable]
+
+#if !LACKS_RETAINED_REQUEST_CONTENT
+    //// --8<-- [start:FakePostAsync]
+    [Fact]
+    public async Task FakePostAsync()
+    {
+        var handler = A.Fake<FakeableHttpMessageHandler>();
+
+        using var client = new HttpClient(handler);
+
+        using var postContent = new StringContent("my post");
+        await client.PostAsync(
+            "https://fakeiteasy.github.io/docs/", postContent);
+
+        A.CallTo(() => handler.FakeSendAsync(
+                A<HttpRequestMessage>.That.Matches(
+                    m => m.Content!.ReadAsStringAsync().Result == "my post"),
+                A<CancellationToken>.Ignored))
+            .MustHaveHappened();
+    }
+    //// --8<-- [end:FakePostAsync]
+#endif
+
+    //// --8<-- [start:FakeableHttpMessageHandler]
+    public abstract class FakeableHttpMessageHandler : HttpMessageHandler
+    {
+        public abstract Task<HttpResponseMessage> FakeSendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken);
+
+        // sealed so FakeItEasy won't intercept calls to this method
+        protected sealed override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            => this.FakeSendAsync(request, cancellationToken);
+    }
+    //// --8<-- [end:FakeableHttpMessageHandler]
+}

--- a/tools/FakeItEasy.Build/Program.cs
+++ b/tools/FakeItEasy.Build/Program.cs
@@ -25,13 +25,17 @@ var testSuites = new Dictionary<string, string[]>
     {
         "tests/FakeItEasy.Specs"
     },
+    ["recipes"] = new[]
+    {
+        "recipes/FakeItEasy.Recipes.CSharp"
+    },
     ["approve"] = new[]
     {
         "tests/FakeItEasy.Tests.Approval"
     }
 };
 
-Target("default", DependsOn("unit", "integ", "spec", "approve", "pack"));
+Target("default", DependsOn("unit", "integ", "spec", "recipes", "approve", "pack"));
 
 Target(
     "build",


### PR DESCRIPTION
Adds runnable recipes (in form of tests) and includes those in a Recipe section of the documentation, by reading "snippets" right out of the executable recipe.

----
**Old description:**
Not baked yet, but a good starting point for discussion. In particular, we're going to at least want to decide whether we want these things called "case studies" or "recipes" or whatever. I picked one so I could have something to commit and push.
@thomaslevesque, everything's negotiable. For example, you might hate tone, approach of showing one way to work and then introducing the fakeable context, showing a "quicky" version of the test where we exercise the fake directly, anything. Don't hold back.

I also have ideas for hosting the code in this article (or others?) separately, similarly to the samples directory, but probably runnable. But let's look at that later…
