### PR TITLE
Fix issue with optional parameter in IsSameSequenceAs and HasSameElementsAs

### DIFF
--- a/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
+++ b/src/FakeItEasy/ArgumentConstraintManagerExtensions.cs
@@ -213,6 +213,23 @@ public static class ArgumentConstraintManagerExtensions
     /// </summary>
     /// <param name="manager">The constraint manager to match the constraint.</param>
     /// <param name="values">The sequence to test against.</param>
+    /// <typeparam name="T">The type of argument to constrain.</typeparam>
+    /// <typeparam name="TElement">The type of the collection's elements.</typeparam>
+    /// <returns>A dummy argument value.</returns>
+    public static T IsSameSequenceAs<T, TElement>(
+        this IArgumentConstraintManager<T> manager,
+        IEnumerable<TElement> values)
+        where T : IEnumerable<TElement>
+    {
+        return manager.IsSameSequenceAs(values, null);
+    }
+
+    /// <summary>
+    /// Constrains the argument collection so that it must contain the same elements as the
+    /// specified collection, in the same order.
+    /// </summary>
+    /// <param name="manager">The constraint manager to match the constraint.</param>
+    /// <param name="values">The sequence to test against.</param>
     /// <param name="comparer">A comparer to test the collection elements for equality. If null, the default equality comparer for <c>TElement</c> will be used.</param>
     /// <typeparam name="T">The type of argument to constrain.</typeparam>
     /// <typeparam name="TElement">The type of the collection's elements.</typeparam>
@@ -220,7 +237,7 @@ public static class ArgumentConstraintManagerExtensions
     public static T IsSameSequenceAs<T, TElement>(
         this IArgumentConstraintManager<T> manager,
         IEnumerable<TElement> values,
-        IEqualityComparer<TElement>? comparer = null)
+        IEqualityComparer<TElement>? comparer)
         where T : IEnumerable<TElement>
     {
         Guard.AgainstNull(manager);
@@ -258,6 +275,23 @@ public static class ArgumentConstraintManagerExtensions
     /// </summary>
     /// <param name="manager">The constraint manager to match the constraint.</param>
     /// <param name="values">The sequence to test against.</param>
+    /// <typeparam name="T">The type of argument to constrain.</typeparam>
+    /// <typeparam name="TElement">The type of the collection's elements.</typeparam>
+    /// <returns>A dummy argument value.</returns>
+    public static T HasSameElementsAs<T, TElement>(
+        this IArgumentConstraintManager<T> manager,
+        IEnumerable<TElement> values)
+        where T : IEnumerable<TElement>
+    {
+        return manager.HasSameElementsAs(values, null);
+    }
+
+    /// <summary>
+    /// Constrains the argument collection so that it must contain the same elements as the
+    /// specified collection, in any order.
+    /// </summary>
+    /// <param name="manager">The constraint manager to match the constraint.</param>
+    /// <param name="values">The sequence to test against.</param>
     /// <param name="comparer">A comparer to test the collection elements for equality. If null, the default equality comparer for <c>TElement</c> will be used.</param>
     /// <typeparam name="T">The type of argument to constrain.</typeparam>
     /// <typeparam name="TElement">The type of the collection's elements.</typeparam>
@@ -265,7 +299,7 @@ public static class ArgumentConstraintManagerExtensions
     public static T HasSameElementsAs<T, TElement>(
         this IArgumentConstraintManager<T> manager,
         IEnumerable<TElement> values,
-        IEqualityComparer<TElement>? comparer = null)
+        IEqualityComparer<TElement>? comparer)
         where T : IEnumerable<TElement>
     {
         Guard.AgainstNull(manager);

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net10.0.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net10.0.verified.txt
@@ -51,9 +51,11 @@ namespace FakeItEasy
             where T : System.Collections.IEnumerable { }
         public static string EndsWith(this FakeItEasy.IArgumentConstraintManager<string> manager, string value) { }
         public static string EndsWith(this FakeItEasy.IArgumentConstraintManager<string> manager, string value, System.StringComparison comparisonType) { }
+        public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values)
+            where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, params TElement[] values)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
-        public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer = null)
+        public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static System.Threading.CancellationToken IsCanceled(this FakeItEasy.IArgumentConstraintManager<System.Threading.CancellationToken> manager) { }
         public static T IsEmpty<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
@@ -74,9 +76,11 @@ namespace FakeItEasy
             where T :  struct { }
         public static string IsNullOrEmpty(this FakeItEasy.IArgumentConstraintManager<string> manager) { }
         public static T IsSameAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
+        public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values)
+            where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, params TElement[] values)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
-        public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer = null)
+        public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Func<T, bool> predicate, string description) { }

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net462.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net462.verified.txt
@@ -51,9 +51,11 @@ namespace FakeItEasy
             where T : System.Collections.IEnumerable { }
         public static string EndsWith(this FakeItEasy.IArgumentConstraintManager<string> manager, string value) { }
         public static string EndsWith(this FakeItEasy.IArgumentConstraintManager<string> manager, string value, System.StringComparison comparisonType) { }
+        public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values)
+            where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, params TElement[] values)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
-        public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer = null)
+        public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static System.Threading.CancellationToken IsCanceled(this FakeItEasy.IArgumentConstraintManager<System.Threading.CancellationToken> manager) { }
         public static T IsEmpty<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
@@ -74,9 +76,11 @@ namespace FakeItEasy
             where T :  struct { }
         public static string IsNullOrEmpty(this FakeItEasy.IArgumentConstraintManager<string> manager) { }
         public static T IsSameAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
+        public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values)
+            where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, params TElement[] values)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
-        public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer = null)
+        public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Func<T, bool> predicate, string description) { }

--- a/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net8.0.verified.txt
+++ b/tests/FakeItEasy.Tests.Approval/ApprovedApi/FakeItEasy/net8.0.verified.txt
@@ -51,9 +51,11 @@ namespace FakeItEasy
             where T : System.Collections.IEnumerable { }
         public static string EndsWith(this FakeItEasy.IArgumentConstraintManager<string> manager, string value) { }
         public static string EndsWith(this FakeItEasy.IArgumentConstraintManager<string> manager, string value, System.StringComparison comparisonType) { }
+        public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values)
+            where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, params TElement[] values)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
-        public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer = null)
+        public static T HasSameElementsAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static System.Threading.CancellationToken IsCanceled(this FakeItEasy.IArgumentConstraintManager<System.Threading.CancellationToken> manager) { }
         public static T IsEmpty<T>(this FakeItEasy.IArgumentConstraintManager<T> manager)
@@ -74,9 +76,11 @@ namespace FakeItEasy
             where T :  struct { }
         public static string IsNullOrEmpty(this FakeItEasy.IArgumentConstraintManager<string> manager) { }
         public static T IsSameAs<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, T value) { }
+        public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values)
+            where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, params TElement[] values)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
-        public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer = null)
+        public static T IsSameSequenceAs<T, TElement>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Collections.Generic.IEnumerable<TElement> values, System.Collections.Generic.IEqualityComparer<TElement>? comparer)
             where T : System.Collections.Generic.IEnumerable<TElement> { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
         public static T Matches<T>(this FakeItEasy.IArgumentConstraintManager<T> manager, System.Func<T, bool> predicate, string description) { }


### PR DESCRIPTION
Optional parameters can't be used in expression trees before C# 14, so we need to have two overloads: one with the comparer parameter, and one without.

Fixes #2084 