### PR TITLE
Build with .NET 9.0 SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
         if: ${{ matrix.dotnet-versions-to-install }}
         with:
           dotnet-version: ${{ matrix.dotnet-versions-to-install }}
+      - name: Print .NET SDK version
+        run: dotnet --version
+        shell: pwsh
       - name: Run build script
         run: ./build.ps1
         shell: pwsh

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -13,7 +13,7 @@ The build requires that a few pieces of software be installed on the host comput
 
 To build FakeItEasy at all, you must have
 
-* an up-to-date version of the .NET 8.0 SDK (currently this means 8.0.204 or later)
+* an up-to-date version of the .NET 9.0 SDK (currently this means 9.0.300 or later)
 
 FakeItEasy supports the following targets
 

--- a/src/FakeItEasy/Core/CompletedFakeObjectCall.cs
+++ b/src/FakeItEasy/Core/CompletedFakeObjectCall.cs
@@ -5,7 +5,7 @@ namespace FakeItEasy.Core
 
     internal class CompletedFakeObjectCall : ICompletedFakeObjectCall
     {
-        public CompletedFakeObjectCall(IInterceptedFakeObjectCall interceptedCall, object[] arguments)
+        public CompletedFakeObjectCall(IInterceptedFakeObjectCall interceptedCall, object?[] arguments)
         {
             this.FakedObject = interceptedCall.FakedObject;
             this.Method = interceptedCall.Method;

--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidator.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyInterceptionValidator.cs
@@ -34,7 +34,7 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
 
         private static string? GetReasonForWhyMethodCanNotBeIntercepted(MethodInfo method)
         {
-            if (Castle.DynamicProxy.ProxyUtil.IsProxyType(method.DeclaringType))
+            if (Castle.DynamicProxy.ProxyUtil.IsProxyType(method.DeclaringType!))
             {
                 return null;
             }

--- a/src/FakeItEasy/Creation/DelegateProxies/CastleInvocationDelegateCallAdapter.cs
+++ b/src/FakeItEasy/Creation/DelegateProxies/CastleInvocationDelegateCallAdapter.cs
@@ -16,7 +16,7 @@ namespace FakeItEasy.Creation.DelegateProxies
     {
         private readonly IInvocation invocation;
         private readonly Delegate theDelegate;
-        private readonly object[] originalArguments;
+        private readonly object?[] originalArguments;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CastleInvocationDelegateCallAdapter"/> class.


### PR DESCRIPTION
We typically advocate using the latest SDK, and the GitHub Actions runners are already using .NET 9.0 SDK, so we might as well formalize it and clean up the warnings that have crept into the build.