### PR TITLE
Make EventRule shared

### DIFF
--- a/src/FakeItEasy/Core/FakeManager.EventRule.cs
+++ b/src/FakeItEasy/Core/FakeManager.EventRule.cs
@@ -3,29 +3,21 @@ namespace FakeItEasy.Core
     public partial class FakeManager
     {
         private class EventRule
-            : IFakeObjectCallRule
+            : SharedFakeObjectCallRule
         {
-            private readonly FakeManager fakeManager;
-
-            public EventRule(FakeManager fakeManager)
-            {
-                this.fakeManager = fakeManager;
-            }
-
-            public int? NumberOfTimesToCall => null;
-
-            public bool IsApplicableTo(IFakeObjectCall fakeObjectCall)
+            public override bool IsApplicableTo(IFakeObjectCall fakeObjectCall)
             {
                 Guard.AgainstNull(fakeObjectCall);
 
                 return EventCall.TryGetEventCall(fakeObjectCall, out _);
             }
 
-            public void Apply(IInterceptedFakeObjectCall fakeObjectCall)
+            public override void Apply(IInterceptedFakeObjectCall fakeObjectCall)
             {
                 if (EventCall.TryGetEventCall(fakeObjectCall, out var eventCall))
                 {
-                    this.fakeManager.EventCallHandler.HandleEventCall(eventCall);
+                    var fakeManager = Fake.GetFakeManager(fakeObjectCall.FakedObject);
+                    fakeManager.EventCallHandler.HandleEventCall(eventCall);
                 }
             }
         }

--- a/src/FakeItEasy/Core/FakeManager.cs
+++ b/src/FakeItEasy/Core/FakeManager.cs
@@ -16,6 +16,7 @@ namespace FakeItEasy.Core
     {
         private static readonly SharedFakeObjectCallRule[] SharedPostUserRules =
         {
+            new EventRule(),
             new ObjectMemberRule(),
             new AutoFakePropertyRule(),
             new PropertySetterRule(),
@@ -23,7 +24,6 @@ namespace FakeItEasy.Core
             new DefaultReturnValueRule(),
         };
 
-        private readonly EventRule eventRule;
         private readonly LinkedList<IInterceptionListener> interceptionListeners;
         private readonly WeakReference objectReference;
 
@@ -50,7 +50,6 @@ namespace FakeItEasy.Core
             this.FakeObjectType = fakeObjectType;
             this.FakeObjectName = fakeObjectName;
 
-            this.eventRule = new EventRule(this);
             this.allUserRules = new LinkedList<CallRuleMetadata>();
 
             this.recordedCalls = new ConcurrentQueue<CompletedFakeObjectCall>();
@@ -256,12 +255,6 @@ namespace FakeItEasy.Core
             {
                 bestUserRule.RecordCall();
                 bestUserRule.Rule.Apply(fakeObjectCall);
-                return;
-            }
-
-            if (this.eventRule.IsApplicableTo(fakeObjectCall))
-            {
-                this.eventRule.Apply(fakeObjectCall);
                 return;
             }
 


### PR DESCRIPTION
While investigating what needed to be saved for the `ResetToInitialConfiguration` feature, I realized we treated `EventRule` as a "special" stateful rule, but it doesn't actually need to be stateful, and can be shared among all fakes. What actually holds the state is the `EventCallHandler`, which is specific to each fake.

This PR is a small refactoring that makes `EventRule` just like the other shared rules.