### PR TITLE
Make ArgumentCollection.GetArgumentNames return type IEnumerable<string?>

### DIFF
--- a/src/FakeItEasy/Configuration/ArgumentCollection.cs
+++ b/src/FakeItEasy/Configuration/ArgumentCollection.cs
@@ -19,7 +19,7 @@ namespace FakeItEasy.Configuration
         ///   The arguments this collection contains.
         /// </summary>
         private readonly object?[] arguments;
-        private readonly Lazy<string[]> argumentNames;
+        private readonly Lazy<string?[]> argumentNames;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref = "ArgumentCollection" /> class.
@@ -39,7 +39,7 @@ namespace FakeItEasy.Configuration
 
             this.arguments = arguments;
             this.Method = method;
-            this.argumentNames = new Lazy<string[]>(this.GetArgumentNames);
+            this.argumentNames = new Lazy<string?[]>(this.GetArgumentNames);
         }
 
         /// <summary>
@@ -53,8 +53,10 @@ namespace FakeItEasy.Configuration
 
         /// <summary>
         ///   Gets the names of the arguments in the list.
+        ///   It's possible to declare methods with anonymous parameters (for example, in F#),
+        ///   in which case the argument names will be <c>null</c>.
         /// </summary>
-        public IEnumerable<string> ArgumentNames => this.argumentNames.Value;
+        public IEnumerable<string?> ArgumentNames => this.argumentNames.Value;
 
         internal MethodInfo Method { get; }
 
@@ -125,14 +127,14 @@ namespace FakeItEasy.Configuration
             return this.arguments;
         }
 
-        private string[] GetArgumentNames() => this.Method.GetParameters().Select(x => x.Name!).ToArray();
+        private string?[] GetArgumentNames() => this.Method.GetParameters().Select(x => x.Name).ToArray();
 
         private int GetArgumentIndex(string argumentName)
         {
             var names = this.argumentNames.Value;
             for (int index = 0; index < names.Length; ++index)
             {
-                if (names[index].Equals(argumentName, StringComparison.Ordinal))
+                if (string.Equals(names[index], argumentName, StringComparison.Ordinal))
                 {
                     return index;
                 }

--- a/src/FakeItEasy/Configuration/ArgumentCollection.cs
+++ b/src/FakeItEasy/Configuration/ArgumentCollection.cs
@@ -11,7 +11,6 @@ namespace FakeItEasy.Configuration
     /// <summary>
     ///   A collection of method arguments.
     /// </summary>
-    [SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Justification = "Best name to describe the type.")]
     public class ArgumentCollection
         : IEnumerable<object?>
     {
@@ -96,7 +95,6 @@ namespace FakeItEasy.Configuration
         /// The argument at the specified index. Note that the value is taken from method's arguments and so may be <c>null</c>,
         /// even if <typeparamref name="T"/> is non-nullable.
         /// </returns>
-        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Used to cast the argument to the specified type.")]
         [return: MaybeNull]
         public T Get<T>(int index)
         {
@@ -113,7 +111,6 @@ namespace FakeItEasy.Configuration
         /// even if <typeparamref name="T"/> is non-nullable.
         /// </returns>
         [return: MaybeNull]
-        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Used to cast the argument to the specified type.")]
         public T Get<T>(string argumentName)
         {
             Guard.AgainstNull(argumentName);

--- a/tests/FakeItEasy.Specs/FakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeSpecs.cs
@@ -4,6 +4,7 @@ namespace FakeItEasy.Specs
     using System.Collections.Generic;
     using System.Linq;
     using FakeItEasy.Core;
+    using FakeItEasy.Tests.TestHelpers.FSharp;
     using FluentAssertions;
     using Xbehave;
 
@@ -177,6 +178,24 @@ namespace FakeItEasy.Specs
 
             "Then the recorded call's return value should be the value that was actually returned"
                 .x(() => recordedCall.ReturnValue.Should().Be(returnValue));
+        }
+
+        [Scenario]
+        public static void RecordedCallWithAnonymousParameterHasNullArgumentName(
+            IHaveAMethodWithAnAnonymousParameter fake,
+            ICompletedFakeObjectCall recordedCall)
+        {
+            "Given a fake with a method that has an anonymous parameter"
+                .x(() => fake = A.Fake<IHaveAMethodWithAnAnonymousParameter>());
+
+            "When I invoke the fake method"
+                .x(() => fake.Save(918));
+
+            "And I retrieve the call from the recorded calls"
+                .x(() => recordedCall = Fake.GetCalls(fake).Single());
+
+            "Then the recorded call's argument name should be null"
+                .x(() => recordedCall.Arguments.ArgumentNames.Single().Should().BeNull());
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net45.verified.txt
@@ -385,7 +385,7 @@ namespace FakeItEasy.Configuration
 {
     public class ArgumentCollection : System.Collections.Generic.IEnumerable<object?>, System.Collections.IEnumerable
     {
-        public System.Collections.Generic.IEnumerable<string> ArgumentNames { get; }
+        public System.Collections.Generic.IEnumerable<string?> ArgumentNames { get; }
         public int Count { get; }
         public object? this[int argumentIndex] { get; }
         [return: System.Diagnostics.CodeAnalysis.MaybeNull]

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net5.0.verified.txt
@@ -424,7 +424,7 @@ namespace FakeItEasy.Configuration
 {
     public class ArgumentCollection : System.Collections.Generic.IEnumerable<object?>, System.Collections.IEnumerable
     {
-        public System.Collections.Generic.IEnumerable<string> ArgumentNames { get; }
+        public System.Collections.Generic.IEnumerable<string?> ArgumentNames { get; }
         public int Count { get; }
         public object? this[int argumentIndex] { get; }
         [return: System.Diagnostics.CodeAnalysis.MaybeNull]

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.verified.txt
@@ -385,7 +385,7 @@ namespace FakeItEasy.Configuration
 {
     public class ArgumentCollection : System.Collections.Generic.IEnumerable<object?>, System.Collections.IEnumerable
     {
-        public System.Collections.Generic.IEnumerable<string> ArgumentNames { get; }
+        public System.Collections.Generic.IEnumerable<string?> ArgumentNames { get; }
         public int Count { get; }
         public object? this[int argumentIndex] { get; }
         [return: System.Diagnostics.CodeAnalysis.MaybeNull]

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.verified.txt
@@ -424,7 +424,7 @@ namespace FakeItEasy.Configuration
 {
     public class ArgumentCollection : System.Collections.Generic.IEnumerable<object?>, System.Collections.IEnumerable
     {
-        public System.Collections.Generic.IEnumerable<string> ArgumentNames { get; }
+        public System.Collections.Generic.IEnumerable<string?> ArgumentNames { get; }
         public int Count { get; }
         public object? this[int argumentIndex] { get; }
         [return: System.Diagnostics.CodeAnalysis.MaybeNull]


### PR DESCRIPTION
Fixes #1922