### PR TITLE
Migrate from Xbehave to LambdaTale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     name: Build on ${{ matrix.os-name }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows, ubuntu, macos]
         include:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,7 @@ The coordinators will usually assign a priority to each issue from 1 (highest) t
 
 ## Tests
 
-Changes in functionality (new features, changed behavior, or bug fixes) should be described by [xBehave.net](https://github.com/adamralph/xbehave.net) acceptance tests in the `FakeItEasy.Specs` project. Doing so ensures that tests are written in language familiar to FakeItEasy's end users and are resilient to refactoring.
+Changes in functionality (new features, changed behavior, or bug fixes) should be described by [LambdaTale](https://github.com/bbvch/LambdaTale) acceptance tests in the `FakeItEasy.Specs` project. Doing so ensures that tests are written in language familiar to FakeItEasy's end users and are resilient to refactoring.
 
 There should be a high level of test coverage. When achieving proper coverage is impractical via acceptance tests, then integration tests or unit tests should be added.
 

--- a/recipes/Directory.Build.props
+++ b/recipes/Directory.Build.props
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="xunit.core" Version="2.4.2" />
+    <PackageReference Include="xunit.core" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />

--- a/recipes/FakeItEasy.Recipes.CSharp/FakeItEasy.Recipes.CSharp.csproj
+++ b/recipes/FakeItEasy.Recipes.CSharp/FakeItEasy.Recipes.CSharp.csproj
@@ -12,6 +12,9 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/FakeItEasy/FakeItEasy.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <!-- suppress NU1902 and NU1903 so long as we have netcoreapp2.1 as a TFM -->
-    <NoWarn>$(NoWarn),CA1014,NU1902,NU1903</NoWarn>
+    <NoWarn>$(NoWarn),CS8002,CA1014,NU1902,NU1903</NoWarn>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="xunit.core" Version="2.4.2" />
+    <PackageReference Include="xunit.core" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />

--- a/tests/FakeItEasy.IntegrationTests/ExternalAssemblyGenerator.cs
+++ b/tests/FakeItEasy.IntegrationTests/ExternalAssemblyGenerator.cs
@@ -4,6 +4,8 @@ namespace FakeItEasy.IntegrationTests
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Versioning;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
 
@@ -65,7 +67,8 @@ namespace FakeItEasy.IntegrationTests
 
         private static string CreateBaseDirectory()
         {
-            var dir = Path.Combine(Path.GetTempPath(), AssemblyName);
+            var tfmAttribute = typeof(ExternalAssemblyGenerator).Assembly.GetCustomAttribute<TargetFrameworkAttribute>();
+            var dir = Path.Combine(Path.GetTempPath(), AssemblyName, tfmAttribute!.FrameworkName);
             if (Directory.Exists(dir))
             {
                 Directory.Delete(dir, recursive: true);

--- a/tests/FakeItEasy.Specs/AnArgumentConstraintSpecs.cs
+++ b/tests/FakeItEasy.Specs/AnArgumentConstraintSpecs.cs
@@ -1,7 +1,7 @@
 namespace FakeItEasy.Specs
 {
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class AnArgumentConstraintSpecs
     {

--- a/tests/FakeItEasy.Specs/AnyCallConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/AnyCallConfigurationSpecs.cs
@@ -3,7 +3,7 @@ namespace FakeItEasy.Specs
     using System;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class AnyCallConfigurationSpecs

--- a/tests/FakeItEasy.Specs/ArgumentCapturingSpecs.cs
+++ b/tests/FakeItEasy.Specs/ArgumentCapturingSpecs.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Specs
     using System.Linq;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class ArgumentCapturingSpecs

--- a/tests/FakeItEasy.Specs/ArgumentEqualityComparerSpecs.cs
+++ b/tests/FakeItEasy.Specs/ArgumentEqualityComparerSpecs.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Specs
     using System.Collections.Generic;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class ArgumentEqualityComparerSpecs

--- a/tests/FakeItEasy.Specs/ArgumentMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/ArgumentMatchingSpecs.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class ArgumentMatchingSpecs

--- a/tests/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
+++ b/tests/FakeItEasy.Specs/ArgumentValueFormatterSpecs.cs
@@ -2,7 +2,7 @@
 {
     using System.Diagnostics.CodeAnalysis;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class ArgumentValueFormatterSpecs
     {

--- a/tests/FakeItEasy.Specs/AssertingCallCountSpecs.cs
+++ b/tests/FakeItEasy.Specs/AssertingCallCountSpecs.cs
@@ -6,7 +6,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class AssertingCallCountSpecs

--- a/tests/FakeItEasy.Specs/AssertingOnSetOnlyPropertiesSpecs.cs
+++ b/tests/FakeItEasy.Specs/AssertingOnSetOnlyPropertiesSpecs.cs
@@ -1,7 +1,7 @@
 namespace FakeItEasy.Specs
 {
     using System.Diagnostics.CodeAnalysis;
-    using Xbehave;
+    using LambdaTale;
 
     public static class AssertingOnSetOnlyPropertiesSpecs
     {

--- a/tests/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
+++ b/tests/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
@@ -6,7 +6,7 @@
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class AssignsOutAndRefParametersSpecs

--- a/tests/FakeItEasy.Specs/CallDescriptionsInAssertionSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallDescriptionsInAssertionSpecs.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Tests.TestHelpers;
     using FakeItEasy.Tests.TestHelpers.FSharp;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public class CallDescriptionsInAssertionSpecs

--- a/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallMatchingSpecs.cs
@@ -9,7 +9,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Tests.TestHelpers;
     using FakeItEasy.Tests.TestHelpers.FSharp;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class CallMatchingSpecs

--- a/tests/FakeItEasy.Specs/CallsBaseMethodsFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/CallsBaseMethodsFakeSpecs.cs
@@ -3,7 +3,7 @@ namespace FakeItEasy.Specs
     using System;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class CallsBaseMethodsFakeSpecs

--- a/tests/FakeItEasy.Specs/CancellationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CancellationSpecs.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Specs
     using System.Threading.Tasks;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class CancellationSpecs

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -7,7 +7,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Creation;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class ConfigurationSpecs

--- a/tests/FakeItEasy.Specs/ConfiguringPropertySetterSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfiguringPropertySetterSpecs.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class ConfiguringPropertySetterSpecs

--- a/tests/FakeItEasy.Specs/CreationOptionsSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationOptionsSpecs.cs
@@ -9,7 +9,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Creation;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public abstract class CreationOptionsSpecsBase

--- a/tests/FakeItEasy.Specs/CreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/CreationSpecs.cs
@@ -10,7 +10,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Tests.TestHelpers;
     using FakeItEasy.Tests.TestHelpers.FSharp;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public abstract class CreationSpecsBase

--- a/tests/FakeItEasy.Specs/DisposableSpecs.cs
+++ b/tests/FakeItEasy.Specs/DisposableSpecs.cs
@@ -3,7 +3,7 @@ namespace FakeItEasy.Specs
     using System;
     using System.Diagnostics.CodeAnalysis;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class DisposableSpecs
     {

--- a/tests/FakeItEasy.Specs/DummyCreationSpecs.cs
+++ b/tests/FakeItEasy.Specs/DummyCreationSpecs.cs
@@ -11,7 +11,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Creation;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     [Collection("DummyCreationSpecs")]

--- a/tests/FakeItEasy.Specs/DummyFactorySpecs.cs
+++ b/tests/FakeItEasy.Specs/DummyFactorySpecs.cs
@@ -3,7 +3,7 @@ namespace FakeItEasy.Specs
     using System;
     using System.Reflection;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class DummyFactorySpecs
     {

--- a/tests/FakeItEasy.Specs/EventActionSpecs.cs
+++ b/tests/FakeItEasy.Specs/EventActionSpecs.cs
@@ -2,7 +2,7 @@ namespace FakeItEasy.Specs
 {
     using System;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public class EventActionSpecs
     {

--- a/tests/FakeItEasy.Specs/EventSpecs.cs
+++ b/tests/FakeItEasy.Specs/EventSpecs.cs
@@ -6,7 +6,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public delegate void CustomEventHandler(object sender, CustomEventArgs e);

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -28,9 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="bbv.LambdaTale" Version="2.9.302" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Xbehave.Core" Version="2.4.1" />
     <ProjectReference Include="..\..\src\FakeItEasy\FakeItEasy.csproj" />
     <ProjectReference Include="..\..\src\FakeItEasy.Extensions.ValueTask\FakeItEasy.Extensions.ValueTask.csproj" />
     <ProjectReference Include="..\FakeItEasy.Tests.TestHelpers\FakeItEasy.Tests.TestHelpers.csproj" />

--- a/tests/FakeItEasy.Specs/FakeManagerSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeManagerSpecs.cs
@@ -3,7 +3,7 @@ namespace FakeItEasy.Specs
     using System.Collections.Generic;
     using FakeItEasy.Core;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class FakeManagerSpecs
     {

--- a/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeOptionsBuilderSpecs.cs
@@ -6,7 +6,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Creation;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class FakeOptionsBuilderSpecs

--- a/tests/FakeItEasy.Specs/FakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakeSpecs.cs
@@ -6,7 +6,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Core;
     using FakeItEasy.Tests.TestHelpers.FSharp;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class FakeSpecs
     {

--- a/tests/FakeItEasy.Specs/FakingDelegates.cs
+++ b/tests/FakeItEasy.Specs/FakingDelegates.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class FakingDelegates

--- a/tests/FakeItEasy.Specs/FakingInternalsSpecs.cs
+++ b/tests/FakeItEasy.Specs/FakingInternalsSpecs.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     internal interface IInternal

--- a/tests/FakeItEasy.Specs/FluentApiSpecs.cs
+++ b/tests/FakeItEasy.Specs/FluentApiSpecs.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Specs
     using System.Linq;
 
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     /// <summary>
     /// Check certain fluent API syntax invariants.

--- a/tests/FakeItEasy.Specs/IllegalFluentApiSpecs.cs
+++ b/tests/FakeItEasy.Specs/IllegalFluentApiSpecs.cs
@@ -10,9 +10,9 @@ namespace FakeItEasy.Specs
 #endif
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
+    using LambdaTale;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
-    using Xbehave;
 
     /// <summary>
     /// Check that certain fluent API syntax constructions are illegal.

--- a/tests/FakeItEasy.Specs/InParametersSpecs.cs
+++ b/tests/FakeItEasy.Specs/InParametersSpecs.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Core;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public class InParameterSpecs

--- a/tests/FakeItEasy.Specs/ManageEventsSpecs.cs
+++ b/tests/FakeItEasy.Specs/ManageEventsSpecs.cs
@@ -3,7 +3,7 @@ namespace FakeItEasy.Specs
     using System;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public class ManageEventsSpecs

--- a/tests/FakeItEasy.Specs/ObjectMembersSpecs.cs
+++ b/tests/FakeItEasy.Specs/ObjectMembersSpecs.cs
@@ -2,7 +2,7 @@ namespace FakeItEasy.Specs
 {
     using FakeItEasy.Core;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class ObjectMembersSpecs
     {

--- a/tests/FakeItEasy.Specs/OrderedCallMatchingSpecs.cs
+++ b/tests/FakeItEasy.Specs/OrderedCallMatchingSpecs.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class OrderedCallMatchingSpecs

--- a/tests/FakeItEasy.Specs/ReadWritePropertySpecs.cs
+++ b/tests/FakeItEasy.Specs/ReadWritePropertySpecs.cs
@@ -1,7 +1,7 @@
 ﻿namespace FakeItEasy.Specs
 {
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class ReadWritePropertySpecs
     {

--- a/tests/FakeItEasy.Specs/ResetFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/ResetFakeSpecs.cs
@@ -4,7 +4,7 @@ using System;
 using FakeItEasy.Core;
 using FakeItEasy.Tests.TestHelpers;
 using FluentAssertions;
-using Xbehave;
+using LambdaTale;
 using Xunit;
 
 public static class ResetFakeSpecs

--- a/tests/FakeItEasy.Specs/StrictFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/StrictFakeSpecs.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Tests.TestHelpers;
     using FakeItEasy.Tests.TestHelpers.FSharp;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class StrictFakeSpecs

--- a/tests/FakeItEasy.Specs/StringExtensions.cs
+++ b/tests/FakeItEasy.Specs/StringExtensions.cs
@@ -3,8 +3,8 @@ namespace FakeItEasy.Specs
     using System;
     using System.Diagnostics.CodeAnalysis;
     using FakeItEasy.Creation;
-    using Xbehave;
-    using Xbehave.Sdk;
+    using LambdaTale;
+    using LambdaTale.Sdk;
 
     public static class StringExtensions
     {

--- a/tests/FakeItEasy.Specs/ThenSpecs.cs
+++ b/tests/FakeItEasy.Specs/ThenSpecs.cs
@@ -3,7 +3,7 @@ namespace FakeItEasy.Specs
     using System;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class ThenSpecs

--- a/tests/FakeItEasy.Specs/ThrowsAsyncSpecs.cs
+++ b/tests/FakeItEasy.Specs/ThrowsAsyncSpecs.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Specs
     using System.Threading.Tasks;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class ThrowsAsyncSpecs
     {

--- a/tests/FakeItEasy.Specs/UnconfiguredFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/UnconfiguredFakeSpecs.cs
@@ -2,7 +2,7 @@ namespace FakeItEasy.Specs
 {
     using System.Diagnostics.CodeAnalysis;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class UnconfiguredFakeSpecs
     {

--- a/tests/FakeItEasy.Specs/UnconfiguredPropertySpecs.cs
+++ b/tests/FakeItEasy.Specs/UnconfiguredPropertySpecs.cs
@@ -3,7 +3,7 @@ namespace FakeItEasy.Specs
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public static class UnconfiguredPropertySpecs
     {

--- a/tests/FakeItEasy.Specs/UnnaturalFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/UnnaturalFakeSpecs.cs
@@ -4,7 +4,7 @@
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class UnnaturalFakeSpecs

--- a/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
+++ b/tests/FakeItEasy.Specs/UserCallbackExceptionSpecs.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Creation;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public class UserCallbackExceptionSpecs

--- a/tests/FakeItEasy.Specs/ValueTaskReturnValueSpecs.cs
+++ b/tests/FakeItEasy.Specs/ValueTaskReturnValueSpecs.cs
@@ -3,7 +3,7 @@ namespace FakeItEasy.Specs
     using System;
     using System.Threading.Tasks;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
 
     public class ValueTaskReturnValueSpecs
     {

--- a/tests/FakeItEasy.Specs/WrappingFakeSpecs.cs
+++ b/tests/FakeItEasy.Specs/WrappingFakeSpecs.cs
@@ -4,7 +4,7 @@ namespace FakeItEasy.Specs
     using FakeItEasy.Configuration;
     using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
-    using Xbehave;
+    using LambdaTale;
     using Xunit;
 
     public static class WrappingFakeSpecs


### PR DESCRIPTION
Since XBehave is no longer maintained

The 1st commit upgrades xUnit to 2.9.3 (required by LambdaTale)
The 2nd commit switches from XBehave to LambdaTale

The following commits are not strictly related to this change, I can move them to a separate PR if you prefer:
- Fix a warning in FakeItEasy.Recipes.CSharp
- Disable fail-fast in the matrix build strategy (so that a failure on one OS doesn't hide the errors on other OSes)
- Disable TFM parallelism for integration tests (new in .NET 9 SDK, was causing an error when accessing the FakeItEasy.ExtensionPoints.ExternalDependency assembly from multiple processes at the same time)
- Re-enable TFM parallelism and fix the code to use different paths for the generated assemblies (could be squashed with previous commit if we want to keep it)

~~At the moment, the tests for net462 and netcoreap2.1 fail because LambdaTale doesn't have a strong name.~~ (the latest version of LambdaTale now has a strong name)