### PR TITLE
Nesting or compounding An-built constraints throws wrong exception

### DIFF
--- a/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
+++ b/src/FakeItEasy/Expressions/ExpressionArgumentConstraintFactory.cs
@@ -64,9 +64,9 @@ namespace FakeItEasy.Expressions
         {
             expression = GetExpressionWithoutConversion(expression);
 
-            if (expression is MemberExpression memberExpression && IsMemberOfA(memberExpression.Member))
+            if (expression is MemberExpression memberExpression && IsBuiltInConstraintDefiningMember(memberExpression))
             {
-                // It's A._, or A.Ignore, so it's safe.
+                // It's ._ or .Ignore, so it's safe.
                 return;
             }
 
@@ -124,9 +124,10 @@ namespace FakeItEasy.Expressions
             return expression;
         }
 
-        private static bool IsMemberOfA(MemberInfo member)
+        private static bool IsBuiltInConstraintDefiningMember(MemberExpression node)
         {
-            return GetGenericTypeDefinition(member.DeclaringType!) == typeof(A<>);
+            Type declaringType = GetGenericTypeDefinition(node.Member.DeclaringType!);
+            return declaringType == typeof(A<>) || declaringType == typeof(An<>);
         }
 
         private static Type GetGenericTypeDefinition(Type type)
@@ -196,7 +197,7 @@ namespace FakeItEasy.Expressions
         {
             protected override Expression VisitMember(MemberExpression node)
             {
-                if (IsMemberOfA(node.Member))
+                if (IsBuiltInConstraintDefiningMember(node))
                 {
                     throw new InvalidOperationException(ExceptionMessages.ArgumentConstraintCannotBeNestedInArgument);
                 }

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -818,16 +818,37 @@ namespace FakeItEasy.Specs
         }
 
         [Scenario]
-        public static void TwoArgumentConstraints(
+        public static void NestedAArgumentConstraint(
             IHaveAnObjectParameter fake,
             Exception exception)
         {
             "Given a fake"
                 .x(() => fake = A.Fake<IHaveAnObjectParameter>());
 
-            "When I try to configure a method of the fake using two constraints on an argument"
+            "When I try to configure a method of the fake using a nested A-built constraint on an argument"
                 .x(() => exception = Record.Exception(() => A.CallTo(() =>
-                    fake.Bar(A<int>.That.Matches(i => i % 2 == 0) + A<int>.That.Matches(i => i % 2 == 1))).Returns(1)));
+                    fake.Bar(A<int>.That.Matches(i => i % 2 == 0) - 7)).Returns(1)));
+
+            "Then the call configuration throws an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
+
+            "And the exception indicates that a nested argument constraint was used"
+                .x(() => exception.Message.Should()
+                    .Be("An argument constraint, such as That, Ignored, or _, cannot be nested in an argument."));
+        }
+
+        [Scenario]
+        public static void NestedAnArgumentConstraint(
+            IHaveAnObjectParameter fake,
+            Exception exception)
+        {
+            "Given a fake"
+                .x(() => fake = A.Fake<IHaveAnObjectParameter>());
+
+            "When I try to configure a method of the fake using a nested An-built constraint on an argument"
+                .x(() => exception = Record.Exception(() =>
+                    A.CallTo(() => fake.Bar(3 +
+                                            An<int>.That.Matches(i => i % 2 == 1))).Returns(1)));
 
             "Then the call configuration throws an InvalidOperationException"
                 .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
@@ -850,7 +871,7 @@ namespace FakeItEasy.Specs
                 .x(() => constraintFactory = () =>
                     {
                         A<object>.That.Matches(i => i is object);
-                        return A<object>.That.Matches(i => i is object);
+                        return An<object>.That.Matches(i => i is object);
                     });
 
             "When I try to configure a method of the fake with this delegate"


### PR DESCRIPTION
```c#
A.CallTo(() => fake.Bar(An<int>.That.Matches(i => i % 2 == 0) +
                        An<int>.That.Matches(i => i % 2 == 1))).Returns(1));
```

yields

> FakeConfigurationException : Too many argument constraints specified. First superfluous constraint is <i => ((i % 2) == 1)>

but

```c#
A.CallTo(() => fake.Bar(A<int>.That.Matches(i => i % 2 == 0) +
                        A<int>.That.Matches(i => i % 2 == 1))).Returns(1));
```

yields

> InvalidOperationException : An argument constraint, such as That, Ignored, or _, cannot be nested in an argument.

The latter is technically more correct, since we're nesting the two constraints inside the `+` expression.

But we already have a test to detect multiple constraints, so we'd be better off with one that explicitly tests single nested constraints.