### PR TITLE
Fix .NET Framework specs

### DIFF
--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -17,10 +17,10 @@ To build FakeItEasy at all, you must have
 
 FakeItEasy supports the following targets
 
-| Target                | Tested On            | Additional prerequisites                   | Build Profile  |
-|-----------------------|----------------------|--------------------------------------------|----------------|
-| .NET 8.0              | .NET 8.0             |                                            | net8.0         |
-| .NET Framework 4.6.2  | .NET Framework 4.6.2 | Windows OS, .NET Framework 4.6.2 or higher | net462         |
+| Target                | Tested On            | Additional prerequisites                                                        | Build Profile  |
+|-----------------------|----------------------|---------------------------------------------------------------------------------|----------------|
+| .NET 8.0              | .NET 8.0             |                                                                                 | net8.0         |
+| .NET Framework 4.6.2  | .NET Framework 4.7.2 | Windows OS, .NET Framework 4.7.2 or higher, .NET Framework 4.6.2 targeting pack | net462         |
 
 The default [build profile](#building-only-a-subset-of-the-supported-target-frameworks) (called `full`)
 will build and test all targets that are supported on the active operating system, so will require all
@@ -75,7 +75,9 @@ but is not official and does not provide the same assurance as a command-line bu
 The additional requirements are:
 
 1. Visual Studio 2022 (17.0 or later)
-2. Install the ".NET Framework 4.6.2 targeting pack" individual component (via the Visual Studio installer)
+2. Install the following components via the Visual Studio installer (in the "Individual components" tab):
+   * .NET Framework 4.7.2 targeting pack
+   * .NET Framework 4.6.2 targeting pack
 
 ### Building only a subset of the supported target frameworks
 

--- a/profiles/full.props
+++ b/profiles/full.props
@@ -4,7 +4,7 @@
     <LibraryTargetFrameworks>net462;net8.0</LibraryTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <TestTargetFrameworks>net462;net8.0</TestTargetFrameworks>
+    <TestTargetFrameworks>net472;net8.0</TestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <TestTargetFrameworks>net8.0</TestTargetFrameworks>
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <FakeItEasyTargetFrameworks>$(LibraryTargetFrameworks)</FakeItEasyTargetFrameworks>
     <ValueTaskExtensionsTargetFrameworks>$(LibraryTargetFrameworks)</ValueTaskExtensionsTargetFrameworks>
-    <TestHelpersTargetFrameworks>$(LibraryTargetFrameworks)</TestHelpersTargetFrameworks>
+    <TestHelpersTargetFrameworks>$(TestTargetFrameworks)</TestHelpersTargetFrameworks>
     <ApprovalTestsTargetFrameworks>net8.0</ApprovalTestsTargetFrameworks>
     <SpecsTargetFrameworks>$(TestTargetFrameworks)</SpecsTargetFrameworks>
     <IntegrationTestsTargetFrameworks>$(TestTargetFrameworks)</IntegrationTestsTargetFrameworks>

--- a/profiles/net462.props
+++ b/profiles/net462.props
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <FakeItEasyTargetFrameworks>net462</FakeItEasyTargetFrameworks>
     <ValueTaskExtensionsTargetFrameworks>net462</ValueTaskExtensionsTargetFrameworks>
-    <SpecsTargetFrameworks>net462</SpecsTargetFrameworks>
-    <IntegrationTestsTargetFrameworks>net462</IntegrationTestsTargetFrameworks>
-    <UnitTestsTargetFrameworks>net462</UnitTestsTargetFrameworks>
-    <TestHelpersTargetFrameworks>net462</TestHelpersTargetFrameworks>
-    <ApprovalTestsTargetFrameworks>net462</ApprovalTestsTargetFrameworks>
-    <RecipesTargetFrameworks>net462</RecipesTargetFrameworks>
+    <SpecsTargetFrameworks>net472</SpecsTargetFrameworks>
+    <IntegrationTestsTargetFrameworks>net472</IntegrationTestsTargetFrameworks>
+    <UnitTestsTargetFrameworks>net472</UnitTestsTargetFrameworks>
+    <TestHelpersTargetFrameworks>net472</TestHelpersTargetFrameworks>
+    <ApprovalTestsTargetFrameworks>net472</ApprovalTestsTargetFrameworks>
+    <RecipesTargetFrameworks>net472</RecipesTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit.core" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
   </ItemGroup>

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="bbv.LambdaTale" Version="2.9.302" />
+    <PackageReference Include="bbv.LambdaTale" Version="2.9.305" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <ProjectReference Include="..\..\src\FakeItEasy\FakeItEasy.csproj" />

--- a/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
+++ b/tests/FakeItEasy.Specs/FakeItEasy.Specs.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <PackageReference Include="bbv.LambdaTale" Version="2.9.305" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <ProjectReference Include="..\..\src\FakeItEasy\FakeItEasy.csproj" />
     <ProjectReference Include="..\..\src\FakeItEasy.Extensions.ValueTask\FakeItEasy.Extensions.ValueTask.csproj" />
     <ProjectReference Include="..\FakeItEasy.Tests.TestHelpers\FakeItEasy.Tests.TestHelpers.csproj" />


### PR DESCRIPTION
Upgrade all tests to .NET 4.7.2, use the latest versions of LambdaTale, Microsoft.NET.Test.Sdk and xunit.runner.visualstudio.

With these changes, we no longer have the "No test is available" warning for the .NET Framework specs.

Note that the libraries themselves still target .NET 4.6.2.