### PR TITLE
Provide placeholder names for anonymous parameters in received call descriptions

### DIFF
--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -7,6 +7,7 @@ namespace FakeItEasy.Specs
     using System.Runtime.InteropServices;
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
+    using FakeItEasy.Tests.TestHelpers.FSharp;
     using FluentAssertions;
     using Xbehave;
     using Xunit;
@@ -183,6 +184,34 @@ namespace FakeItEasy.Specs
   Expected to find it once or more but didn't find it among the calls:
     1: FakeItEasy.Specs.CallMatchingSpecs+IHaveTwoGenericParameters.Bar`2[System.Int32,System.Double](baz1: 1, baz2: 2)
     2: FakeItEasy.Specs.CallMatchingSpecs+IHaveTwoGenericParameters.Bar`2[FakeItEasy.Specs.CallMatchingSpecs+GenericClass`2[System.Boolean,System.Int64],System.Int32](baz1: FakeItEasy.Specs.CallMatchingSpecs+GenericClass`2[System.Boolean,System.Int64], baz2: 3)
+
+"));
+        }
+
+        [Scenario]
+        public static void FailingMatchCallWithAnonymousParameter(
+            IHaveAMethodWithAnAnonymousParameter fake,
+            Exception exception)
+        {
+            "Given a fake that has a method with anonymous parameters"
+                .x(() => fake = A.Fake<IHaveAMethodWithAnAnonymousParameter>());
+
+            "And a call with argument 1 made on this fake"
+                .x(() => fake.Save(1));
+
+            "When I assert that a call with argument 3 has happened on this fake"
+                .x(() => exception = Record.Exception(() => A.CallTo(() => fake.Save(3)).MustHaveHappened()));
+
+            "Then the assertion should fail"
+                .x(() => exception.Should().BeAnExceptionOfType<ExpectationException>());
+
+            "And the exception message should tell us that the call was not matched using a placeholder parameter name"
+                .x(() => exception.Message.Should().BeModuloLineEndings(@"
+
+  Assertion failed for the following call:
+    FakeItEasy.Tests.TestHelpers.FSharp.IHaveAMethodWithAnAnonymousParameter.Save(param1: 3)
+  Expected to find it once or more but didn't find it among the calls:
+    1: FakeItEasy.Tests.TestHelpers.FSharp.IHaveAMethodWithAnAnonymousParameter.Save(param1: 1)
 
 "));
         }

--- a/tests/FakeItEasy.Specs/StrictFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/StrictFakeSpecs.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy.Specs
 {
     using System;
     using FakeItEasy.Tests.TestHelpers;
+    using FakeItEasy.Tests.TestHelpers.FSharp;
     using FluentAssertions;
     using Xbehave;
     using Xunit;
@@ -330,6 +331,24 @@ namespace FakeItEasy.Specs
                     .Should()
                     .BeAnExceptionOfType<ExpectationException>()
                     .WithMessage(@"Call to unconfigured method of strict fake: FakeItEasy.Specs.StrictFakeSpecs+IMyInterface.MakeIt(name: ""argument"") on Foo1."));
+        }
+
+        [Scenario]
+        public static void AnonymousParameterInExpectationException(
+            IHaveAMethodWithAnAnonymousParameter fake,
+            Exception exception)
+        {
+            "Given a strict fake that has a method with anonymous parameters"
+                .x(() => fake = A.Fake<IHaveAMethodWithAnAnonymousParameter>(o => o.Strict()));
+
+            "And I call an unconfigured method"
+                .x(() => exception = Record.Exception(() => fake.Save(23978)));
+
+            "Then the thrown exception should include a placeholder parameter name"
+                .x(() => exception
+                    .Should()
+                    .BeAnExceptionOfType<ExpectationException>()
+                    .WithMessage(@"Call to unconfigured method of strict fake: FakeItEasy.Tests.TestHelpers.FSharp.IHaveAMethodWithAnAnonymousParameter.Save(param1: 23978)."));
         }
     }
 


### PR DESCRIPTION
Follows from fix for #1920.

If a method has anonymous parameters, the description of a received call should use placeholder names just as we would for a call that is expected but not received.