### PR TITLE
Build netstandard2.0 and netstandard2.1 even on macOs (but don't test)

### DIFF
--- a/profiles/full.props
+++ b/profiles/full.props
@@ -21,8 +21,8 @@
     <RecipesTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</RecipesTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <FakeItEasyTargetFrameworks>net6.0;net8.0</FakeItEasyTargetFrameworks>
-    <ValueTaskExtensionsTargetFrameworks>net6.0;net8.0</ValueTaskExtensionsTargetFrameworks>
+    <FakeItEasyTargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</FakeItEasyTargetFrameworks>
+    <ValueTaskExtensionsTargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</ValueTaskExtensionsTargetFrameworks>
     <SpecsTargetFrameworks>net6.0;net8.0</SpecsTargetFrameworks>
     <IntegrationTestsTargetFrameworks>net6.0;net8.0</IntegrationTestsTargetFrameworks>
     <UnitTestsTargetFrameworks>net6.0;net8.0</UnitTestsTargetFrameworks>


### PR DESCRIPTION
Silences warnings on macOS when we pack the
FakeItEasy.Extensions.ValueTask package:

> Warning: /Users/runner/.dotnet/sdk/8.0.402/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below: [/Users/runner/work/FakeItEasy/FakeItEasy/src/FakeItEasy.Extensions.ValueTask/FakeItEasy.Extensions.ValueTask.csproj]
> Warning: /Users/runner/.dotnet/sdk/8.0.402/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5128: - Add a dependency group for .NETStandard2.1 to the nuspec [/Users/runner/work/FakeItEasy/FakeItEasy/src/FakeItEasy.Extensions.ValueTask/FakeItEasy.Extensions.ValueTask.csproj]