### PR TITLE
Match enumerable arguments by comparing contents rather than via Equals

### DIFF
--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -32,6 +32,10 @@ test from this list:
 * if one value is `null` and the other isn't, they are not considered equal,
 * the highest-priority [custom argument equality comparer](custom-argument-equality.md)
   that can compare the example object's type, or
+* if the example object's type implements `System.Collections.IEnumerable`, the values
+  are considered equal if and only if the actual object's type also implements
+  `System.Collections.IEnumerable` and `System.Linq.Enumerable.SequenceEqual` evaluates
+  to true, or
 * `Object.Equals`
 
 If this list is not satisfactory, you may have to use the `That.Matches`

--- a/docs/argument-constraints.md
+++ b/docs/argument-constraints.md
@@ -32,6 +32,7 @@ test from this list:
 * if one value is `null` and the other isn't, they are not considered equal,
 * the highest-priority [custom argument equality comparer](custom-argument-equality.md)
   that can compare the example object's type, or
+* if both values are `string`, `string.Equals` (as an optimization),
 * if the example object's type implements `System.Collections.IEnumerable`, the values
   are considered equal if and only if the actual object's type also implements
   `System.Collections.IEnumerable` and `System.Linq.Enumerable.SequenceEqual` evaluates

--- a/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
+++ b/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy.Core
 {
     using System;
+    using System.Collections;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
@@ -12,7 +13,10 @@ namespace FakeItEasy.Core
 
         public ArgumentEqualityComparer(IEnumerable<IArgumentEqualityComparer> argumentEqualityComparers)
         {
-            this.argumentEqualityComparers = argumentEqualityComparers.OrderByDescending(c => c.Priority).ToArray();
+            this.argumentEqualityComparers = argumentEqualityComparers
+                .OrderByDescending(c => c.Priority)
+                .Concat(new EnumerableComparer())
+                .ToArray();
         }
 
         public bool AreEqual(object expectedValue, object argumentValue)
@@ -36,5 +40,18 @@ namespace FakeItEasy.Core
 
         private IArgumentEqualityComparer? FindHighestPriorityComparer(Type type)
             => this.argumentEqualityComparers.FirstOrDefault(c => c.CanCompare(type));
+
+        private class EnumerableComparer : IArgumentEqualityComparer
+        {
+            public Priority Priority => Priority.Internal;
+
+            public bool CanCompare(Type type) => typeof(IEnumerable).IsAssignableFrom(type);
+
+            public bool AreEqual(object expectedValue, object argumentValue) =>
+                argumentValue is IEnumerable argumentEnumerable &&
+                Enumerable.SequenceEqual(
+                    ((IEnumerable)expectedValue).Cast<object?>(),
+                    argumentEnumerable.Cast<object?>());
+        }
     }
 }

--- a/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
+++ b/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
@@ -5,6 +5,7 @@ namespace FakeItEasy.Core
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+    using FakeItEasy.Expressions.ArgumentConstraints;
 
     internal class ArgumentEqualityComparer
     {
@@ -15,7 +16,7 @@ namespace FakeItEasy.Core
         {
             this.argumentEqualityComparers = argumentEqualityComparers
                 .OrderByDescending(c => c.Priority)
-                .Concat(new EnumerableComparer())
+                .Concat(new EnumerableComparer(new ArgumentConstraintEqualityComparer()))
                 .ToArray();
         }
 
@@ -43,22 +44,42 @@ namespace FakeItEasy.Core
 
         private class EnumerableComparer : IArgumentEqualityComparer
         {
+            private readonly IEqualityComparer<object?> elementComparer;
+
+            public EnumerableComparer(IEqualityComparer<object?> elementComparer)
+            {
+                this.elementComparer = elementComparer;
+            }
+
             public Priority Priority => Priority.Internal;
 
             public bool CanCompare(Type type) => typeof(IEnumerable).IsAssignableFrom(type);
 
             public bool AreEqual(object expectedValue, object argumentValue)
             {
+                if (argumentValue is not IEnumerable argumentEnumerable)
+                {
+                    return false;
+                }
+
                 if (expectedValue is string expectedString && argumentValue is string argumentString)
                 {
                     return string.Equals(expectedString, argumentString, StringComparison.Ordinal);
                 }
 
-                return argumentValue is IEnumerable argumentEnumerable &&
-                    Enumerable.SequenceEqual(
-                        ((IEnumerable)expectedValue).Cast<object?>(),
-                        argumentEnumerable.Cast<object?>());
+                IEnumerable expectedEnumerable = (IEnumerable)expectedValue;
+                return expectedEnumerable.Cast<object?>().SequenceEqual(
+                    argumentEnumerable.Cast<object?>(),
+                    this.elementComparer);
             }
+        }
+
+        private class ArgumentConstraintEqualityComparer : IEqualityComparer<object?>
+        {
+            public new bool Equals(object? x, object? y)
+                => EqualityArgumentConstraint.FromExpectedValue(x).IsValid(y);
+
+            public int GetHashCode(object? obj) => obj is null ? 0 : obj.GetHashCode();
         }
     }
 }

