### PR TITLE
Add support for default interface methods

### DIFF
--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="5.1.1" />
+    <PackageReference Include="Castle.Core" Version="5.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FakeItEasy.IntegrationTests/ExceptionMessagesTests.cs
+++ b/tests/FakeItEasy.IntegrationTests/ExceptionMessagesTests.cs
@@ -82,7 +82,7 @@ namespace FakeItEasy.IntegrationTests
                 @"
 
   The current proxy generator can not intercept the property System.Collections.Generic.Dictionary`2[System.String,System.Int32].Item[System.String key] for the following reason:
-    - Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted.
+    - Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted.
 
 ";
 

--- a/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/tests/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -290,7 +290,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws a fake configuration exception"
                 .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                    .And.Message.Should().ContainModuloLineEndings("The current proxy generator can not intercept the method FakeItEasy.Specs.ConfigurationSpecs+BaseClass.DoSomethingNonVirtual(System.Int32 anInt) for the following reason:\r\n    - Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
+                    .And.Message.Should().ContainModuloLineEndings("The current proxy generator can not intercept the method FakeItEasy.Specs.ConfigurationSpecs+BaseClass.DoSomethingNonVirtual(System.Int32 anInt) for the following reason:\r\n    - Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted."));
         }
 
         [Scenario]
@@ -322,7 +322,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws a fake configuration exception"
                .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                   .And.Message.Should().Contain("Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
+                   .And.Message.Should().Contain("Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted."));
         }
 
         [Scenario]
@@ -354,7 +354,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws a fake configuration exception"
                 .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                    .And.Message.Should().Contain("Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
+                    .And.Message.Should().Contain("Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted."));
         }
 
         [Scenario]
@@ -386,7 +386,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws a fake configuration exception"
                 .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                    .And.Message.Should().Contain("Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
+                    .And.Message.Should().Contain("Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted."));
         }
 
         [Scenario]
@@ -418,7 +418,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws a fake configuration exception"
                 .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                    .And.Message.Should().Contain("Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
+                    .And.Message.Should().Contain("Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted."));
         }
 
         [Scenario]
@@ -450,7 +450,7 @@ namespace FakeItEasy.Specs
 
             "Then it throws a fake configuration exception"
                .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
-                   .And.Message.Should().Contain("Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
+                   .And.Message.Should().Contain("Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted."));
         }
 
         [Scenario]

--- a/tests/FakeItEasy.Specs/DefaultInterfaceMethodSpecs.cs
+++ b/tests/FakeItEasy.Specs/DefaultInterfaceMethodSpecs.cs
@@ -1,21 +1,27 @@
 ﻿namespace FakeItEasy.Specs;
 
+using System;
+using FakeItEasy.Configuration;
+using FakeItEasy.Tests.TestHelpers;
 using FluentAssertions;
 using LambdaTale;
+using Xunit;
 
 #if !LACKS_DEFAULT_INTERFACE_METHODS
 public static class DefaultInterfaceMethodSpecs
 {
-    public interface IHaveDefaultMethod
+    public interface IHaveDefaultMethods
     {
         int Foo() => 42;
+
+        sealed int Bar() => 123;
     }
 
     [Scenario]
-    public static void FakeInterfaceWithDefaultMethod(IHaveDefaultMethod fake, int result)
+    public static void FakeInterfaceWithDefaultMethod(IHaveDefaultMethods fake, int result)
     {
         "Given a faked interface with a default method"
-            .x(() => fake = A.Fake<IHaveDefaultMethod>());
+            .x(() => fake = A.Fake<IHaveDefaultMethods>());
 
         "When the default interface method is called"
             .x(() => result = fake.Foo());
@@ -25,16 +31,59 @@ public static class DefaultInterfaceMethodSpecs
     }
 
     [Scenario]
-    public static void FakeInterfaceWithDefaultMethodWithCallsBaseMethods(IHaveDefaultMethod fake, int result)
+    public static void FakeInterfaceWithDefaultMethodWithCallsBaseMethods(IHaveDefaultMethods fake, int result)
     {
         "Given a faked interface with a default method configured to call base methods"
-            .x(() => fake = A.Fake<IHaveDefaultMethod>(o => o.CallsBaseMethods()));
+            .x(() => fake = A.Fake<IHaveDefaultMethods>(o => o.CallsBaseMethods()));
 
         "When the default interface method is called"
             .x(() => result = fake.Foo());
 
         "Then it should return the value from the default implementation"
             .x(() => result.Should().Be(42));
+    }
+
+    [Scenario]
+    public static void FakeInterfaceWithDefaultMethodOverrideBehavior(IHaveDefaultMethods fake, int result)
+    {
+        "Given a faked interface with a default method"
+            .x(() => fake = A.Fake<IHaveDefaultMethods>());
+
+        "When the default method is configured to return something else"
+            .x(() => A.CallTo(() => fake.Foo()).Returns(99));
+
+        "And the default interface method is called"
+            .x(() => result = fake.Foo());
+
+        "Then it should return the configured value"
+            .x(() => result.Should().Be(99));
+    }
+
+    [Scenario]
+    public static void FakeInterfaceWithSealedDefaultMethod(IHaveDefaultMethods fake, int result)
+    {
+        "Given a faked interface with a sealed default method"
+            .x(() => fake = A.Fake<IHaveDefaultMethods>());
+
+        "When the default interface method is called"
+            .x(() => result = fake.Bar());
+
+        "Then it should return the value from the default implementation"
+            .x(() => result.Should().Be(123));
+    }
+
+    [Scenario]
+    public static void FakeInterfaceWithSealedDefaultMethodOverrideBehavior(IHaveDefaultMethods fake, Exception? exception)
+    {
+        "Given a faked interface with a sealed default method"
+            .x(() => fake = A.Fake<IHaveDefaultMethods>());
+
+        "When the sealed default method is configured to return something else"
+            .x(() => exception = Record.Exception(() => A.CallTo(() => fake.Bar()).Returns(99)));
+
+        "Then it throws a fake configuration exception"
+            .x(() => exception.Should().BeAnExceptionOfType<FakeConfigurationException>()
+                .And.Message.Should().Contain("Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted."));
     }
 }
 #endif

--- a/tests/FakeItEasy.Specs/DefaultInterfaceMethodSpecs.cs
+++ b/tests/FakeItEasy.Specs/DefaultInterfaceMethodSpecs.cs
@@ -1,0 +1,40 @@
+﻿namespace FakeItEasy.Specs;
+
+using FluentAssertions;
+using LambdaTale;
+
+#if !LACKS_DEFAULT_INTERFACE_METHODS
+public static class DefaultInterfaceMethodSpecs
+{
+    public interface IHaveDefaultMethod
+    {
+        int Foo() => 42;
+    }
+
+    [Scenario]
+    public static void FakeInterfaceWithDefaultMethod(IHaveDefaultMethod fake, int result)
+    {
+        "Given a faked interface with a default method"
+            .x(() => fake = A.Fake<IHaveDefaultMethod>());
+
+        "When the default interface method is called"
+            .x(() => result = fake.Foo());
+
+        "Then it should return the default value"
+            .x(() => result.Should().Be(0));
+    }
+
+    [Scenario]
+    public static void FakeInterfaceWithDefaultMethodWithCallsBaseMethods(IHaveDefaultMethod fake, int result)
+    {
+        "Given a faked interface with a default method configured to call base methods"
+            .x(() => fake = A.Fake<IHaveDefaultMethod>(o => o.CallsBaseMethods()));
+
+        "When the default interface method is called"
+            .x(() => result = fake.Foo());
+
+        "Then it should return the value from the default implementation"
+            .x(() => result.Should().Be(42));
+    }
+}
+#endif

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -16,11 +16,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-      <DefineConstants>$(DefineConstants);LACKS_FAKEABLE_GENERIC_IN_PARAMETERS</DefineConstants>
+      <DefineConstants>$(DefineConstants);LACKS_FAKEABLE_GENERIC_IN_PARAMETERS;LACKS_DEFAULT_INTERFACE_METHODS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">
-      <DefineConstants>$(DefineConstants);LACKS_FAKEABLE_GENERIC_IN_PARAMETERS;CAN_CREATE_ISBYREFLIKE</DefineConstants>
+      <DefineConstants>$(DefineConstants);LACKS_FAKEABLE_GENERIC_IN_PARAMETERS;CAN_CREATE_ISBYREFLIKE;LACKS_DEFAULT_INTERFACE_METHODS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidatorTests.cs
+++ b/tests/FakeItEasy.Tests/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidatorTests.cs
@@ -37,7 +37,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
             return TestCases.FromObject(
                 new NonInterceptableTestCase(
                     () => new object().GetType(),
-                    "Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."),
+                    "Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted."),
                 new NonInterceptableTestCase(
                     () => object.Equals("foo", "bar"),
                     "Static methods can not be intercepted."),
@@ -48,7 +48,7 @@ namespace FakeItEasy.Tests.Creation.CastleDynamicProxy
                     "Extension methods can not be intercepted since they're static."),
                 new NonInterceptableTestCase(
                     () => new TypeWithSealedOverride().ToString(),
-                    "Non-virtual members can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted."));
+                    "Non-virtual or sealed members can not be intercepted. Only interface members and non-sealed virtual, overriding, and abstract members can be intercepted."));
         }
 
         public static IEnumerable<object?[]> InterceptableMethods()


### PR DESCRIPTION
Upgrade Castle.Core to 5.2.1, which introduces this support.
Fix the case of sealed default interface methods.
Reword the "non-virtual members can not be intercepted" message to also mentioned sealed members.

Fixes #1633