### PR TITLE
Build for net462 on Linux and Mac

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,17 +18,10 @@ max_line_length = 160
 
 insert_final_newline = true
 
-[*.{csproj,vbproj}]
+[*.{csproj,vbproj,props}]
 insert_final_newline = false
-charset = utf-8-bom
-
-[project.json]
-insert_final_newline = false
-charset = utf-8-bom
-
-[*.nuget.targets]
-insert_final_newline = false
-charset = utf-8-bom
+# 2-column space indentation
+indent_size = 2
 
 [*.json]
 # 2-column space indentation

--- a/profiles/full.props
+++ b/profiles/full.props
@@ -1,33 +1,25 @@
 <Project>
   <!-- Everything -->
+  <PropertyGroup>
+    <LibraryTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</LibraryTargetFrameworks>
+  </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <FakeItEasyTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</FakeItEasyTargetFrameworks>
-    <ValueTaskExtensionsTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</ValueTaskExtensionsTargetFrameworks>
-    <SpecsTargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</SpecsTargetFrameworks>
-    <IntegrationTestsTargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</IntegrationTestsTargetFrameworks>
-    <UnitTestsTargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</UnitTestsTargetFrameworks>
-    <TestHelpersTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</TestHelpersTargetFrameworks>
-    <ApprovalTestsTargetFrameworks>net8.0</ApprovalTestsTargetFrameworks>
-    <RecipesTargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</RecipesTargetFrameworks>
+    <TestTargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</TestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-    <FakeItEasyTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</FakeItEasyTargetFrameworks>
-    <ValueTaskExtensionsTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</ValueTaskExtensionsTargetFrameworks>
-    <SpecsTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</SpecsTargetFrameworks>
-    <IntegrationTestsTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</IntegrationTestsTargetFrameworks>
-    <UnitTestsTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</UnitTestsTargetFrameworks>
-    <TestHelpersTargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TestHelpersTargetFrameworks>
-    <ApprovalTestsTargetFrameworks>net8.0</ApprovalTestsTargetFrameworks>
-    <RecipesTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</RecipesTargetFrameworks>
+    <TestTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</TestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <FakeItEasyTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</FakeItEasyTargetFrameworks>
-    <ValueTaskExtensionsTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</ValueTaskExtensionsTargetFrameworks>
-    <SpecsTargetFrameworks>net6.0;net8.0</SpecsTargetFrameworks>
-    <IntegrationTestsTargetFrameworks>net6.0;net8.0</IntegrationTestsTargetFrameworks>
-    <UnitTestsTargetFrameworks>net6.0;net8.0</UnitTestsTargetFrameworks>
-    <TestHelpersTargetFrameworks>net6.0;net8.0</TestHelpersTargetFrameworks>
+    <TestTargetFrameworks>net6.0;net8.0</TestTargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <FakeItEasyTargetFrameworks>$(LibraryTargetFrameworks)</FakeItEasyTargetFrameworks>
+    <ValueTaskExtensionsTargetFrameworks>$(LibraryTargetFrameworks)</ValueTaskExtensionsTargetFrameworks>
+    <TestHelpersTargetFrameworks>$(LibraryTargetFrameworks)</TestHelpersTargetFrameworks>
     <ApprovalTestsTargetFrameworks>net8.0</ApprovalTestsTargetFrameworks>
-    <RecipesTargetFrameworks>net6.0;net8.0</RecipesTargetFrameworks>
+    <SpecsTargetFrameworks>$(TestTargetFrameworks)</SpecsTargetFrameworks>
+    <IntegrationTestsTargetFrameworks>$(TestTargetFrameworks)</IntegrationTestsTargetFrameworks>
+    <UnitTestsTargetFrameworks>$(TestTargetFrameworks)</UnitTestsTargetFrameworks>
+    <RecipesTargetFrameworks>$(TestTargetFrameworks)</RecipesTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/profiles/full.props
+++ b/profiles/full.props
@@ -11,8 +11,8 @@
     <RecipesTargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</RecipesTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-    <FakeItEasyTargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</FakeItEasyTargetFrameworks>
-    <ValueTaskExtensionsTargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</ValueTaskExtensionsTargetFrameworks>
+    <FakeItEasyTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</FakeItEasyTargetFrameworks>
+    <ValueTaskExtensionsTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</ValueTaskExtensionsTargetFrameworks>
     <SpecsTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</SpecsTargetFrameworks>
     <IntegrationTestsTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</IntegrationTestsTargetFrameworks>
     <UnitTestsTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</UnitTestsTargetFrameworks>
@@ -21,8 +21,8 @@
     <RecipesTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</RecipesTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <FakeItEasyTargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</FakeItEasyTargetFrameworks>
-    <ValueTaskExtensionsTargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</ValueTaskExtensionsTargetFrameworks>
+    <FakeItEasyTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</FakeItEasyTargetFrameworks>
+    <ValueTaskExtensionsTargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</ValueTaskExtensionsTargetFrameworks>
     <SpecsTargetFrameworks>net6.0;net8.0</SpecsTargetFrameworks>
     <IntegrationTestsTargetFrameworks>net6.0;net8.0</IntegrationTestsTargetFrameworks>
     <UnitTestsTargetFrameworks>net6.0;net8.0</UnitTestsTargetFrameworks>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,6 +23,13 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
+  <ItemGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework' And !$([MSBuild]::IsOSPlatform('Windows'))">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)*.cs" />
   </ItemGroup>


### PR DESCRIPTION
We can build (but not test) the net462 TFM on Linux and Mac by referencing the [Microsoft.NETFramework.ReferenceAssemblies](https://www.nuget.org/packages/Microsoft.NETFramework.ReferenceAssemblies) package.

I also refactored the `full` build profile to avoid repetition, because:
- the TFMs for libraries are now always the same
- the TFMs for tests for a given OS are always the same

Finally, in the last commit, I cleaned up the .editorconfig (it still had stuff related to project.json...) and explicitly set the indent size to 2 for MSBuild projects (to reflect the reality, and because Rider insisted on using 4 spaces when I edited the files manually...). I can move this to a separate PR if you prefer.