### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write # enable GitHub OIDC token issuance, needed for Nuget trusted publishing
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Add the `id-token` permission to `deploy` job, necessary for Github trusted publishing