### PR TITLE
Update the docs to show how to specify InternalsVisibleTo in the project file

### DIFF
--- a/docs/how-to-fake-internal-types.md
+++ b/docs/how-to-fake-internal-types.md
@@ -24,14 +24,15 @@ adding the following to your project file (assuming you're using
 
 If you're using an older SDK, you can add this to your
 AssemblyInfo.cs/vb file instead:
-```csharp
-// C#
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-```
-```vb
-' VB
-<Assembly:InternalsVisibleTo("DynamicProxyGenAssembly2")>
-```
+
+=== "C#"
+    ```csharp
+    [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+    ```
+=== "VB"
+    ```vb
+    <Assembly:InternalsVisibleTo("DynamicProxyGenAssembly2")>
+    ```
 
 ### Signed assemblies
 
@@ -45,11 +46,11 @@ proxy-generating assembly in your project file:
 ```
 
 Or, if using an older SDK, in your AssemblyInfo.cs/vb file:
-```csharp
-// C#
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
-```
-```vb
-' VB
-<Assembly:InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")>
-```
+=== "C#"
+    ```csharp
+    [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+    ```
+=== "VB"
+    ```vb
+    <Assembly:InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")>
+    ```

--- a/docs/how-to-fake-internal-types.md
+++ b/docs/how-to-fake-internal-types.md
@@ -20,6 +20,14 @@ file:
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 ```
 
+If you're using the .NET 5 SDK or higher, you can specify this in the
+project file instead:
+```xml
+  <ItemGroup>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+```
+
 ### Signed assemblies
 
 For signed assemblies you have to specify the strong name of the
@@ -27,4 +35,13 @@ proxy-generating assembly:
 
 ```csharp
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+```
+
+Similarly, if you're using the .NET 5 SDK or higher, you can specify
+this in the project file, by specifying the public key in the `Key`
+attribute:
+```xml
+  <ItemGroup>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
+  </ItemGroup>
 ```

--- a/docs/how-to-fake-internal-types.md
+++ b/docs/how-to-fake-internal-types.md
@@ -12,9 +12,18 @@ test, not your test-assembly that needs this attribute.
 
 ### Unsigned assemblies
 
-If your assembly is not signed with a strong name it's as easy as
-adding the following to your AssemblyInfo.cs/vb file:
+If your assembly is not signed with a strong name, it's as easy as
+adding the following to your project file (assuming you're using
+.NET 5 SDK or higher):
 
+```xml
+<ItemGroup>
+  <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+</ItemGroup>
+```
+
+If you're using an older SDK, you can add this to your
+AssemblyInfo.cs/vb file instead:
 ```csharp
 // C#
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
@@ -24,19 +33,18 @@ adding the following to your AssemblyInfo.cs/vb file:
 <Assembly:InternalsVisibleTo("DynamicProxyGenAssembly2")>
 ```
 
-If you're using the .NET 5 SDK or higher, you can specify this in the
-project file instead:
-```xml
-  <ItemGroup>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-  </ItemGroup>
-```
-
 ### Signed assemblies
 
-For signed assemblies you have to specify the strong name of the
-proxy-generating assembly:
+For signed assemblies, you have to specify the public key of the
+proxy-generating assembly in your project file:
 
+```xml
+<ItemGroup>
+  <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
+</ItemGroup>
+```
+
+Or, if using an older SDK, in your AssemblyInfo.cs/vb file:
 ```csharp
 // C#
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
@@ -44,13 +52,4 @@ proxy-generating assembly:
 ```vb
 ' VB
 <Assembly:InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")>
-```
-
-Similarly, if you're using the .NET 5 SDK or higher, you can specify
-this in the project file, by specifying the public key in the `Key`
-attribute:
-```xml
-  <ItemGroup>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
-  </ItemGroup>
 ```

--- a/docs/how-to-fake-internal-types.md
+++ b/docs/how-to-fake-internal-types.md
@@ -13,11 +13,15 @@ test, not your test-assembly that needs this attribute.
 ### Unsigned assemblies
 
 If your assembly is not signed with a strong name it's as easy as
-adding the equivalent of the following to your AssemblyInfo.cs/vb
-file:
+adding the following to your AssemblyInfo.cs/vb file:
 
 ```csharp
+// C#
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+```
+```vb
+' VB
+<Assembly:InternalsVisibleTo("DynamicProxyGenAssembly2")>
 ```
 
 If you're using the .NET 5 SDK or higher, you can specify this in the
@@ -34,7 +38,12 @@ For signed assemblies you have to specify the strong name of the
 proxy-generating assembly:
 
 ```csharp
+// C#
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+```
+```vb
+' VB
+<Assembly:InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")>
 ```
 
 Similarly, if you're using the .NET 5 SDK or higher, you can specify

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,8 @@ markdown_extensions:
       check_paths: true
       dedent_subsections: true
   - pymdownx.superfences
+  - pymdownx.tabbed:
+        alternate_style: true
   - pymdownx.tilde
 
 nav:


### PR DESCRIPTION
The first commit explains how to add `InternalsVisibleTo` to the project file.
The second explicitly shows the VB usage, because I was briefly confused by the phrase "the equivalent of the following". I can drop it if you don't like it.

Closes #2027 