### PR TITLE
Fix mistake in 'how to build' document

### DIFF
--- a/how-to-build.md
+++ b/how-to-build.md
@@ -140,5 +140,5 @@ If you wish to update the packages used, edit `pyproject.toml`, specifying the d
 uv lock
 ```
 
-from the root of the repository. After verifying the generated documentation, you can commit both
+from the `docs` directory. After verifying the generated documentation, you can commit both
 `pyproject.toml` and `uv.lock`.


### PR DESCRIPTION
Noticed this when making the changes to use `uv` in the analyzers project, and forgot to submit the change here.