### PR TITLE
Make build.ps1 executable on Linux

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 try {
     Push-Location $PSScriptRoot
     dotnet run --project "./tools/FakeItEasy.Build" -- $args


### PR DESCRIPTION
- added shebang
- converted line endings to LF (Windows doesn't care which it is)
- added execute mode bit