### PR TITLE
Require pymdown-extensions 10.0.1 or higher

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,8 @@
 mike == 1.1.2
 mkdocs == 1.4.2
 mkdocs-material == 9.1.3
+
+# Security risk: any file can be included as a snippet with pymdown-extensions < 10
+# https://github.com/advisories/GHSA-jh85-wwv9-24hv
+# May become unnecessary when mkdocs-material version is bumped.
+pymdown-extensions >= 10.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,8 +48,10 @@ packaging==23.0
     # via mkdocs
 pygments==2.14.0
     # via mkdocs-material
-pymdown-extensions==9.10
-    # via mkdocs-material
+pymdown-extensions==10.0.1
+    # via
+    #   -r requirements.in
+    #   mkdocs-material
 python-dateutil==2.8.2
     # via ghp-import
 pyyaml==6.0


### PR DESCRIPTION
Fixes a security risk: any file can be included as a snippet with pymdown-extensions < 10

  https://github.com/advisories/GHSA-jh85-wwv9-24hv
  
Closes #1944.