### PR TITLE
Fix formatting of bullet lists in docs

### DIFF
--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -1,3 +1,3 @@
 [filtering]
-ignorewarningsforurls=
-  ^https://stackoverflow\.com ^http-rate-limited$
+ignore=
+  ^https://stackoverflow\.com/

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -15,6 +15,7 @@ Fake.Reset(fake);
 ```
 
 This method resets all changes made to the fake after it was created. This includes:
+
 * call configurations
 * values of [auto-faked read-write properties](default-fake-behavior.md#readwrite-properties)
 * event handlers
@@ -23,6 +24,7 @@ This method resets all changes made to the fake after it was created. This inclu
 
 However, any changes made _during_ fake creation (via fake creation options) will be preserved.
 This includes all the elements mentioned above, but also:
+
 * [strictness](strict-fakes.md),
 * [object wrapping](calling-wrapped-methods.md),
 * [redirecting to base methods](calling-base-methods.md), and

--- a/docs/read-write-property-behavior.md
+++ b/docs/read-write-property-behavior.md
@@ -1,3 +1,4 @@
 The contents of this page have moved. See
+
 * [Default fake behavior](default-fake-behavior.md) for information about unconfigured properties and
 * [Specifying a Call to Configure](specifying-a-call-to-configure.md) for how to configure a property.


### PR DESCRIPTION
Broken formatting here:
![image](https://github.com/user-attachments/assets/8e1031b1-ff5c-4fa1-b2cc-ddb9aab393fe)
