### PR TITLE
Stop trying to create ByRef-like Dummies on TMFs lower than netstandard2.1

### DIFF
--- a/src/FakeItEasy/Creation/DummyValueResolver.cs
+++ b/src/FakeItEasy/Creation/DummyValueResolver.cs
@@ -39,6 +39,13 @@ namespace FakeItEasy.Creation
 
         public CreationResult TryResolveDummyValue(Type typeOfDummy, LoopDetectingResolutionContext resolutionContext)
         {
+#if !TRY_ISBYREF_CREATION
+            if (typeOfDummy.IsByRefLike())
+            {
+                return CreationResult.FailedToCreateDummy(typeOfDummy, "It is byref-like.");
+            }
+#endif
+
             // Make sure we're not already resolving typeOfDummy. It may seem that we could skip this check when we have
             // a cached resolution strategy in strategyCache, but it's necessary in case multiple threads are involved and
             // typeOfDummy has a constructor that takes typeOfDummy as a parameter.

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -46,13 +46,13 @@
   <!-- .NET Standard 2.0 -->
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);LACKS_NULLABLE_ATTRIBUTES;LACKS_STRING_CONTAINS_COMPARISONTYPE;LACKS_CALLERARGUMENTEXPRESSION</DefineConstants>
+    <DefineConstants>$(DefineConstants);LACKS_NULLABLE_ATTRIBUTES;LACKS_STRING_CONTAINS_COMPARISONTYPE;LACKS_CALLERARGUMENTEXPRESSION;LACKS_ISBYREFLIKE</DefineConstants>
   </PropertyGroup>
 
   <!-- .NET Framework -->
 
   <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">
-    <DefineConstants>$(DefineConstants);LACKS_NULLABLE_ATTRIBUTES;LACKS_ARRAY_EMPTY;LACKS_STRING_CONTAINS_COMPARISONTYPE;LACKS_CALLERARGUMENTEXPRESSION</DefineConstants>
+    <DefineConstants>$(DefineConstants);LACKS_NULLABLE_ATTRIBUTES;LACKS_ARRAY_EMPTY;LACKS_STRING_CONTAINS_COMPARISONTYPE;LACKS_CALLERARGUMENTEXPRESSION;LACKS_ISBYREFLIKE;TRY_ISBYREF_CREATION</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">

--- a/src/FakeItEasy/TypeExtensions.cs
+++ b/src/FakeItEasy/TypeExtensions.cs
@@ -2,6 +2,7 @@ namespace FakeItEasy
 {
     using System;
     using System.Diagnostics;
+    using System.Linq;
 
     /// <summary>
     /// Provides extension methods for <see cref="Type"/>.
@@ -29,6 +30,15 @@ namespace FakeItEasy
         {
             return !type.IsValueType
                 || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+
+        public static bool IsByRefLike(this Type type)
+        {
+#if LACKS_ISBYREFLIKE
+            return type.GetCustomAttributesData().Any(att => att.AttributeType.FullName == "System.Runtime.CompilerServices.IsByRefLikeAttribute");
+#else
+            return type.IsByRefLike;
+#endif
         }
 
         [DebuggerStepThrough]

--- a/tests/FakeItEasy.Specs/DummyCreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/DummyCreationSpecs.cs
@@ -911,6 +911,35 @@ namespace FakeItEasy.Specs
 
     public class NonGenericDummyCreationSpecs : DummyCreationSpecsBase
     {
+        [Scenario]
+        public void IsByRefLikeCreation(object? dummy, Exception? exception)
+        {
+            "Given a byref-like value type"
+                .See(nameof(ReadOnlySpan<char>));
+
+            "When a dummy of that type is requested"
+                .x(() => exception = Record.Exception(() => dummy = Sdk.Create.Dummy(typeof(ReadOnlySpan<char>))));
+
+#if CAN_CREATE_ISBYREFLIKE
+            "Then no exception is thrown"
+                .x(() => exception.Should().BeNull());
+
+            "And the dummy was created"
+                .x(() => dummy.Should().NotBeNull());
+#else
+            "Then it throws an exception of type DummyCreationException"
+                .x(() => exception.Should().BeAnExceptionOfType<DummyCreationException>());
+
+            "And its message indicates that a dummy couldn't be created due to its byref-likeness"
+                .x(() => exception!.Message.Should().BeModuloLineEndings("""
+
+                      Failed to create dummy of type System.ReadOnlySpan`1[System.Char]:
+                        It is byref-like.
+
+                    """));
+#endif
+        }
+
         protected override T CreateDummy<T>()
         {
             return (T)Sdk.Create.Dummy(typeof(T))!;

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">
-      <DefineConstants>$(DefineConstants);LACKS_FAKEABLE_GENERIC_IN_PARAMETERS</DefineConstants>
+      <DefineConstants>$(DefineConstants);LACKS_FAKEABLE_GENERIC_IN_PARAMETERS;CAN_CREATE_ISBYREFLIKE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
As with #2019, an incomplete pull request at this time. Avoids touching the CreationResult code at all, as you suggested, @thomaslevesque.