### PR TITLE
Update shared tools submodule

### DIFF
--- a/FakeItEasy.sln
+++ b/FakeItEasy.sln
@@ -110,24 +110,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{9D99B251
 		tools\Build.cs = tools\Build.cs
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FakeItEasy.PrepareRelease", "tools-shared\FakeItEasy.PrepareRelease\FakeItEasy.PrepareRelease.csproj", "{0E2ED1CD-C7ED-4641-9482-C4BBBA58B623}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FakeItEasy.Deploy", "tools-shared\FakeItEasy.Deploy\FakeItEasy.Deploy.csproj", "{5F4FC5FA-E2FA-456D-813F-6057B7CE7FF0}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FakeItEasy.Extensions.ValueTask", "src\FakeItEasy.Extensions.ValueTask\FakeItEasy.Extensions.ValueTask.csproj", "{17B22C7C-9ECB-4D05-A238-48B40DDA06E8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FakeItEasy.Tests.TestHelpers", "tests\FakeItEasy.Tests.TestHelpers\FakeItEasy.Tests.TestHelpers.csproj", "{458FBDA4-91F9-4A69-BFBC-5AC3D85D4A03}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FakeItEasy.Tests.ExtensionPoints", "tests\FakeItEasy.Tests.ExtensionPoints\FakeItEasy.Tests.ExtensionPoints.csproj", "{55451191-0521-41E1-BCCF-6D135D646589}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{101E0992-8233-42C8-9CAF-FEC799BF5DDB}"
-	ProjectSection(SolutionItems) = preProject
-		tools-shared\.editorconfig = tools-shared\.editorconfig
-		tools-shared\.githubtoken = tools-shared\.githubtoken
-		tools-shared\.gitignore = tools-shared\.gitignore
-		tools-shared\Directory.Build.props = tools-shared\Directory.Build.props
-		tools-shared\README.md = tools-shared\README.md
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Recipes", "Recipes", "{8733C91C-38B3-4105-88A3-11AD82CB78CD}"
 	ProjectSection(SolutionItems) = preProject
@@ -153,6 +140,39 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "profiles", "profiles", "{42
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeGen", "tools\CodeGen\CodeGen.csproj", "{95F1F48E-D5D7-4B9E-A0CE-FF5EC6C20190}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{5655FC36-5B1B-49FD-9C14-B1097762A0BB}"
+	ProjectSection(SolutionItems) = preProject
+		tools-shared\Common\GitHubTokenSource.cs = tools-shared\Common\GitHubTokenSource.cs
+		tools-shared\Common\ReleaseHelpers.cs = tools-shared\Common\ReleaseHelpers.cs
+		tools-shared\Common\ToolHelpers.cs = tools-shared\Common\ToolHelpers.cs
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{868881C6-9208-497D-A8D3-B8495C0A8686}"
+	ProjectSection(SolutionItems) = preProject
+		tools-shared\Deploy\CommandLineOptions.cs = tools-shared\Deploy\CommandLineOptions.cs
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PrepareRelease", "PrepareRelease", "{F7C5B4FF-52FD-4835-AD14-9C08472E0E3E}"
+	ProjectSection(SolutionItems) = preProject
+		tools-shared\PrepareRelease\GitHubHelper.cs = tools-shared\PrepareRelease\GitHubHelper.cs
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{43B72E50-DC21-49D5-91DD-52BF613037AF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "actions", "actions", "{3717488C-0613-4B18-989B-DD063165B463}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "deploy", "deploy", "{20F341C1-98F2-451F-8DDE-C46B1F4EF51B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools-shared", "tools-shared", "{86DFE4D4-37A9-4503-A869-E5836A89E34A}"
+	ProjectSection(SolutionItems) = preProject
+		tools-shared\.editorconfig = tools-shared\.editorconfig
+		tools-shared\.githubtoken = tools-shared\.githubtoken
+		tools-shared\.gitignore = tools-shared\.gitignore
+		tools-shared\Deploy.cs = tools-shared\Deploy.cs
+		tools-shared\Directory.Build.props = tools-shared\Directory.Build.props
+		tools-shared\PrepareRelease.cs = tools-shared\PrepareRelease.cs
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -184,10 +204,6 @@ Global
 		{74165807-676F-4464-B607-8770C13E8991}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74165807-676F-4464-B607-8770C13E8991}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74165807-676F-4464-B607-8770C13E8991}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0E2ED1CD-C7ED-4641-9482-C4BBBA58B623}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0E2ED1CD-C7ED-4641-9482-C4BBBA58B623}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5F4FC5FA-E2FA-456D-813F-6057B7CE7FF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5F4FC5FA-E2FA-456D-813F-6057B7CE7FF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{17B22C7C-9ECB-4D05-A238-48B40DDA06E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{17B22C7C-9ECB-4D05-A238-48B40DDA06E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{17B22C7C-9ECB-4D05-A238-48B40DDA06E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -228,17 +244,20 @@ Global
 		{9D4A41F1-D444-4244-AAAC-F610D9977B2F} = {AD790E7D-D664-4B5F-8BE8-01507A2A9F3B}
 		{42A92357-2A87-4B87-A591-CA78B6CE4461} = {9D4A41F1-D444-4244-AAAC-F610D9977B2F}
 		{74165807-676F-4464-B607-8770C13E8991} = {59466C4D-C407-4DD9-B77B-D99162B9FC7C}
-		{0E2ED1CD-C7ED-4641-9482-C4BBBA58B623} = {9D99B251-FB4F-49BF-8405-F6E0DE46EB32}
-		{5F4FC5FA-E2FA-456D-813F-6057B7CE7FF0} = {9D99B251-FB4F-49BF-8405-F6E0DE46EB32}
 		{17B22C7C-9ECB-4D05-A238-48B40DDA06E8} = {59466C4D-C407-4DD9-B77B-D99162B9FC7C}
 		{458FBDA4-91F9-4A69-BFBC-5AC3D85D4A03} = {AD790E7D-D664-4B5F-8BE8-01507A2A9F3B}
 		{55451191-0521-41E1-BCCF-6D135D646589} = {AD790E7D-D664-4B5F-8BE8-01507A2A9F3B}
-		{101E0992-8233-42C8-9CAF-FEC799BF5DDB} = {9D99B251-FB4F-49BF-8405-F6E0DE46EB32}
 		{8733C91C-38B3-4105-88A3-11AD82CB78CD} = {072853A5-377B-47C4-8644-AF1F4FD669E2}
 		{CDA19B53-4E12-456A-ADA7-06654C161D64} = {FFFFB03D-8D02-46C5-BD12-EC176C0E056C}
 		{469F0214-2840-446D-A418-7539BDD2DEC0} = {AD790E7D-D664-4B5F-8BE8-01507A2A9F3B}
 		{427B2879-0943-4BF7-97BB-E99BC91D630A} = {A6A7B553-5359-4FB9-B19C-8A23004F49DB}
 		{95F1F48E-D5D7-4B9E-A0CE-FF5EC6C20190} = {9D99B251-FB4F-49BF-8405-F6E0DE46EB32}
+		{3717488C-0613-4B18-989B-DD063165B463} = {43B72E50-DC21-49D5-91DD-52BF613037AF}
+		{20F341C1-98F2-451F-8DDE-C46B1F4EF51B} = {3717488C-0613-4B18-989B-DD063165B463}
+		{43B72E50-DC21-49D5-91DD-52BF613037AF} = {86DFE4D4-37A9-4503-A869-E5836A89E34A}
+		{5655FC36-5B1B-49FD-9C14-B1097762A0BB} = {86DFE4D4-37A9-4503-A869-E5836A89E34A}
+		{868881C6-9208-497D-A8D3-B8495C0A8686} = {86DFE4D4-37A9-4503-A869-E5836A89E34A}
+		{F7C5B4FF-52FD-4835-AD14-9C08472E0E3E} = {86DFE4D4-37A9-4503-A869-E5836A89E34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E70BBF50-5920-49F2-835D-4A2DBD73F0E1}

--- a/tools/prepare_release.cmd
+++ b/tools/prepare_release.cmd
@@ -1,4 +1,4 @@
 @echo off
 git submodule -q update --init
 if %errorlevel% neq 0 exit /b %errorlevel%
-dotnet run --project "%~dp0..\tools-shared\FakeItEasy.PrepareRelease\FakeItEasy.PrepareRelease.csproj" -- FakeItEasy %*
+dotnet run "%~dp0..\tools-shared\PrepareRelease.cs" -- FakeItEasy %*


### PR DESCRIPTION
To get latest changes in PrepareRelease and Deploy

I manually added the files to the solution, keeping the same structure as on the filesystem:
<img width="331" height="442" alt="image" src="https://github.com/user-attachments/assets/574546c4-9094-415c-b776-30f35a1157a9" />

It's a bit of a pain to maintain, but I don't see a good alternative 🤔 