### PR TITLE
Update docs dependencies for security

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,3 @@
 mike == 1.1.2
 mkdocs == 1.4.2
 mkdocs-material == 9.1.3
-
-# Security risk: any file can be included as a snippet with pymdown-extensions < 10
-# https://github.com/advisories/GHSA-jh85-wwv9-24hv
-# May become unnecessary when mkdocs-material version is bumped.
-pymdown-extensions >= 10.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile requirements.in
 #
-certifi==2022.12.7
+certifi==2023.7.22
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.6
     # via mkdocs
 colorama==0.4.6
     # via
@@ -29,7 +29,7 @@ markdown==3.3.7
     #   mkdocs
     #   mkdocs-material
     #   pymdown-extensions
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mergedeep==1.3.4
     # via mkdocs
@@ -44,17 +44,15 @@ mkdocs-material==9.1.3
     # via -r requirements.in
 mkdocs-material-extensions==1.1.1
     # via mkdocs-material
-packaging==23.0
+packaging==23.1
     # via mkdocs
-pygments==2.14.0
+pygments==2.15.1
     # via mkdocs-material
-pymdown-extensions==10.0.1
-    # via
-    #   -r requirements.in
-    #   mkdocs-material
+pymdown-extensions==10.1
+    # via mkdocs-material
 python-dateutil==2.8.2
     # via ghp-import
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   mike
     #   mkdocs
@@ -62,13 +60,13 @@ pyyaml==6.0
     #   pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-regex==2022.10.31
+regex==2023.6.3
     # via mkdocs-material
-requests==2.28.2
+requests==2.31.0
     # via mkdocs-material
 six==1.16.0
     # via python-dateutil
-urllib3==1.26.15
+urllib3==2.0.4
     # via requests
 verspec==0.1.0
     # via mike


### PR DESCRIPTION
Rolls up dependabot PRs #1946, #1957, and #1958.

Accomplished by running `pip-compile --upgrade requirements.in`.