### PR TITLE
Ensure anonymous parameters are handled and displayed correctly in remaining cases

### DIFF
--- a/src/FakeItEasy/MethodInfoExtensions.cs
+++ b/src/FakeItEasy/MethodInfoExtensions.cs
@@ -170,10 +170,15 @@ namespace FakeItEasy
             for (int i = 0; i < parameters.Length; i++)
             {
                 AppendParameterSeparator(builder, i);
-                builder
-                    .Append(parameters[i].ParameterType)
-                    .Append(' ')
-                    .Append(parameters[i].Name);
+                builder.Append(parameters[i].ParameterType);
+
+                var parameterName = parameters[i].Name;
+                if (parameterName is not null)
+                {
+                    builder
+                       .Append(' ')
+                       .Append(parameterName);
+                }
             }
         }
 

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -269,7 +269,7 @@ namespace FakeItEasy.Specs
                 .x(() => notAFake = new BaseClass());
 
             "When I start to configure a non-virtual void method on the object"
-                .x(() => exception = Record.Exception(() => A.CallTo(() => notAFake.DoSomethingNonVirtual())));
+                .x(() => exception = Record.Exception(() => A.CallTo(() => notAFake.DoSomethingNonVirtual(1))));
 
             "Then it throws an argument exception"
                .x(() => exception.Should().BeAnExceptionOfType<ArgumentException>()
@@ -285,11 +285,11 @@ namespace FakeItEasy.Specs
                 .x(() => fake = A.Fake<BaseClass>());
 
             "When I start to configure a non-virtual void method on the fake"
-                .x(() => exception = Record.Exception(() => A.CallTo(() => fake.DoSomethingNonVirtual())));
+                .x(() => exception = Record.Exception(() => A.CallTo(() => fake.DoSomethingNonVirtual(2))));
 
             "Then it throws a fake configuration exception"
                 .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                    .And.Message.Should().Contain("Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
+                    .And.Message.Should().ContainModuloLineEndings("The current proxy generator can not intercept the method FakeItEasy.Specs.ConfigurationSpecs+BaseClass.DoSomethingNonVirtual(System.Int32 anInt) for the following reason:\r\n    - Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
         }
 
         [Scenario]
@@ -799,7 +799,7 @@ namespace FakeItEasy.Specs
                 this.WasCalled = true;
             }
 
-            public void DoSomethingNonVirtual()
+            public void DoSomethingNonVirtual(int anInt)
             {
             }
 

--- a/tests/FakeItEasy.Specs/CreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationSpecs.cs
@@ -8,6 +8,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Core;
     using FakeItEasy.Creation;
     using FakeItEasy.Tests.TestHelpers;
+    using FakeItEasy.Tests.TestHelpers.FSharp;
     using FluentAssertions;
     using Xbehave;
     using Xunit;
@@ -385,6 +386,19 @@ namespace FakeItEasy.Specs
   Failed to create fake of type System.Func`1[FakeItEasy.Specs.CreationSpecsBase+PrivateClass]:
     Can not create proxy for type System.Func`1[[FakeItEasy.Specs.CreationSpecsBase+PrivateClass, FakeItEasy.Specs, Version=1.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c]] because type FakeItEasy.Specs.CreationSpecsBase+PrivateClass is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(*DynamicProxyGenAssembly2*)] attribute*
 "));
