### PR TITLE
Install .NET Core 3.1 on Windows in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
             os-image: windows-2022
             os-name: Windows
             artifact-name: windows-artifacts
+            dotnet-versions-to-install: |
+              3.1
           - os: ubuntu
             os-image: ubuntu-22.04
             os-name: Ubuntu


### PR DESCRIPTION
It's been [removed](https://github.com/actions/runner-images/issues/7667) from Github Hosted worker images.