### PR TITLE
Upgrade mkdocs-material to 9.1.3

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ theme:
   name: material
   favicon: img/favicon.ico
   logo: img/icon.svg
+  features:
+    - navigation.footer
 
   palette:
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,3 @@
 mike == 1.1.2
 mkdocs == 1.4.2
-mkdocs-material == 8.5.10
+mkdocs-material == 9.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 certifi==2022.12.7
     # via requests
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via mkdocs
@@ -14,6 +14,7 @@ colorama==0.4.6
     # via
     #   click
     #   mkdocs
+    #   mkdocs-material
 ghp-import==2.1.0
     # via mkdocs
 idna==3.4
@@ -28,7 +29,7 @@ markdown==3.3.7
     #   mkdocs
     #   mkdocs-material
     #   pymdown-extensions
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mergedeep==1.3.4
     # via mkdocs
@@ -39,15 +40,15 @@ mkdocs==1.4.2
     #   -r requirements.in
     #   mike
     #   mkdocs-material
-mkdocs-material==8.5.10
+mkdocs-material==9.1.3
     # via -r requirements.in
 mkdocs-material-extensions==1.1.1
     # via mkdocs-material
-packaging==22.0
+packaging==23.0
     # via mkdocs
 pygments==2.14.0
     # via mkdocs-material
-pymdown-extensions==9.9
+pymdown-extensions==9.10
     # via mkdocs-material
 python-dateutil==2.8.2
     # via ghp-import
@@ -55,16 +56,19 @@ pyyaml==6.0
     # via
     #   mike
     #   mkdocs
+    #   pymdown-extensions
     #   pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-requests==2.28.1
+regex==2022.10.31
+    # via mkdocs-material
+requests==2.28.2
     # via mkdocs-material
 six==1.16.0
     # via python-dateutil
-urllib3==1.26.13
+urllib3==1.26.15
     # via requests
 verspec==0.1.0
     # via mike
-watchdog==2.2.1
+watchdog==3.0.0
     # via mkdocs


### PR DESCRIPTION
Brings improved plugin versions, such as snippets, which will be used to add recipes to the docs.