--- a/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
+++ b/src/FakeItEasy/Core/ArgumentEqualityComparer.cs
@@ -47,11 +47,18 @@ namespace FakeItEasy.Core
 
             public bool CanCompare(Type type) => typeof(IEnumerable).IsAssignableFrom(type);
 
-            public bool AreEqual(object expectedValue, object argumentValue) =>
-                argumentValue is IEnumerable argumentEnumerable &&
-                Enumerable.SequenceEqual(
-                    ((IEnumerable)expectedValue).Cast<object?>(),
-                    argumentEnumerable.Cast<object?>());
+            public bool AreEqual(object expectedValue, object argumentValue)
+            {
+                if (expectedValue is string expectedString && argumentValue is string argumentString)
+                {
+                    return string.Equals(expectedString, argumentString, StringComparison.Ordinal);
+                }
+
+                return argumentValue is IEnumerable argumentEnumerable &&
+                    Enumerable.SequenceEqual(
+                        ((IEnumerable)expectedValue).Cast<object?>(),
+                        argumentEnumerable.Cast<object?>());
+            }
         }
     }
 }

--- a/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
+++ b/src/FakeItEasy/Expressions/ArgumentConstraints/EqualityArgumentConstraint.cs
@@ -9,12 +9,17 @@ namespace FakeItEasy.Expressions.ArgumentConstraints
     {
         private readonly object expectedValue;
 
-        public EqualityArgumentConstraint(object expectedValue)
+        private EqualityArgumentConstraint(object expectedValue)
         {
             this.expectedValue = expectedValue;
         }
 
         public string ConstraintDescription => this.ToString();
+
+        public static IArgumentConstraint FromExpectedValue(object? expectedValue)
+            => expectedValue is null
+                ? NullArgumentConstraint.Instance
+                : new EqualityArgumentConstraint(expectedValue);
 
         public bool IsValid(object? argument)
         {

--- a/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
+++ b/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
@@ -60,11 +60,6 @@ namespace FakeItEasy.Expressions
             return argument.ArgumentInformation.IsOut;
         }
 
-        private static IArgumentConstraint CreateEqualityConstraint(object? expressionValue)
-            => expressionValue is null
-                ? NullArgumentConstraint.Instance
-                : new EqualityArgumentConstraint(expressionValue);
-
         private static void CheckArgumentExpressionIsValid(Expression expression)
         {
             expression = GetExpressionWithoutConversion(expression);
@@ -165,7 +160,7 @@ namespace FakeItEasy.Expressions
             {
                 constraint = this.argumentConstraintTrapper.TrapConstraintOrCreate(
                     () => expressionValue = expression.Evaluate(),
-                    () => CreateEqualityConstraint(expressionValue));
+                    () => EqualityArgumentConstraint.FromExpectedValue(expressionValue));
             }
             catch (TargetInvocationException ex)
             {

--- a/tests/FakeItEasy.IntegrationTests/CallMatchingTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/CallMatchingTests.cs
@@ -1,0 +1,30 @@
+namespace FakeItEasy.IntegrationTests
+{
+    using System;
+    using FluentAssertions;
+    using Xunit;
+
+    public class CallMatchingTests
+    {
+        [Fact]
+        public void Comparing_string_arguments_does_not_use_general_enumerable_comparer()
+        {
+            // Arrange
+            var fake = A.Fake<Action<string>>();
+
+            A.CallTo(() => fake.Invoke("abc")).DoesNothing();
+
+            // Act
+            var exception = Record.Exception(() => fake("abc"));
+
+            // Assert
+            exception.Should().BeNull();
+        }
+
+        public class ThrowingCharComparer : ArgumentEqualityComparer<char>
+        {
+            protected override bool AreEqual(char expectedValue, char argumentValue)
+                => throw new InvalidOperationException("We don't want to compare chars individually");
+        }
+    }
+}

--- a/tests/FakeItEasy.Specs/ArgumentEqualityComparerSpecs.cs
+++ b/tests/FakeItEasy.Specs/ArgumentEqualityComparerSpecs.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy.Specs
 {
     using System;
+    using System.Collections.Generic;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using Xbehave;
@@ -181,9 +182,67 @@ namespace FakeItEasy.Specs
                 .x(() => result.Should().NotBe(53));
         }
 
+        [Scenario]
+        public static void NestedCustomArgumentEqualityComparerMatches(IFoo fake, int result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a type for which a custom argument equality comparer exists"
+                .See<ClassWithCustomArgumentEqualityComparer>();
+
+            "When a call to the fake is configured with a sequence of those types"
+                .x(() => A.CallTo(() => fake.Barlist(new[]
+                {
+                    new ClassWithCustomArgumentEqualityComparer { Value = 1 },
+                    new ClassWithCustomArgumentEqualityComparer { Value = 2 },
+                })).Returns(42));
+
+            "And a call to the fake is made with a distinct but identical sequence"
+                .x(() => result = fake.Barlist(
+                    new List<ClassWithCustomArgumentEqualityComparer>
+                    {
+                        new ClassWithCustomArgumentEqualityComparer { Value = 1 },
+                        new ClassWithCustomArgumentEqualityComparer { Value = 2 },
+                    }));
+
+            "Then it should return the configured value"
+                .x(() => result.Should().Be(42));
+        }
+
+        [Scenario]
+        public static void NestedCustomArgumentEqualityComparerMismatch(IFoo fake, int result)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "And a type for which a custom argument equality comparer exists"
+                .See<ClassWithCustomArgumentEqualityComparer>();
+
+            "When a call to the fake is configured with a sequence of those types"
+                .x(() => A.CallTo(() => fake.Barlist(new[]
+                {
+                    new ClassWithCustomArgumentEqualityComparer { Value = 1 },
+                    new ClassWithCustomArgumentEqualityComparer { Value = 2 },
+                })).Returns(42));
+
+            "And a call to the fake is made with a different sequence"
+                .x(() => result = fake.Barlist(
+                    new List<ClassWithCustomArgumentEqualityComparer>
+                    {
+                        new ClassWithCustomArgumentEqualityComparer { Value = 2 },
+                        new ClassWithCustomArgumentEqualityComparer { Value = 1 },
+                    }));
+
+            "Then it should not return the configured value"
+                .x(() => result.Should().NotBe(42));
+        }
+
         public interface IFoo
         {
             int Bar(ClassWithCustomArgumentEqualityComparer? arg);
+
+            int Barlist(IEnumerable<ClassWithCustomArgumentEqualityComparer> arg);
 
             int Baz(ClassWithTwoEligibleArgumentEqualityComparers arg);
 

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -1,6 +1,7 @@
 namespace FakeItEasy.Specs
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
@@ -985,6 +986,32 @@ namespace FakeItEasy.Specs
 
             "Then the expression that invokes the constraint factory is called exactly once"
                 .x(() => constraintFactory.InvocationCount.Should().Be(1));
+        }
+
+        [Scenario]
+        public static void SimpleEnumerableMatchedByValues(Action<IEnumerable> fake)
+        {
+            "Given a fake with a method that takes an enumerable parameter"
+                .x(() => fake = A.Fake<Action<IEnumerable>>());
+
+            "When I call the method"
+                .x(() => fake.Invoke(new[] { 1, 2, 3 }));
+
+            "Then the fake says the method was called with a distinct but equivalent sequence"
+                .x(() => A.CallTo(() => fake.Invoke(new List<int> { 1, 2, 3 })).MustHaveHappened());
+        }
+
+        [Scenario]
+        public static void SimpleEnumerableDoesNotMatchNonEnumerable(Action<object> fake)
+        {
+            "Given a fake with a method that takes an object parameter"
+                .x(() => fake = A.Fake<Action<object>>());
+
+            "When I call the method with an enumerable"
+                .x(() => fake.Invoke(new[] { 1, 2, 3 }));
+
+            "Then the fake says the method was not called with an integer"
+                .x(() => A.CallTo(() => fake.Invoke(6)).MustNotHaveHappened());
         }
 
         public static IEnumerable<object[]> Fakes()

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -1001,16 +1001,115 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
-        public static void SimpleEnumerableDoesNotMatchNonEnumerable(Action<object> fake)
+        public static void SimpleEnumerableDoesNotMatchNonEnumerable(Action<object> fake, Exception exception)
         {
             "Given a fake with a method that takes an object parameter"
                 .x(() => fake = A.Fake<Action<object>>());
 
-            "When I call the method with an enumerable"
+            "And I call the method with an enumerable"
                 .x(() => fake.Invoke(new[] { 1, 2, 3 }));
 
-            "Then the fake says the method was not called with an integer"
-                .x(() => A.CallTo(() => fake.Invoke(6)).MustNotHaveHappened());
+            "When I check to see if the method was called with an integer"
+                .x(() => exception = Record.Exception(() => A.CallTo(() => fake.Invoke(6)).MustHaveHappened()));
+
+            "Then it should fail with a descriptive message"
+                .x(() => exception.Should().BeAnExceptionOfType<ExpectationException>()
+                     .WithMessageModuloLineEndings(@"
+
+  Assertion failed for the following call:
+    System.Action`1[System.Object].Invoke(obj: 6)
+  Expected to find it once or more but didn't find it among the calls:
+    1: System.Action`1[System.Object].Invoke(obj: [1, 2, 3])
+
+"));
+        }
+
+        [Scenario]
+        public static void NestedEnumerableMatchedByValues(Action<IEnumerable<IEnumerable<int>>> fake)
+        {
+            "Given a fake with a method that takes a nested enumerable parameter"
+                .x(() => fake = A.Fake<Action<IEnumerable<IEnumerable<int>>>>());
+
+            "When I call the method"
+                .x(() => fake.Invoke(new[] { new[] { 1, 2, 3 } }));
+
+            "Then the fake says the method was called with a distinct but equivalent sequence"
+                .x(() => A.CallTo(() => fake.Invoke(new List<List<int>> { new List<int> { 1, 2, 3 } })).MustHaveHappened());
+        }
+
+        [Scenario]
+        public static void NestedEnumerableMismatchedByInnerElement(
+            Action<IEnumerable<IEnumerable<int>>> fake, Exception exception)
+        {
+            "Given a fake with a method that takes a nested enumerable parameter"
+                .x(() => fake = A.Fake<Action<IEnumerable<IEnumerable<int>>>>());
+
+            "And I call the method"
+                .x(() => fake.Invoke(new[] { new[] { 1, 2, 3 } }));
+
+            "When I check to see if the method was called with an enumerable with a differing inner element "
+                .x(() => exception = Record.Exception(
+                     () => A.CallTo(() => fake.Invoke(new List<List<int>> { new List<int> { 1, 4, 3 } })).MustHaveHappened()));
+
+            "Then it should fail with a descriptive message"
+                .x(() => exception.Should().BeAnExceptionOfType<ExpectationException>()
+                     .WithMessageModuloLineEndings(@"
+  Assertion failed for the following call:
+    System.Action`1[System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IEnumerable`1[System.Int32]]].Invoke(obj: [[1, 4, 3]])
+  Expected to find it once or more but didn't find it among the calls:
+    1: System.Action`1[System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IEnumerable`1[System.Int32]]].Invoke(obj: [[1, 2, 3]])
+
+"));
+        }
+
+        [Scenario]
+        public static void NestedEnumerableMismatchedByLongerEnumerableElement(
+                Action<IEnumerable<IEnumerable<int>>> fake, Exception exception)
+        {
+            "Given a fake with a method that takes a nested enumerable parameter"
+                .x(() => fake = A.Fake<Action<IEnumerable<IEnumerable<int>>>>());
+
+            "And I call the method"
+                .x(() => fake.Invoke(new[] { new[] { 1, 2, 3 } }));
+
+            "When I check to see if the method was called with an enumerable with a longer nested enumerable"
+                .x(() => exception = Record.Exception(
+                     () => A.CallTo(() => fake.Invoke(new List<List<int>> { new List<int> { 1, 2, 3, 4 } })).MustHaveHappened()));
+
+            "Then it should fail with a descriptive message"
+                .x(() => exception.Should().BeAnExceptionOfType<ExpectationException>()
+                     .WithMessageModuloLineEndings(@"
+  Assertion failed for the following call:
+    System.Action`1[System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IEnumerable`1[System.Int32]]].Invoke(obj: [[1, 2, 3, 4]])
+  Expected to find it once or more but didn't find it among the calls:
+    1: System.Action`1[System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IEnumerable`1[System.Int32]]].Invoke(obj: [[1, 2, 3]])
+
+"));
+        }
+
+        [Scenario]
+        public static void NestedEnumerableMismatchedByShorterEnumerableElement(
+            Action<IEnumerable<IEnumerable<int>>> fake, Exception exception)
+        {
+            "Given a fake with a method that takes a nested enumerable parameter"
+                .x(() => fake = A.Fake<Action<IEnumerable<IEnumerable<int>>>>());
+
+            "And I call the method"
+                .x(() => fake.Invoke(new[] { new[] { 1, 2, 3 } }));
+
+            "When I check to see if the method was called with an enumerable with a shorter nested enumerable"
+                .x(() => exception = Record.Exception(
+                     () => A.CallTo(() => fake.Invoke(new List<List<int>> { new List<int> { 1, 2 } })).MustHaveHappened()));
+
+            "Then it should fail with a descriptive message"
+                .x(() => exception.Should().BeAnExceptionOfType<ExpectationException>()
+                     .WithMessageModuloLineEndings(@"
+  Assertion failed for the following call:
+    System.Action`1[System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IEnumerable`1[System.Int32]]].Invoke(obj: [[1, 2]])
+  Expected to find it once or more but didn't find it among the calls:
+    1: System.Action`1[System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IEnumerable`1[System.Int32]]].Invoke(obj: [[1, 2, 3]])
+
+"));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/AggregateArgumentConstraintTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/AggregateArgumentConstraintTests.cs
@@ -13,8 +13,8 @@ namespace FakeItEasy.Tests.Expressions.ArgumentConstraints
         {
             this.Constraint = new AggregateArgumentConstraint(new[]
                 {
-                    new EqualityArgumentConstraint("foo"),
-                    new EqualityArgumentConstraint("bar")
+                    EqualityArgumentConstraint.FromExpectedValue("foo"),
+                    EqualityArgumentConstraint.FromExpectedValue("bar")
                 });
         }
 

--- a/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/EqualityArgumentConstraintTests.cs
+++ b/tests/FakeItEasy.Tests/Expressions/ArgumentConstraints/EqualityArgumentConstraintTests.cs
@@ -12,7 +12,7 @@ namespace FakeItEasy.Tests.ExpressionsConstraints
     {
         public EqualityArgumentConstraintTests()
         {
-            this.Constraint = new EqualityArgumentConstraint(1);
+            this.Constraint = EqualityArgumentConstraint.FromExpectedValue(1);
         }
 
         protected override string ExpectedDescription => "1";
@@ -56,7 +56,7 @@ namespace FakeItEasy.Tests.ExpressionsConstraints
         [Fact]
         public void ToString_should_put_accents_when_expected_value_is_string()
         {
-            var validator = new EqualityArgumentConstraint("foo");
+            var validator = EqualityArgumentConstraint.FromExpectedValue("foo");
 
             validator.ToString().Should().Be("\"foo\"");
         }


### PR DESCRIPTION
Fixes #1960.