### PR TITLE
Stop trying to upload link check reports in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,15 +86,3 @@ jobs:
         with:
           name: documentation
           path: artifacts/docs
-      - name: Upload docs link check report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: docs-link-check
-          path: artifacts/docs-link-check.html
-      - name: Upload readme link check report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-            name: readme-link-check
-            path: artifacts/readme-link-check.html


### PR DESCRIPTION
Since we no longer do those checks in that workflow.