+        }
+
+        [Scenario]
+        public void PublicDelegateWithAnonymousParameterCanBeFaked(IAmADelegateWithAnAnonymousParameter fake)
+        {
+            "Given a public delegate with an anonymous parameter "
+                .See<IAmADelegateWithAnAnonymousParameter>();
+
+            "When I create a fake of the delegate"
+                .x(() => fake = this.CreateFake<IAmADelegateWithAnAnonymousParameter>());
+
+            "Then the fake is created"
+                .x(() => fake.Should().BeAFake());
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Tests.TestHelpers.FSharp/FakeItEasy.Tests.TestHelpers.FSharp.fsproj
+++ b/tests/FakeItEasy.Tests.TestHelpers.FSharp/FakeItEasy.Tests.TestHelpers.FSharp.fsproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="IAmADelegateWithAnAnonymousParameter.fs" />
     <Compile Include="IHaveAMethodWithAnAnonymousParameter.fs" />
   </ItemGroup>
 

--- a/tests/FakeItEasy.Tests.TestHelpers.FSharp/FakeItEasy.Tests.TestHelpers.FSharp.fsproj
+++ b/tests/FakeItEasy.Tests.TestHelpers.FSharp/FakeItEasy.Tests.TestHelpers.FSharp.fsproj
@@ -13,4 +13,7 @@
     <Compile Include="IHaveAMethodWithAnAnonymousParameter.fs" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(TargetFramework)' == 'net461'">
+    <Exec Command="pwsh postbuild.ps1 &quot;$(TargetPath)&quot;" />
+  </Target>
 </Project>

--- a/tests/FakeItEasy.Tests.TestHelpers.FSharp/IAmADelegateWithAnAnonymousParameter.fs
+++ b/tests/FakeItEasy.Tests.TestHelpers.FSharp/IAmADelegateWithAnAnonymousParameter.fs
@@ -1,0 +1,3 @@
+namespace FakeItEasy.Tests.TestHelpers.FSharp
+
+type IAmADelegateWithAnAnonymousParameter = delegate of int -> int

--- a/tests/FakeItEasy.Tests.TestHelpers.FSharp/postbuild.ps1
+++ b/tests/FakeItEasy.Tests.TestHelpers.FSharp/postbuild.ps1
@@ -1,0 +1,38 @@
+# Due to dotnet/fsharp#14863, FakeItEasy.Tests.TestHelper.FSharp is delay signed.
+# This prevents FakeItEasy.Tests from loading the assembly.
+# Workaround until the tooling is fixed is to resign the assembly.
+# The path to sn.exe seems impossible to find with any certainty, so
+# for now we'll probe a few likely location and hope we can remove this
+# postbuild step before it becomes an issue.
+
+$assembly = $Args[0]
+
+
+$windowsSDKExecutablePath = $env:WindowsSDK_ExecutablePath_x86
+
+$netfxsdkKey = "HKLM:\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.8\"
+if (Test-Path $netfxsdkKey) {
+    $toolsItem = Get-ItemProperty "${netfxsdkKey}\WinSDK-NetFx40Tools"
+    if ($toolsItem) {
+        $netFx40ToolsPath = $toolsItem.InstallationFolderd
+    }
+    else {
+        $netFx40ToolsPath = $null
+    }
+}
+
+$assumedProgramFilesNextFx48ToolsPath = Join-Path ${env:ProgramFiles(x86)} "Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools"
+
+$candidatePaths = [array]($windowsSDKExecutablePath, $netFx40ToolsPath, $assumedProgramFilesNextFx48ToolsPath |
+    Where-Object { $_ } |
+    ForEach-Object { Join-Path $_ "sn.exe" } |
+    Where-Object { Test-Path $_ }
+)
+
+if (!$candidatePaths) {
+    throw "Can't find sn.exe."
+}
+
+$sn = $candidatePaths[0]
+
+&$sn -q -R $assembly ../../src/FakeItEasy.snk

--- a/tests/FakeItEasy.Tests/FakeItEasy.Tests.csproj
+++ b/tests/FakeItEasy.Tests/FakeItEasy.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\FakeItEasy\FakeItEasy.csproj" />
+    <ProjectReference Include="..\FakeItEasy.Tests.TestHelpers.FSharp\FakeItEasy.Tests.TestHelpers.FSharp.fsproj" />
     <ProjectReference Include="..\FakeItEasy.Tests.TestHelpers\FakeItEasy.Tests.TestHelpers.csproj" />
   </ItemGroup>
 

--- a/tests/FakeItEasy.Tests/MethodInfoExtensionsTests.cs
+++ b/tests/FakeItEasy.Tests/MethodInfoExtensionsTests.cs
@@ -1,0 +1,28 @@
+namespace FakeItEasy.Tests;
+
+using FakeItEasy.Tests.TestHelpers.FSharp;
+using FluentAssertions;
+using Xunit;
+
+public class MethodInfoExtensionsTests
+{
+    [Fact]
+    public void GetDescription_AnonymousParameters_OmitsParameterNames()
+    {
+        // F# (at least) allows users to declare methods with anonymous parameters, which requires
+        // special handling to render in a pleasing way.
+        // Attempts to trigger the method-rendering from specs have failed so far, as it requires
+        // generating a method with anonymous types that can't be intercepted, on a type that can
+        // be. But just in case we're not clever enough to find a way, and some client does, check
+        // the rendering with a unit test.
+
+        // Arrange
+        var expected = "FakeItEasy.Tests.TestHelpers.FSharp.IHaveAMethodWithAnAnonymousParameter.Save(System.Int32)";
+
+        // Act
+        var actual = typeof(IHaveAMethodWithAnAnonymousParameter).GetMethod("Save")!.GetDescription();
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Provides test coverage of the last 2 instances where we access parameter names, ensuring we behave somewhat sanely when the parameters have no names. Includes one minor change in how anonymous parameters are displayed, but we can only figure out how to exercise that via unit test. An "organic" use may not be possible.

Finishes work started in #1920, #1922, and #1924.
