### PR TITLE
Check links in a nightly scheduled workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,34 @@
+name: Check links
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-doc-links:
+    name: Check links
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: '0.9.4'
+      - name: Check links
+        run: ./build.ps1 check-links
+        shell: pwsh
+      - name: Upload docs link check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-link-check
+          path: artifacts/docs-link-check.html
+      - name: Upload readme link check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+            name: readme-link-check
+            path: artifacts/readme-link-check.html

--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -6,3 +6,5 @@ ignorewarningsforurls=
   # linkcheck always warns that it can't check markdown files,
   # even though it does via the MarkdownCheck plugin
   ^file:.*\.md$ ^url-content-type-unparseable
+
+[MarkdownCheck]

--- a/tools/FakeItEasy.Build/Program.cs
+++ b/tools/FakeItEasy.Build/Program.cs
@@ -57,7 +57,9 @@ Target(
     forEach: projectsToPack,
     action: project => Run("dotnet", $"pack {project.Path} --configuration Release --no-build --nologo --output \"{Path.GetFullPath("artifacts/output")}\""));
 
-Target("docs", DependsOn("check-docs-links", "check-readme-links"));
+Target("docs", DependsOn("generate-docs"));
+
+Target("check-links", DependsOn("check-docs-links", "check-readme-links"));
 
 // If mkdocs's site_url configuration is not set, sitemap.xml is full of "None" links.
 // Even with a valid site_url, the link check would fail if we added a new page.


### PR DESCRIPTION
Rather than in the main CI build workflow.

Note that it also builds the docs, since the `check-docs-link` targets runs on the generated docs, rather than the source Markdown files.

Also fix link checking of the README