### PR TITLE
Choose equality comparer based on example type instead of parameter type

### DIFF
--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -31,7 +31,7 @@ test from this list:
 * if both values are `null`, they are considered equal,
 * if one value is `null` and the other isn't, they are not considered equal,
 * the highest-priority [custom argument equality comparer](custom-argument-equality.md)
-  that can compare the parameter's type, or
+  that can compare the example object's type, or
 * `Object.Equals`
 
 If this list is not satisfactory, you may have to use the `That.Matches`

--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -25,11 +25,16 @@ A.CallTo(() => foo.Bar("hello", 17)).MustHaveHappened();
 Then FakeItEasy will look _only_ for calls made with the arguments
 `"hello"` and `17` - no other calls will match the rule.
 
-When checking for argument equality, FakeItEasy uses
-`object.Equals`, unless a
-[custom argument equality comparer](custom-argument-equality.md) is defined.
-If the type to be checked does not provide an
-adequate `Equals` method, you may have to use the `That.Matches`
+When checking for argument equality, FakeItEasy uses the first applicable equality
+test from this list:
+
+* if both values are `null`, they are considered equal,
+* if one value is `null` and the other isn't, they are not considered equal,
+* the highest-priority [custom argument equality comparer](custom-argument-equality.md)
+  that can compare the parameter's type, or
+* `Object.Equals`
+
+If this list is not satisfactory, you may have to use the `That.Matches`
 method described in [Custom matching](#custom-matching). Be
 particularly careful of types whose `Equals` methods perform reference
 equality rather than value equality. In that case, the objects have to

--- a/docs/custom-argument-equality.md
+++ b/docs/custom-argument-equality.md
@@ -74,11 +74,11 @@ public interface IArgumentEqualityComparer
 
 When FakeItEasy needs to compare a non-null argument value with a non-null expected value,
 it looks at all known `IArgumentEqualityComparer` implementations for which
-`CanCompare` returns true for the parameter type. If multiple implementations
+`CanCompare` returns true for the type of the expected value. If multiple implementations
 match, the one with the highest `Priority` is used.
 
 If all that's needed is an Argument Equality Comparer that specifies how to
-compare instances of a specific type,  extending `abstract class
+compare two instances of a specific type, extending `abstract class
 ArgumentEqualityComparer<T>: IArgumentEqualityComparer` is preferred. It
 provides default implementations of `Priority` and `CanCompare` (although
 they can be overridden if needed).

--- a/docs/custom-argument-equality.md
+++ b/docs/custom-argument-equality.md
@@ -1,4 +1,4 @@
-﻿# Custom argument equality
+# Custom argument equality
 
 ## Default behavior when comparing argument values
 
@@ -49,9 +49,9 @@ the `AreEqual` method:
 ```csharp
 public class FooComparer : ArgumentEqualityComparer<Foo>
 {
-    protected override bool AreEqual(Foo? expectedValue, Foo? argumentValue)
+    protected override bool AreEqual(Foo expectedValue, Foo argumentValue)
     {
-        return expectedValue?.Bar == argumentValue?.Bar;
+        return expectedValue.Bar == argumentValue.Bar;
     }
 }
 ```
@@ -67,15 +67,15 @@ FakeItEasy uses classes that implement the following interface to compare argume
 public interface IArgumentEqualityComparer
 {
     bool CanCompare(Type type);
-    bool AreEqual(object? expectedValue, object? argumentValue);
+    bool AreEqual(object expectedValue, object argumentValue);
     Priority Priority { get; }
 }
 ```
 
-When FakeItEasy needs to compare an argument value with the configured value,
+When FakeItEasy needs to compare a non-null argument value with a non-null expected value,
 it looks at all known `IArgumentEqualityComparer` implementations for which
 `CanCompare` returns true for the parameter type. If multiple implementations
-match, the one with the highest `Priority`is used.
+match, the one with the highest `Priority` is used.
 
 If all that's needed is an Argument Equality Comparer that specifies how to
 compare instances of a specific type,  extending `abstract class
@@ -93,9 +93,9 @@ class ToStringArgumentEqualityComparer : IArgumentEqualityComparer
 {
     public bool CanCompare(Type type) => type.Namespace == "MySpecialNamespace";
 
-    public bool AreEqual(object? expectedValue, object? argumentValue)
+    public bool AreEqual(object expectedValue, object argumentValue)
     {
-        return expectedValue?.ToString() == argumentValue?.ToString();
+        return expectedValue.ToString() == argumentValue.ToString();
     }
 
     public Priority Priority => Priority.Default;

--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -7,6 +7,7 @@ namespace FakeItEasy
     using System.Linq;
     using System.Linq.Expressions;
     using System.Threading;
+    using FakeItEasy.Expressions.ArgumentConstraints;
 
     /// <summary>
     /// Provides validation extensions for <see cref="IArgumentConstraintManager{T}"/>.
@@ -23,7 +24,7 @@ namespace FakeItEasy
         {
             Guard.AgainstNull(manager);
 
-            return manager.Matches(x => x is null, x => x.Write("NULL"));
+            return manager.Matches(NullArgumentConstraint.Instance.IsValid, NullArgumentConstraint.Instance.ConstraintDescription);
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace FakeItEasy
         {
             Guard.AgainstNull(manager);
 
-            return manager.Matches(x => x is null, x => x.Write("NULL"));
+            return manager.Matches(x => NullArgumentConstraint.Instance.IsValid(x), NullArgumentConstraint.Instance.ConstraintDescription);
         }
 
         /// <summary>

--- a/src/FakeItEasy/ArgumentEqualityComparer.cs
+++ b/src/FakeItEasy/ArgumentEqualityComparer.cs
@@ -30,7 +30,7 @@ public abstract class ArgumentEqualityComparer<T> : IArgumentEqualityComparer
     /// <param name="argumentValue">The second object to compare.</param>
     /// <returns><c>true</c> if the objects are considered equal. Otherwise <c>false</c>.</returns>
     /// <remarks>This method cannot be overridden. Override the <see cref="AreEqual(T, T)"/> method instead.</remarks>
-    public bool AreEqual(object? expectedValue, object? argumentValue) => this.AreEqual((T?)expectedValue, (T?)argumentValue);
+    public bool AreEqual(object expectedValue, object argumentValue) => this.AreEqual((T)expectedValue, (T)argumentValue);
 
     /// <summary>
     /// When overridden in a derived class, indicates whether <paramref name="expectedValue"/> and
@@ -39,5 +39,5 @@ public abstract class ArgumentEqualityComparer<T> : IArgumentEqualityComparer
     /// <param name="expectedValue">The first object to compare.</param>
     /// <param name="argumentValue">The second object to compare.</param>
     /// <returns><c>true</c> if the objects are considered equal. Otherwise <c>false</c>.</returns>
-    protected abstract bool AreEqual(T? expectedValue, T? argumentValue);
+    protected abstract bool AreEqual(T expectedValue, T argumentValue);
 }

--- a/src/FakeItEasy/ArgumentEqualityComparer.cs
+++ b/src/FakeItEasy/ArgumentEqualityComparer.cs
@@ -16,6 +16,7 @@ public abstract class ArgumentEqualityComparer<T> : IArgumentEqualityComparer
 
     /// <summary>
     /// Whether or not this object can compare instances of <paramref name="type"/> for equality.
+    /// True if and only if <paramref name="type"/> is <typeparamref name="T"/>.
     /// </summary>
     /// <param name="type">The type of the objects to compare.</param>
     /// <returns>
@@ -25,12 +26,16 @@ public abstract class ArgumentEqualityComparer<T> : IArgumentEqualityComparer
 
     /// <summary>
     /// Indicates whether <paramref name="expectedValue"/> and <paramref name="argumentValue"/> are considered equal.
+    /// Requires that <paramref name="argumentValue"/> be a <typeparamref name="T"/>; otherwise returns <c>false</c>.
+    /// (The <paramref name="expectedValue"/> is assumed to be a <typeparamref name="T"/> already, since this method
+    /// is only invoked if <see cref="CanCompare(Type)"/> is <c>true</c>.
     /// </summary>
     /// <param name="expectedValue">The first object to compare.</param>
     /// <param name="argumentValue">The second object to compare.</param>
     /// <returns><c>true</c> if the objects are considered equal. Otherwise <c>false</c>.</returns>
     /// <remarks>This method cannot be overridden. Override the <see cref="AreEqual(T, T)"/> method instead.</remarks>
-    public bool AreEqual(object expectedValue, object argumentValue) => this.AreEqual((T)expectedValue, (T)argumentValue);
+    public bool AreEqual(object expectedValue, object argumentValue) =>
+        argumentValue is T argumentValueAsT && this.AreEqual((T)expectedValue, argumentValueAsT);
 
     /// <summary>
     /// When overridden in a derived class, indicates whether <paramref name="expectedValue"/> and

--- a/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
+++ b/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
@@ -1,4 +1,4 @@
-﻿namespace FakeItEasy.Core
+namespace FakeItEasy.Core
 {
     using System;
     using System.Collections.Concurrent;
@@ -15,7 +15,7 @@
             this.argumentEqualityComparers = argumentEqualityComparers.OrderByDescending(c => c.Priority).ToArray();
         }
 
-        public bool AreEqual(object? expectedValue, object? argumentValue, Type parameterType)
+        public bool AreEqual(object expectedValue, object argumentValue, Type parameterType)
         {
             var comparer = this.cachedComparers.GetOrAdd(parameterType, t => this.argumentEqualityComparers.FirstOrDefault(c => c.CanCompare(t)));
 

--- a/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
+++ b/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
@@ -15,9 +15,9 @@ namespace FakeItEasy.Core
             this.argumentEqualityComparers = argumentEqualityComparers.OrderByDescending(c => c.Priority).ToArray();
         }
 
-        public bool AreEqual(object expectedValue, object argumentValue, Type parameterType)
+        public bool AreEqual(object expectedValue, object argumentValue)
         {
-            var comparer = this.cachedComparers.GetOrAdd(parameterType, t => this.argumentEqualityComparers.FirstOrDefault(c => c.CanCompare(t)));
+            var comparer = this.cachedComparers.GetOrAdd(expectedValue.GetType(), this.FindHighestPriorityComparer);
 
             if (comparer is null)
             {
@@ -33,5 +33,8 @@ namespace FakeItEasy.Core
                 throw new UserCallbackException(ExceptionMessages.UserCallbackThrewAnException("Argument Equality Comparer"), exception);
             }
         }
+
+        private IArgumentEqualityComparer? FindHighestPriorityComparer(Type type)
+            => this.argumentEqualityComparers.FirstOrDefault(c => c.CanCompare(type));
     }
 }

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
@@ -8,12 +8,10 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
         : IArgumentConstraint
     {
         private readonly object expectedValue;
-        private readonly Type parameterType;
 
-        public EqualityArgumentConstraint(object expectedValue, Type parameterType)
+        public EqualityArgumentConstraint(object expectedValue)
         {
             this.expectedValue = expectedValue;
-            this.parameterType = parameterType;
         }
 
         public string ConstraintDescription => this.ToString();
@@ -26,7 +24,7 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
             }
 
             var argumentEqualityComparer = ServiceLocator.Resolve<ArgumentEqualityComparer>();
-            return argumentEqualityComparer.AreEqual(this.expectedValue, argument, this.parameterType);
+            return argumentEqualityComparer.AreEqual(this.expectedValue, argument);
         }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Any type of exception may be encountered.")]

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
@@ -7,10 +7,10 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
     internal class EqualityArgumentConstraint
         : IArgumentConstraint
     {
-        private readonly object? expectedValue;
+        private readonly object expectedValue;
         private readonly Type parameterType;
 
-        public EqualityArgumentConstraint(object? expectedValue, Type parameterType)
+        public EqualityArgumentConstraint(object expectedValue, Type parameterType)
         {
             this.expectedValue = expectedValue;
             this.parameterType = parameterType;
@@ -20,6 +20,11 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
 
         public bool IsValid(object? argument)
         {
+            if (argument is null)
+            {
+                return false;
+            }
+
             var argumentEqualityComparer = ServiceLocator.Resolve<ArgumentEqualityComparer>();
             return argumentEqualityComparer.AreEqual(this.expectedValue, argument, this.parameterType);
         }
@@ -33,12 +38,11 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
                 writer.WriteArgumentValue(this.expectedValue);
                 return writer.Builder.ToString();
             }
-            catch (Exception ex) when (!(ex is UserCallbackException))
+            catch (Exception ex) when (ex is not UserCallbackException)
             {
-                // if ExpectedValue were null, WriteArgumentValue wouldn't have thrown
-                return Fake.TryGetFakeManager(this.expectedValue!, out var manager)
+                return Fake.TryGetFakeManager(this.expectedValue, out var manager)
                     ? manager.FakeObjectDisplayName
-                    : this.expectedValue!.GetType().ToString();
+                    : this.expectedValue.GetType().ToString();
             }
         }
 

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/NullArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/NullArgumentConstraint.cs
@@ -1,0 +1,23 @@
+namespace FakeItEasy.Expressions.ArgumentConstraints
+{
+    using FakeItEasy;
+    using FakeItEasy.Core;
+
+    internal class NullArgumentConstraint
+            : IArgumentConstraint
+    {
+        private NullArgumentConstraint()
+        {
+        }
+
+        public static NullArgumentConstraint Instance { get; } = new NullArgumentConstraint();
+
+        public string ConstraintDescription => this.ToString();
+
+        public bool IsValid(object? argument) => argument is null;
+
+        public override string ToString() => "NULL";
+
+        public void WriteDescription(IOutputWriter writer) => writer.Write(this.ToString());
+    }
+}

--- a/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
+++ b/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
@@ -61,9 +61,9 @@ namespace FakeItEasy.Expressions
         }
 
         private static IArgumentConstraint CreateEqualityConstraint(object? expressionValue, Type parameterType)
-        {
-            return new EqualityArgumentConstraint(expressionValue, parameterType);
-        }
+            => expressionValue is null
+                ? NullArgumentConstraint.Instance
+                : new EqualityArgumentConstraint(expressionValue, parameterType);
 
         private static void CheckArgumentExpressionIsValid(Expression expression)
         {

--- a/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
+++ b/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
@@ -60,10 +60,10 @@ namespace FakeItEasy.Expressions
             return argument.ArgumentInformation.IsOut;
         }
 
-        private static IArgumentConstraint CreateEqualityConstraint(object? expressionValue, Type parameterType)
+        private static IArgumentConstraint CreateEqualityConstraint(object? expressionValue)
             => expressionValue is null
                 ? NullArgumentConstraint.Instance
-                : new EqualityArgumentConstraint(expressionValue, parameterType);
+                : new EqualityArgumentConstraint(expressionValue);
 
         private static void CheckArgumentExpressionIsValid(Expression expression)
         {
@@ -165,7 +165,7 @@ namespace FakeItEasy.Expressions
             {
                 constraint = this.argumentConstraintTrapper.TrapConstraintOrCreate(
                     () => expressionValue = expression.Evaluate(),
-                    () => CreateEqualityConstraint(expressionValue, parameterType));
+                    () => CreateEqualityConstraint(expressionValue));
             }
             catch (TargetInvocationException ex)
             {

--- a/src/FakeItEasy/IArgumentEqualityComparer.cs
+++ b/src/FakeItEasy/IArgumentEqualityComparer.cs
@@ -28,6 +28,6 @@
         /// <param name="expectedValue">The first object to compare.</param>
         /// <param name="argumentValue">The second object to compare.</param>
         /// <returns><c>true</c> if the objects are considered equal. Otherwise <c>false</c>.</returns>
-        bool AreEqual(object? expectedValue, object? argumentValue);
+        bool AreEqual(object expectedValue, object argumentValue);
     }
 }

--- a/tests/FakeItEasy.Specs/ArgumentEqualityComparerSpecs.cs
+++ b/tests/FakeItEasy.Specs/ArgumentEqualityComparerSpecs.cs
@@ -143,6 +143,25 @@ namespace FakeItEasy.Specs
                 .x(() => exception.Should().BeNull());
         }
 
+        [Scenario]
+        public static void ArgumentEqualityComparerObjectParameter(IFoo fake, int result)
+        {
+            "Given a fake with a method that has an object parameter"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a type for which a throwing custom argument equality comparer exists"
+                .See<ClassWithCustomArgumentEqualityComparer>();
+
+            "When a call to the fake is configured with a specific argument value"
+                .x(() => A.CallTo(() => fake.ConsumeObject(new ClassWithCustomArgumentEqualityComparer { Value = 7 })).Returns(53));
+
+            "And a call to the fake is made with a distinct but identical instance"
+                .x(() => result = fake.ConsumeObject(new ClassWithCustomArgumentEqualityComparer { Value = 7 }));
+
+            "Then it should return the configured value"
+                .x(() => result.Should().Be(53));
+        }
+
         public interface IFoo
         {
             int Bar(ClassWithCustomArgumentEqualityComparer? arg);
@@ -150,6 +169,8 @@ namespace FakeItEasy.Specs
             int Baz(ClassWithTwoEligibleArgumentEqualityComparers arg);
 
             int Frob(ClassWithEqualityComparerThatThrows? arg);
+
+            int ConsumeObject(object arg);
         }
 
         public class ClassWithCustomArgumentEqualityComparer

--- a/tests/FakeItEasy.Specs/ArgumentEqualityComparerSpecs.cs
+++ b/tests/FakeItEasy.Specs/ArgumentEqualityComparerSpecs.cs
@@ -162,6 +162,25 @@ namespace FakeItEasy.Specs
                 .x(() => result.Should().Be(53));
         }
 
+        [Scenario]
+        public static void ArgumentEqualityComparerObjectWrongType(IFoo fake, int result)
+        {
+            "Given a fake with a method that has an object parameter"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a type for which a throwing custom argument equality comparer exists"
+                .See<ClassWithCustomArgumentEqualityComparer>();
+
+            "When a call to the fake is configured with a specific argument value"
+                .x(() => A.CallTo(() => fake.ConsumeObject(new ClassWithCustomArgumentEqualityComparer { Value = 7 })).Returns(53));
+
+            "And a call to the fake is made with an instance of an incompatible type"
+                .x(() => result = fake.ConsumeObject("I am not the right type"));
+
+            "Then it should not return the configured value"
+                .x(() => result.Should().NotBe(53));
+        }
+
         public interface IFoo
         {
             int Bar(ClassWithCustomArgumentEqualityComparer? arg);

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net462.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net462.verified.txt
@@ -84,8 +84,8 @@ namespace FakeItEasy
     {
         protected ArgumentEqualityComparer() { }
         public virtual FakeItEasy.Priority Priority { get; }
-        protected abstract bool AreEqual(T? expectedValue, T? argumentValue);
-        public bool AreEqual(object? expectedValue, object? argumentValue) { }
+        public bool AreEqual(object expectedValue, object argumentValue) { }
+        protected abstract bool AreEqual(T expectedValue, T argumentValue);
         public virtual bool CanCompare(System.Type type) { }
     }
     public static class ArgumentValidationConfigurationExtensions
@@ -253,7 +253,7 @@ namespace FakeItEasy
     public interface IArgumentEqualityComparer
     {
         FakeItEasy.Priority Priority { get; }
-        bool AreEqual(object? expectedValue, object? argumentValue);
+        bool AreEqual(object expectedValue, object argumentValue);
         bool CanCompare(System.Type type);
     }
     public interface IArgumentValueFormatter

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net6.0.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net6.0.verified.txt
@@ -84,8 +84,8 @@ namespace FakeItEasy
     {
         protected ArgumentEqualityComparer() { }
         public virtual FakeItEasy.Priority Priority { get; }
-        protected abstract bool AreEqual(T? expectedValue, T? argumentValue);
-        public bool AreEqual(object? expectedValue, object? argumentValue) { }
+        public bool AreEqual(object expectedValue, object argumentValue) { }
+        protected abstract bool AreEqual(T expectedValue, T argumentValue);
         public virtual bool CanCompare(System.Type type) { }
     }
     public static class ArgumentValidationConfigurationExtensions
@@ -253,7 +253,7 @@ namespace FakeItEasy
     public interface IArgumentEqualityComparer
     {
         FakeItEasy.Priority Priority { get; }
-        bool AreEqual(object? expectedValue, object? argumentValue);
+        bool AreEqual(object expectedValue, object argumentValue);
         bool CanCompare(System.Type type);
     }
     public interface IArgumentValueFormatter

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.0.verified.txt
@@ -84,8 +84,8 @@ namespace FakeItEasy
     {
         protected ArgumentEqualityComparer() { }
         public virtual FakeItEasy.Priority Priority { get; }
-        protected abstract bool AreEqual(T? expectedValue, T? argumentValue);
-        public bool AreEqual(object? expectedValue, object? argumentValue) { }
+        public bool AreEqual(object expectedValue, object argumentValue) { }
+        protected abstract bool AreEqual(T expectedValue, T argumentValue);
         public virtual bool CanCompare(System.Type type) { }
     }
     public static class ArgumentValidationConfigurationExtensions
@@ -253,7 +253,7 @@ namespace FakeItEasy
     public interface IArgumentEqualityComparer
     {
         FakeItEasy.Priority Priority { get; }
-        bool AreEqual(object? expectedValue, object? argumentValue);
+        bool AreEqual(object expectedValue, object argumentValue);
         bool CanCompare(System.Type type);
     }
     public interface IArgumentValueFormatter

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/netstandard2.1.verified.txt
@@ -84,8 +84,8 @@ namespace FakeItEasy
     {
         protected ArgumentEqualityComparer() { }
         public virtual FakeItEasy.Priority Priority { get; }
-        protected abstract bool AreEqual(T? expectedValue, T? argumentValue);
-        public bool AreEqual(object? expectedValue, object? argumentValue) { }
+        public bool AreEqual(object expectedValue, object argumentValue) { }
+        protected abstract bool AreEqual(T expectedValue, T argumentValue);
         public virtual bool CanCompare(System.Type type) { }
     }
     public static class ArgumentValidationConfigurationExtensions
@@ -253,7 +253,7 @@ namespace FakeItEasy
     public interface IArgumentEqualityComparer
     {
         FakeItEasy.Priority Priority { get; }
-        bool AreEqual(object? expectedValue, object? argumentValue);
+        bool AreEqual(object expectedValue, object argumentValue);
         bool CanCompare(System.Type type);
     }
     public interface IArgumentValueFormatter

--- a/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/AggregateArgumentConstraintTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/AggregateArgumentConstraintTests.cs
@@ -13,8 +13,8 @@ namespace FakeItEasy.Tests.Expressions.ArgumentConstraints
         {
             this.Constraint = new AggregateArgumentConstraint(new[]
                 {
-                    new EqualityArgumentConstraint("foo", typeof(string)),
-                    new EqualityArgumentConstraint("bar", typeof(string))
+                    new EqualityArgumentConstraint("foo"),
+                    new EqualityArgumentConstraint("bar")
                 });
         }
 

--- a/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/EqualityArgumentConstraintTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/EqualityArgumentConstraintTests.cs
@@ -12,7 +12,7 @@ namespace FakeItEasy.Tests.ExpressionsConstraints
     {
         public EqualityArgumentConstraintTests()
         {
-            this.Constraint = new EqualityArgumentConstraint(1, typeof(int));
+            this.Constraint = new EqualityArgumentConstraint(1);
         }
 
         protected override string ExpectedDescription => "1";
@@ -56,7 +56,7 @@ namespace FakeItEasy.Tests.ExpressionsConstraints
         [Fact]
         public void ToString_should_put_accents_when_expected_value_is_string()
         {
-            var validator = new EqualityArgumentConstraint("foo", typeof(string));
+            var validator = new EqualityArgumentConstraint("foo");
 
             validator.ToString().Should().Be("\"foo\"");
         }

--- a/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/EqualityArgumentConstraintTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/EqualityArgumentConstraintTests.cs
@@ -54,14 +54,6 @@ namespace FakeItEasy.Tests.ExpressionsConstraints
         }
 
         [Fact]
-        public void ToString_should_return_NULL_when_expected_value_is_null()
-        {
-            var validator = new EqualityArgumentConstraint(null, typeof(object));
-
-            validator.ToString().Should().Be("NULL");
-        }
-
-        [Fact]
         public void ToString_should_put_accents_when_expected_value_is_string()
         {
             var validator = new EqualityArgumentConstraint("foo", typeof(string));


### PR DESCRIPTION
Continues #1952.