### PR TITLE
 Stress that methods must be fully configured to capture arguments

### DIFF
--- a/docs/capturing-arguments.md
+++ b/docs/capturing-arguments.md
@@ -20,7 +20,7 @@ Suppose we want to make sure that we send correct messages to the logger.
 We can record the first argument to each `Log` call in a variable of type
 `Captured` and verify the values in the "assert" phase of the test.
 
-```csharp title="simple capture" linenums="1" hl_lines="2 6 17 22"
+```csharp title="simple capture" linenums="1" hl_lines="2 6 8 17 22"
 --8<--
 recipes/FakeItEasy.Recipes.CSharp/CapturingArguments.cs:SimpleCapture
 --8<--
@@ -32,6 +32,12 @@ This is a fairly standard test with fakes, except we:
 * use the `Captured` object's `_` member to configure the call to capture any values for that argument
   (this is analogous to the `A<T>._` member, and just like it, there is a matching `Ignored` member in
   case you prefer that name)
+* specify that the method will [do nothing](doing-nothing.md). 
+  As with any attempt to [configure a fake object's behavior](specifying-a-call-to-configure), it's the final
+  action that completes the `A.CallTo` sequence. Without it, there's no change to the fake object's
+  behavior, and no values will be captured on calls to the method. You don't need to pair `DoesNothing` with
+  configuration that uses a capturing argument: you could return values, throw exceptions, or whatever;
+  it was just appropriate here for a method that returns nothing.
 * use `Values` to access all the captured values so they can be asserted
 * (alternative flow) use `GetLastValue` to access the most recent captured value so it can be asserted.
   This will throw a `FakeItEasy.ExpectationException` if no values have been captured.

--- a/docs/doing-nothing.md
+++ b/docs/doing-nothing.md
@@ -9,13 +9,21 @@ A.CallTo(() => aFake.SomeVoidMethodThatShouldDoNothing())
 This is quite close to what a default Fake's
 [unconfigured member will do](default-fake-behavior.md#overrideable-members-are-faked),
 but there a few situations where you may need to make the `DoesNothing` call
-explicitly.
+explicitly. Here are some examples:
 
-If the [Fake is strict](strict-fakes.md), an unconfigured call will throw an exception, so `DoesNothing` can be used to allow a call to a member on the Fake.
+* To allow a call to a member on a [strict Fake](strict-fakes.md), where an otherwise
+  unconfigured call will throw an exception.
+* To change the behavior that an already-configured call is supposed to have.
+  For example, if a call is [set to throw an exception](throwing-exceptions.md), that can be
+  overridden. For more on this kind of thing, see how to
+  [override the behavior for a call](changing-behavior-between-calls.md#overriding-the-behavior-for-a-call).
+* To fulfill FakeItEasy's configuration API requirements by providing an action when applying 
+  [capturing arguments](capturing-arguments.md) to a Fake's member. Aside from capturing, you may
+  not want to change the behavior of the member, but you have to use some action to complete the
+  chained calls that configure the method.
 
-Or, `DoesNothing` can be used to change the behavior that an already-configured call is supposed to have. For example, if a call is [set to throw an exception](throwing-exceptions.md), that can be overridden. For more on this kind of thing, see how to [override the behavior for a call](changing-behavior-between-calls.md#overriding-the-behavior-for-a-call).
-
-**Note that `DoesNothing` is only applicable when configuring members that have a
-`void` return (or `Task`, which is the async equivalent of `void`).** To override
-behavior on already-configured (or strict) members that return values, you must
-instead [configure a preferred return value](specifying-return-values.md).
+???+ note "Only applies to members that return nothing"
+    Note that `DoesNothing` is only applicable when configuring members that have a
+    `void` return (or `Task`, which is the async equivalent of `void`). To override
+    behavior on members that return values, you must
+    instead [configure a preferred return value](specifying-return-values.md).

--- a/docs/specifying-a-call-to-configure.md
+++ b/docs/specifying-a-call-to-configure.md
@@ -17,10 +17,16 @@ are just used to identify which call to configure, after which
 `A.CallTo` returns an object that can be used to specify how the fake
 should behave when the call is made.
 
+???+ note "Use an action to complete call configuration"
+    Specifying the call via `A.CallTo` and related methods does not
+    have any effect on the fake object. You must include an action
+    for the call to perform to alter the behavior of the fake object.
 
-Many types of actions can be specified, including
-[returning various values](specifying-return-values.md),
-[throwing exceptions](throwing-exceptions.md), and more.
+    There are many types of actions that can be specified, including
+    [returning various values](specifying-return-values.md),
+    [throwing exceptions](throwing-exceptions.md), and more. Even
+    [doing nothing](doing-nothing.md), which may be required for a
+    void method.
 
 ## Specifying a call to a property setter
 


### PR DESCRIPTION
Relates to #2010.