### PR TITLE
Drop 'No constructor matches the passed arguments for constructor.'

### DIFF
--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
@@ -132,7 +132,7 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
 
         private static ProxyGeneratorResult GetResultForFailedProxyGeneration(Type typeOfProxy, IEnumerable<object?> argumentsForConstructor, Exception e) =>
             argumentsForConstructor.Any()
-                ? new ProxyGeneratorResult(DynamicProxyMessages.ArgumentsForConstructorDoesNotMatchAnyConstructor, e)
+                ? new ProxyGeneratorResult(e)
                 : GetProxyResultForNoDefaultConstructor(typeOfProxy, e);
 
         private static ProxyGeneratorResult GetProxyResultForNoDefaultConstructor(Type typeOfProxy, Exception e)

--- a/src/FakeItEasy/Creation/CastleDynamicProxy/DynamicProxyMessages.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/DynamicProxyMessages.cs
@@ -1,12 +1,9 @@
-﻿namespace FakeItEasy.Creation.CastleDynamicProxy
+namespace FakeItEasy.Creation.CastleDynamicProxy
 {
     using System;
 
     internal static class DynamicProxyMessages
     {
-        public static string ArgumentsForConstructorDoesNotMatchAnyConstructor =>
-            "No constructor matches the passed arguments for constructor.";
-
         public static string ArgumentsForConstructorOnInterfaceType =>
             "Arguments for constructor specified for interface type.";
 

--- a/src/FakeItEasy/Creation/ProxyGeneratorResult.cs
+++ b/src/FakeItEasy/Creation/ProxyGeneratorResult.cs
@@ -28,6 +28,32 @@ namespace FakeItEasy.Creation
         /// Creates a new instance representing a failed proxy
         /// generation attempt due to an exception being caught.
         /// </summary>
+        /// <param name="exception">
+        /// The exception thrown from the creation attempt.
+        /// </param>
+        public ProxyGeneratorResult(Exception exception)
+        {
+            Guard.AgainstNull(exception);
+
+            if (exception is TargetInvocationException && exception.InnerException is not null)
+            {
+                exception = exception.InnerException;
+            }
+
+            this.ReasonForFailure =
+                string.Format(
+                    "An exception of type {1} was caught during this call. Its message was:{0}{2}{0}{3}",
+                    Environment.NewLine,
+                    exception.GetType(),
+                    exception.Message,
+                    exception.StackTrace);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProxyGeneratorResult"/> class.
+        /// Creates a new instance representing a failed proxy
+        /// generation attempt due to an exception being caught.
+        /// </summary>
         /// <param name="reasonForFailure">
         /// The reason the proxy generation failed.
         /// </param>

--- a/tests/FakeItEasy.Specs/CreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationSpecs.cs
@@ -121,7 +121,6 @@ namespace FakeItEasy.Specs
          *FakeItEasy.Specs.CreationSpecsBase.ClassWithMultipleConstructors..ctor()*
 
     Constructor with signature (System.String) failed:
-      No constructor matches the passed arguments for constructor.
       An exception of type System.Exception was caught during this call. Its message was:
       string constructor failed
       with reason on two lines
@@ -530,7 +529,6 @@ namespace FakeItEasy.Specs
             "And the exception message indicates the reason for failure"
                 .x(() => exception.Message.Should().StartWithModuloLineEndings(@"
   Failed to create fake of type FakeItEasy.Specs.CreationSpecsBase+AClassThatCouldBeFakedWithTheRightConstructorArguments:
-    No constructor matches the passed arguments for constructor.
     An exception of type System.ArgumentException was caught during this call. Its message was:
     Can not instantiate proxy of class: FakeItEasy.Specs.CreationSpecsBase+AClassThatCouldBeFakedWithTheRightConstructorArguments.
     Could not find a constructor that would match given arguments:


### PR DESCRIPTION
Fixes #1929.