### PR TITLE
Documentation fix: Update URL in link to Moq

### DIFF
--- a/docs/creating-fakes.md
+++ b/docs/creating-fakes.md
@@ -82,7 +82,7 @@ mentioned above.
 
 ## Unnatural fakes
 
-For those accustomed to [Moq](https://www.moqthis.com/) there is an
+For those accustomed to [Moq](https://github.com/devlooped/moq/) there is an
 alternative way of creating fakes through the `new Fake<T>`
 syntax. The fake provides a fluent interface for configuring the faked
 object:


### PR DESCRIPTION
The existing URL in the link to Moq seems to be for a gambling website, this update changes it to the github repo, which was the best online resource I could find for Moq.