### PR TITLE
Acknowledge that we'll never be able to fake methods on generic types that have in parameters before .NET 6

### DIFF
--- a/docs/what-can-be-faked.md
+++ b/docs/what-can-be-faked.md
@@ -20,8 +20,9 @@ Note that special steps will need to be taken to
 
 ### Types whose methods have `in` parameters
 
-Generic types that contain methods having a parameter modified by the `in` keyword cannot be faked by FakeItEasy.
-This limitation is tracked as [issue 1382](https://github.com/FakeItEasy/FakeItEasy/issues/1382).
+Due to deficiencies in earlier .NET framework releases, generic types that contain methods having
+a parameter modified by the `in` keyword cannot be faked by FakeItEasy running on target frameworks
+earlier than .NET 6.
 
 ### Where do the constructor arguments come from?
   

--- a/tests/FakeItEasy.Specs/InParametersSpecs.cs
+++ b/tests/FakeItEasy.Specs/InParametersSpecs.cs
@@ -79,9 +79,7 @@ namespace FakeItEasy.Specs
 
 #if LACKS_FAKEABLE_GENERIC_IN_PARAMETERS
         // A characterization test, representing the current capabilities of the code, not the desired state.
-        // If it start failing, update it and fix the "What can be faked" documentation page.
-        //
-        // https://github.com/FakeItEasy/FakeItEasy/issues/1382 tracks this failing.
+        // If it starts failing, update it and fix the "What can be faked" documentation page.
         [Scenario]
         public void FakingGenericInParam(Exception exception)
         {


### PR DESCRIPTION
Closes #1382.